### PR TITLE
feat: allow API-key authenticated package import

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@
   - TIDAS ZIP 导入入口。
   - `POST` only。
   - 支持 `AuthMethod.JWT` 与 `AuthMethod.USER_API_KEY`。
+  - JWT 请求不应依赖 Redis；Redis 仅用于 `USER_API_KEY` 鉴权缓存。
   - action `prepare_upload` 负责创建 import job / source artifact 并返回 signed upload URL。
   - action `enqueue` 负责将 source artifact 标记为 ready 并触发 `lca_package_enqueue_job`。
 - `supabase/functions/tidas_package_jobs`

--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ The supported auth headers are:
 Recommended flow:
 
 1. Call `POST /import_tidas_package` with `{"action":"prepare_upload", ...}` to create the import job and receive a signed upload target.
-2. Upload the ZIP bytes directly to the returned `upload.signed_url`.
+2. Upload the ZIP bytes with the returned signed-upload fields.
+   - Preferred: use `upload.bucket`, `upload.path`, and `upload.token` with the Supabase Storage signed-upload helper.
+   - Optional convenience: if `upload.signed_url` is non-null, clients may upload directly to that URL.
 3. Call `POST /import_tidas_package` with `{"action":"enqueue", ...}` to mark the source artifact ready and enqueue the async worker job.
 4. Poll `GET /tidas_package_jobs/{job_id}` until the job reaches `completed` or `failed`.
 
@@ -231,7 +233,18 @@ curl -i --location --request POST "${BASE_URL}/import_tidas_package" \
   }'
 ```
 
-Example direct upload to the returned signed URL:
+Example upload with the Supabase Storage signed-upload helper:
+
+```ts
+const { error } = await supabase.storage
+  .from(upload.bucket)
+  .uploadToSignedUrl(upload.path, upload.token, file, {
+    contentType: upload.content_type,
+    upsert: true,
+  });
+```
+
+Optional direct upload when `upload.signed_url` is present:
 
 ```bash
 curl -i --request PUT "${SIGNED_URL}" \
@@ -266,6 +279,7 @@ curl -i --location --request GET "${BASE_URL}/tidas_package_jobs/<job-id>" \
 Notes:
 
 - The edge function keeps the existing browser JWT flow unchanged; API-key clients use the same prepare-upload, direct-upload, enqueue, and poll contract.
+- JWT callers do not require Redis; the Redis-backed path is only used for `USER_API_KEY` bearer authentication.
 - Import validation now happens asynchronously in the calculator worker after enqueue, and validation failures are surfaced through the import report artifact linked from `tidas_package_jobs`.
 
 ## LCA Minimal Integration Script (submit -> poll -> fetch)

--- a/supabase/functions/import_tidas_package/index.ts
+++ b/supabase/functions/import_tidas_package/index.ts
@@ -10,6 +10,19 @@ import {
   TidasPackageError,
 } from '../_shared/tidas_package.ts';
 
+function resolveBearerToken(req: Request): string {
+  return (
+    req.headers
+      .get('Authorization')
+      ?.replace(/^Bearer\s+/i, '')
+      .trim() ?? ''
+  );
+}
+
+function looksLikeJwtToken(token: string): boolean {
+  return /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(token);
+}
+
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return json('ok');
@@ -26,11 +39,15 @@ Deno.serve(async (req) => {
     );
   }
 
-  const redis = await getRedisClient();
+  const bearerToken = resolveBearerToken(req);
+  const shouldTryUserApiKey = bearerToken.length > 0 && !looksLikeJwtToken(bearerToken);
+  const redis = shouldTryUserApiKey ? await getRedisClient() : undefined;
   const authResult = await authenticateRequest(req, {
     supabase: supabaseClient,
     redis,
-    allowedMethods: [AuthMethod.JWT, AuthMethod.USER_API_KEY],
+    allowedMethods: shouldTryUserApiKey
+      ? [AuthMethod.USER_API_KEY, AuthMethod.JWT]
+      : [AuthMethod.JWT],
   });
 
   if (!authResult.isAuthenticated || !authResult.user?.id) {

--- a/test.example.http
+++ b/test.example.http
@@ -276,6 +276,18 @@ curl -i --location --request POST '{{$dotenv REMOTE_ENDPOINT}}/import_tidas_pack
       "content_type": "application/zip"
     }'
 
+### @name TIDAS_Import_Prepare_Upload：Local (USER_JWT)
+curl -i --location --request POST '{{$dotenv LOCAL_ENDPOINT}}/import_tidas_package' \
+    --header 'Content-Type: application/json' \
+    --header 'Authorization: Bearer {{$dotenv USER_JWT}}' \
+    --header 'X-Idempotency-Key: tidas-import-local-jwt-prepare-001' \
+    --data '{
+      "action": "prepare_upload",
+      "filename": "example-package.zip",
+      "byte_size": 123456,
+      "content_type": "application/zip"
+    }'
+
 ### @name TIDAS_Import_Enqueue：Local (USER_API_KEY)
 curl -i --location --request POST '{{$dotenv LOCAL_ENDPOINT}}/import_tidas_package' \
     --header 'Content-Type: application/json' \
@@ -319,6 +331,10 @@ curl -i --location --request POST '{{$dotenv LOCAL_ENDPOINT}}/tidas_package_jobs
     --data '{
       "job_id": "{{$dotenv TIDAS_IMPORT_JOB_ID}}"
     }'
+
+### @name TIDAS_Package_Job_Status：Local (path param, USER_JWT)
+curl -i --location --request GET '{{$dotenv LOCAL_ENDPOINT}}/tidas_package_jobs/{{$dotenv TIDAS_IMPORT_JOB_ID}}' \
+    --header 'Authorization: Bearer {{$dotenv USER_JWT}}'
 
 
 ### @name LCA_Query_Results：Local (single process -> all impacts)


### PR DESCRIPTION
Closes linancn/tiangong-lca-edge-functions#39

## Summary
- Allow import_tidas_package to authenticate with either browser JWTs or USER_API_KEY bearer tokens.
- Document the prepare-upload, direct-upload, enqueue, and poll workflow for API clients.

## Key Decisions
- Reuse the existing shared USER_API_KEY auth path so API imports follow the same contract as other edge APIs.
- Keep prepare_upload and enqueue payloads unchanged so the current web client remains compatible.

## Validation
- npm run lint
- deno check --config supabase/functions/deno.json supabase/functions/import_tidas_package/index.ts

## Risks / Rollback
- HTTP fixtures were added, but no live local or remote request was executed in this session because the required runtime environment was not started here.

## Follow-ups
- Next repo work should surface this API import flow in the web UI and docs using the edge-function base URL.

## Workspace Integration
- Requires later workspace submodule bump after merge.