### PR TITLE
fix: stop forcing strict provider rule in snapshot edge requests

### DIFF
--- a/supabase/functions/lca_contribution_path/index.ts
+++ b/supabase/functions/lca_contribution_path/index.ts
@@ -897,7 +897,6 @@ async function ensureSnapshotBuildQueued(
     snapshot_id: snapshotId,
     scope,
     ...buildSnapshotBuildPayloadFields(processFilter),
-    provider_rule: 'strict_unique_provider',
     reference_normalization_mode: 'lenient',
     allocation_fraction_mode: 'lenient',
     self_loop_cutoff: 0.999999,
@@ -917,7 +916,6 @@ async function ensureSnapshotBuildQueued(
     id: snapshotId,
     scope: 'full_library',
     process_filter: processFilter,
-    provider_matching_rule: 'strict_unique_provider',
     status: 'draft',
     created_by: userId,
   });

--- a/supabase/functions/lca_query_results/index.ts
+++ b/supabase/functions/lca_query_results/index.ts
@@ -762,7 +762,6 @@ async function ensureSnapshotBuildQueued(
     snapshot_id: snapshotId,
     scope,
     ...buildSnapshotBuildPayloadFields(processFilter),
-    provider_rule: 'strict_unique_provider',
     reference_normalization_mode: 'lenient',
     allocation_fraction_mode: 'lenient',
     self_loop_cutoff: 0.999999,
@@ -782,7 +781,6 @@ async function ensureSnapshotBuildQueued(
     id: snapshotId,
     scope: 'full_library',
     process_filter: processFilter,
-    provider_matching_rule: 'strict_unique_provider',
     status: 'draft',
     created_by: userId,
   });

--- a/supabase/functions/lca_solve/index.ts
+++ b/supabase/functions/lca_solve/index.ts
@@ -809,7 +809,6 @@ async function ensureSnapshotBuildQueued(
     snapshot_id: snapshotId,
     scope,
     ...buildSnapshotBuildPayloadFields(processFilter),
-    provider_rule: 'strict_unique_provider',
     reference_normalization_mode: 'lenient',
     allocation_fraction_mode: 'lenient',
     self_loop_cutoff: 0.999999,
@@ -829,7 +828,6 @@ async function ensureSnapshotBuildQueued(
     id: snapshotId,
     scope: 'full_library',
     process_filter: processFilter,
-    provider_matching_rule: 'strict_unique_provider',
     status: 'draft',
     created_by: userId,
   });


### PR DESCRIPTION
Closes linancn/tiangong-lca-edge-functions#45

## Summary
- Remove the explicit provider_rule=strict_unique_provider override from build_snapshot jobs created by lca_solve, lca_query_results, and lca_contribution_path.
- Remove the same strict hardcode from the corresponding lca_network_snapshots draft inserts so the edge code no longer pins provider selection in these paths.

## Key Decisions
- Use the calculator-side default provider rule instead of re-declaring it in edge request construction, so future provider-rule changes do not require another edge override update.

## Validation
- deno check --config supabase/functions/deno.json supabase/functions/lca_solve/index.ts
- deno check --config supabase/functions/deno.json supabase/functions/lca_query_results/index.ts
- deno check --config supabase/functions/deno.json supabase/functions/lca_contribution_path/index.ts

## Risks / Rollback
- The database column lca_network_snapshots.provider_matching_rule still has a schema default of strict_unique_provider, so persisted snapshot draft metadata may continue to show strict until that schema default is changed later. The job payload override is removed in this PR.

## Follow-ups
- Deploy lca_solve, lca_query_results, and lca_contribution_path after merge, then re-run a live build_snapshot request and confirm the queued job payload no longer includes provider_rule=strict_unique_provider.

## Workspace Integration
- After merge, deploy the updated edge functions before the next live provider-rule validation.