### PR TITLE
feat: add lifecycle model bundle edge functions

### DIFF
--- a/supabase/functions/_shared/lifecyclemodel_bundle.ts
+++ b/supabase/functions/_shared/lifecyclemodel_bundle.ts
@@ -273,10 +273,23 @@ export function normalizeLifecycleModelRow(row: any) {
   return {
     id: String(row?.id ?? ''),
     version: String(row?.version ?? ''),
-    json: row?.json ?? null,
+    json: row?.json ?? row?.json_ordered ?? null,
     json_tg: row?.json_tg ?? null,
     ruleVerification: Boolean(row?.rule_verification),
   };
+}
+
+export function permissionErrorStatusCode(error: { code?: string }) {
+  switch (error.code) {
+    case 'FORBIDDEN':
+      return 403;
+    case 'MODEL_NOT_FOUND':
+      return 404;
+    case 'MODEL_LOOKUP_FAILED':
+      return 500;
+    default:
+      return 400;
+  }
 }
 
 function normalizeRpcErrorCode(error: { message?: string; code?: string }) {

--- a/supabase/functions/delete_lifecycle_model_bundle/index.ts
+++ b/supabase/functions/delete_lifecycle_model_bundle/index.ts
@@ -6,6 +6,7 @@ import {
   json,
   mapRpcError,
   normalizeDeleteRpcPayload,
+  permissionErrorStatusCode,
   validateDeleteBody,
 } from '../_shared/lifecyclemodel_bundle.ts';
 import { supabaseClient } from '../_shared/supabase_client.ts';
@@ -77,7 +78,7 @@ Deno.serve(async (req) => {
     payload.version,
   );
   if (!permission.ok) {
-    return json(permission.error, permission.error.code === 'FORBIDDEN' ? 403 : 404);
+    return json(permission.error, permissionErrorStatusCode(permission.error));
   }
 
   const { data, error } = await supabaseClient.rpc('delete_lifecycle_model_bundle', {

--- a/supabase/functions/save_lifecycle_model_bundle/index.ts
+++ b/supabase/functions/save_lifecycle_model_bundle/index.ts
@@ -6,6 +6,7 @@ import {
   json,
   mapRpcError,
   normalizeSaveRpcPayload,
+  permissionErrorStatusCode,
   validateSavePlan,
 } from '../_shared/lifecyclemodel_bundle.ts';
 import { supabaseClient } from '../_shared/supabase_client.ts';
@@ -78,12 +79,18 @@ Deno.serve(async (req) => {
       plan.version!,
     );
     if (!permission.ok) {
-      return json(permission.error, permission.error.code === 'FORBIDDEN' ? 403 : 404);
+      return json(permission.error, permissionErrorStatusCode(permission.error));
     }
   }
 
+  // The RPC runs with service_role, so ownership must be forwarded explicitly.
+  const rpcPlan = {
+    ...plan,
+    actorUserId: userId,
+  };
+
   const { data, error } = await supabaseClient.rpc('save_lifecycle_model_bundle', {
-    p_plan: plan,
+    p_plan: rpcPlan,
   });
 
   if (error) {


### PR DESCRIPTION
## Summary
- add `save_lifecycle_model_bundle` and `delete_lifecycle_model_bundle` edge functions
- validate payloads, enforce auth/owner-or-review-admin checks, and map RPC failures to stable business codes
- normalize save/delete responses for the lifecycle model client contract

## Testing
- npm run lint

Closes #34
