### PR TITLE
fix: expand published snapshot state range

### DIFF
--- a/supabase/functions/_shared/lca_snapshot_scope.ts
+++ b/supabase/functions/_shared/lca_snapshot_scope.ts
@@ -1,4 +1,11 @@
-export const DEFAULT_PUBLISHED_PROCESS_STATES: readonly number[] = [100];
+export const DEFAULT_PUBLISHED_PROCESS_STATE_START = 100;
+export const DEFAULT_PUBLISHED_PROCESS_STATE_END = 199;
+export const DEFAULT_PUBLISHED_PROCESS_STATES: readonly number[] = Array.from(
+  {
+    length: DEFAULT_PUBLISHED_PROCESS_STATE_END - DEFAULT_PUBLISHED_PROCESS_STATE_START + 1,
+  },
+  (_, index) => DEFAULT_PUBLISHED_PROCESS_STATE_START + index,
+);
 
 export type LcaDataScope = 'current_user' | 'open_data' | 'all_data';
 
@@ -32,7 +39,8 @@ export function buildSnapshotProcessFilter(
     default:
       // Business semantics: open_data, all_data, and current_user all reuse the same
       // snapshot family for solving, i.e. published data plus the current user's
-      // private data. The root-process scope is validated separately per request.
+      // private data. Published data currently covers state_code 100..199, while
+      // root-process scope is validated separately per request.
       return {
         all_states: false,
         process_states: [...DEFAULT_PUBLISHED_PROCESS_STATES],

--- a/test/lca_process_scope_test.ts
+++ b/test/lca_process_scope_test.ts
@@ -16,6 +16,10 @@ Deno.test('matchesProcessDataScope enforces root-process semantics per scope', (
     state_code: 100,
     user_id: 'user-2',
   };
+  const publishedRangeOwnedByOtherUser = {
+    state_code: 150,
+    user_id: 'user-2',
+  };
   const privateOwnedByCurrentUser = {
     state_code: 0,
     user_id: 'user-1',
@@ -26,13 +30,22 @@ Deno.test('matchesProcessDataScope enforces root-process semantics per scope', (
   };
 
   assertEquals(matchesProcessDataScope(publishedOwnedByOtherUser, 'open_data', 'user-1'), true);
+  assertEquals(
+    matchesProcessDataScope(publishedRangeOwnedByOtherUser, 'open_data', 'user-1'),
+    true,
+  );
   assertEquals(matchesProcessDataScope(privateOwnedByCurrentUser, 'open_data', 'user-1'), false);
 
   assertEquals(matchesProcessDataScope(privateOwnedByCurrentUser, 'current_user', 'user-1'), true);
   assertEquals(matchesProcessDataScope(publishedOwnedByOtherUser, 'current_user', 'user-1'), false);
+  assertEquals(
+    matchesProcessDataScope(publishedRangeOwnedByOtherUser, 'current_user', 'user-1'),
+    false,
+  );
 
   assertEquals(matchesProcessDataScope(privateOwnedByCurrentUser, 'all_data', 'user-1'), true);
   assertEquals(matchesProcessDataScope(publishedOwnedByOtherUser, 'all_data', 'user-1'), true);
+  assertEquals(matchesProcessDataScope(publishedRangeOwnedByOtherUser, 'all_data', 'user-1'), true);
   assertEquals(matchesProcessDataScope(privateOwnedByOtherUser, 'all_data', 'user-1'), false);
   assertEquals(matchesProcessDataScope(undefined, 'all_data', 'user-1'), false);
 });

--- a/test/lca_snapshot_scope_test.ts
+++ b/test/lca_snapshot_scope_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from 'jsr:@std/assert';
 
 import {
+  DEFAULT_PUBLISHED_PROCESS_STATES,
   buildSnapshotBuildPayloadFields,
   buildSnapshotContainsFilter,
   buildSnapshotProcessFilter,
@@ -18,21 +19,28 @@ Deno.test('parseLcaDataScope defaults unknown values to current_user', () => {
 });
 
 Deno.test('buildSnapshotProcessFilter maps each scope to the expected process filter', () => {
+  const expectedStates = [...DEFAULT_PUBLISHED_PROCESS_STATES];
   assertEquals(buildSnapshotProcessFilter('current_user', 'user-1'), {
     all_states: false,
-    process_states: [100],
+    process_states: expectedStates,
     include_user_id: 'user-1',
   });
   assertEquals(buildSnapshotProcessFilter('open_data', 'user-1'), {
     all_states: false,
-    process_states: [100],
+    process_states: expectedStates,
     include_user_id: 'user-1',
   });
   assertEquals(buildSnapshotProcessFilter('all_data', 'user-1'), {
     all_states: false,
-    process_states: [100],
+    process_states: expectedStates,
     include_user_id: 'user-1',
   });
+});
+
+Deno.test('DEFAULT_PUBLISHED_PROCESS_STATES covers 100 through 199', () => {
+  assertEquals(DEFAULT_PUBLISHED_PROCESS_STATES.length, 100);
+  assertEquals(DEFAULT_PUBLISHED_PROCESS_STATES[0], 100);
+  assertEquals(DEFAULT_PUBLISHED_PROCESS_STATES.at(-1), 199);
 });
 
 Deno.test(
@@ -58,36 +66,38 @@ Deno.test('query/build payload helper outputs stay aligned with snapshot semanti
   const currentUserFilter = buildSnapshotProcessFilter('current_user', 'user-1');
   const openDataFilter = buildSnapshotProcessFilter('open_data', 'user-1');
   const allDataFilter = buildSnapshotProcessFilter('all_data', 'user-1');
+  const expectedStates = [...DEFAULT_PUBLISHED_PROCESS_STATES];
+  const expectedStatesCsv = DEFAULT_PUBLISHED_PROCESS_STATES.join(',');
 
   assertEquals(buildSnapshotContainsFilter(currentUserFilter), {
     all_states: false,
-    process_states: [100],
+    process_states: expectedStates,
     include_user_id: 'user-1',
   });
   assertEquals(buildSnapshotContainsFilter(openDataFilter), {
     all_states: false,
-    process_states: [100],
+    process_states: expectedStates,
     include_user_id: 'user-1',
   });
   assertEquals(buildSnapshotContainsFilter(allDataFilter), {
     all_states: false,
-    process_states: [100],
+    process_states: expectedStates,
     include_user_id: 'user-1',
   });
 
   assertEquals(buildSnapshotBuildPayloadFields(currentUserFilter), {
     all_states: false,
-    process_states: '100',
+    process_states: expectedStatesCsv,
     include_user_id: 'user-1',
   });
   assertEquals(buildSnapshotBuildPayloadFields(openDataFilter), {
     all_states: false,
-    process_states: '100',
+    process_states: expectedStatesCsv,
     include_user_id: 'user-1',
   });
   assertEquals(buildSnapshotBuildPayloadFields(allDataFilter), {
     all_states: false,
-    process_states: '100',
+    process_states: expectedStatesCsv,
     include_user_id: 'user-1',
   });
 });


### PR DESCRIPTION
## Summary
- expand the published snapshot process state family to `100..199` in snapshot scope helpers
- align process-scope and snapshot-scope tests with the broader published range
- keep snapshot filtering semantics consistent across helper utilities

## Validation
- deno test test/lca_process_scope_test.ts test/lca_snapshot_scope_test.ts

## Notes
- prepared from the Neo9281 fork on top of the current upstream `main`