### PR TITLE
feat: add review workflow commands

### DIFF
--- a/supabase/functions/_shared/commands/review/approve_review.ts
+++ b/supabase/functions/_shared/commands/review/approve_review.ts
@@ -1,0 +1,53 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import { assertApproveReviewPolicy } from "./policy.ts";
+import {
+  createReviewCommandRepository,
+  type ReviewCommandRepository,
+} from "./repository.ts";
+import type {
+  ApproveReviewRequest,
+  ReviewCommandExecutionResult,
+} from "./types.ts";
+import { parseApproveReviewRequest } from "./validation.ts";
+
+export function parseApproveReviewCommand(body: unknown) {
+  return parseApproveReviewRequest(body);
+}
+
+export async function executeApproveReviewCommand(
+  request: ApproveReviewRequest,
+  actor: ActorContext,
+  repository: ReviewCommandRepository = createReviewCommandRepository(
+    actor.supabase,
+  ),
+): Promise<ReviewCommandExecutionResult> {
+  const policy = assertApproveReviewPolicy(request);
+  if (!policy.ok) {
+    return policy;
+  }
+
+  const audit = buildCommandAuditPayload({
+    command: "review_approve",
+    actorUserId: actor.userId,
+    targetTable: request.table,
+    targetId: request.reviewId,
+    targetVersion: "",
+    payload: {},
+  });
+
+  const result = await repository.approveReview(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "review_approve",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/review/assign_reviewers.ts
+++ b/supabase/functions/_shared/commands/review/assign_reviewers.ts
@@ -1,0 +1,56 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import { assertAssignReviewersPolicy } from "./policy.ts";
+import {
+  createReviewCommandRepository,
+  type ReviewCommandRepository,
+} from "./repository.ts";
+import type {
+  AssignReviewersRequest,
+  ReviewCommandExecutionResult,
+} from "./types.ts";
+import { parseAssignReviewersRequest } from "./validation.ts";
+
+export function parseAssignReviewersCommand(body: unknown) {
+  return parseAssignReviewersRequest(body);
+}
+
+export async function executeAssignReviewersCommand(
+  request: AssignReviewersRequest,
+  actor: ActorContext,
+  repository: ReviewCommandRepository = createReviewCommandRepository(
+    actor.supabase,
+  ),
+): Promise<ReviewCommandExecutionResult> {
+  const policy = assertAssignReviewersPolicy(request);
+  if (!policy.ok) {
+    return policy;
+  }
+
+  const audit = buildCommandAuditPayload({
+    command: "review_assign_reviewers",
+    actorUserId: actor.userId,
+    targetTable: "reviews",
+    targetId: request.reviewId,
+    targetVersion: "",
+    payload: {
+      reviewerIds: request.reviewerIds,
+      deadline: request.deadline ?? null,
+    },
+  });
+
+  const result = await repository.assignReviewers(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "review_assign_reviewers",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/review/policy.ts
+++ b/supabase/functions/_shared/commands/review/policy.ts
@@ -1,0 +1,76 @@
+import type {
+  ApproveReviewRequest,
+  AssignReviewersRequest,
+  RejectReviewRequest,
+  ReviewCommandFailure,
+  RevokeReviewerRequest,
+  SaveAssignmentDraftRequest,
+  SaveCommentDraftRequest,
+  SubmitCommentRequest,
+} from "./types.ts";
+
+function invalidInput(code: string, message: string): ReviewCommandFailure {
+  return {
+    ok: false,
+    code,
+    message,
+    status: 400,
+  };
+}
+
+export function assertSaveAssignmentDraftPolicy(
+  _request: SaveAssignmentDraftRequest,
+): { ok: true } | ReviewCommandFailure {
+  return { ok: true };
+}
+
+export function assertAssignReviewersPolicy(
+  _request: AssignReviewersRequest,
+): { ok: true } | ReviewCommandFailure {
+  return { ok: true };
+}
+
+export function assertRevokeReviewerPolicy(
+  _request: RevokeReviewerRequest,
+): { ok: true } | ReviewCommandFailure {
+  return { ok: true };
+}
+
+export function assertSaveCommentDraftPolicy(
+  _request: SaveCommentDraftRequest,
+): { ok: true } | ReviewCommandFailure {
+  return { ok: true };
+}
+
+export function assertSubmitCommentPolicy(
+  request: SubmitCommentRequest,
+): { ok: true } | ReviewCommandFailure {
+  if (
+    request.commentState !== undefined &&
+    request.commentState !== -3 &&
+    request.commentState !== 1
+  ) {
+    return invalidInput(
+      "INVALID_COMMENT_STATE",
+      "commentState must be 1 or -3",
+    );
+  }
+
+  return { ok: true };
+}
+
+export function assertApproveReviewPolicy(
+  _request: ApproveReviewRequest,
+): { ok: true } | ReviewCommandFailure {
+  return { ok: true };
+}
+
+export function assertRejectReviewPolicy(
+  request: RejectReviewRequest,
+): { ok: true } | ReviewCommandFailure {
+  if (!request.reason.trim()) {
+    return invalidInput("REASON_REQUIRED", "reason is required");
+  }
+
+  return { ok: true };
+}

--- a/supabase/functions/_shared/commands/review/reject_review.ts
+++ b/supabase/functions/_shared/commands/review/reject_review.ts
@@ -1,0 +1,55 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import { assertRejectReviewPolicy } from "./policy.ts";
+import {
+  createReviewCommandRepository,
+  type ReviewCommandRepository,
+} from "./repository.ts";
+import type {
+  RejectReviewRequest,
+  ReviewCommandExecutionResult,
+} from "./types.ts";
+import { parseRejectReviewRequest } from "./validation.ts";
+
+export function parseRejectReviewCommand(body: unknown) {
+  return parseRejectReviewRequest(body);
+}
+
+export async function executeRejectReviewCommand(
+  request: RejectReviewRequest,
+  actor: ActorContext,
+  repository: ReviewCommandRepository = createReviewCommandRepository(
+    actor.supabase,
+  ),
+): Promise<ReviewCommandExecutionResult> {
+  const policy = assertRejectReviewPolicy(request);
+  if (!policy.ok) {
+    return policy;
+  }
+
+  const audit = buildCommandAuditPayload({
+    command: "review_reject",
+    actorUserId: actor.userId,
+    targetTable: request.table,
+    targetId: request.reviewId,
+    targetVersion: "",
+    payload: {
+      reason: request.reason,
+    },
+  });
+
+  const result = await repository.rejectReview(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "review_reject",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/review/repository.ts
+++ b/supabase/functions/_shared/commands/review/repository.ts
@@ -1,0 +1,90 @@
+import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+
+import type { CommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import {
+  callReviewApproveRpc,
+  callReviewAssignReviewersRpc,
+  callReviewRejectRpc,
+  callReviewRevokeReviewerRpc,
+  callReviewSaveAssignmentDraftRpc,
+  callReviewSaveCommentDraftRpc,
+  callReviewSubmitCommentRpc,
+  type ReviewRpcResult,
+} from "../../db_rpc/review_commands.ts";
+import type {
+  ApproveReviewRequest,
+  AssignReviewersRequest,
+  RejectReviewRequest,
+  RevokeReviewerRequest,
+  SaveAssignmentDraftRequest,
+  SaveCommentDraftRequest,
+  SubmitCommentRequest,
+} from "./types.ts";
+
+type RpcClient = Pick<SupabaseClient, "rpc">;
+
+export type ReviewCommandRepository = {
+  saveAssignmentDraft: (
+    request: SaveAssignmentDraftRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<ReviewRpcResult>;
+  assignReviewers: (
+    request: AssignReviewersRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<ReviewRpcResult>;
+  revokeReviewer: (
+    request: RevokeReviewerRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<ReviewRpcResult>;
+  saveCommentDraft: (
+    request: SaveCommentDraftRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<ReviewRpcResult>;
+  submitComment: (
+    request: SubmitCommentRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<ReviewRpcResult>;
+  approveReview: (
+    request: ApproveReviewRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<ReviewRpcResult>;
+  rejectReview: (
+    request: RejectReviewRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<ReviewRpcResult>;
+};
+
+function requireExplicitClient(
+  supabase: RpcClient | null | undefined,
+): RpcClient {
+  if (!supabase || typeof supabase.rpc !== "function") {
+    throw new Error(
+      "Review command repository requires an explicit Supabase client",
+    );
+  }
+
+  return supabase;
+}
+
+export function createReviewCommandRepository(
+  supabase: RpcClient,
+): ReviewCommandRepository {
+  const client = requireExplicitClient(supabase);
+
+  return {
+    saveAssignmentDraft: (request, audit) =>
+      callReviewSaveAssignmentDraftRpc(client, request, audit),
+    assignReviewers: (request, audit) =>
+      callReviewAssignReviewersRpc(client, request, audit),
+    revokeReviewer: (request, audit) =>
+      callReviewRevokeReviewerRpc(client, request, audit),
+    saveCommentDraft: (request, audit) =>
+      callReviewSaveCommentDraftRpc(client, request, audit),
+    submitComment: (request, audit) =>
+      callReviewSubmitCommentRpc(client, request, audit),
+    approveReview: (request, audit) =>
+      callReviewApproveRpc(client, request, audit),
+    rejectReview: (request, audit) =>
+      callReviewRejectRpc(client, request, audit),
+  };
+}

--- a/supabase/functions/_shared/commands/review/revoke_reviewer.ts
+++ b/supabase/functions/_shared/commands/review/revoke_reviewer.ts
@@ -1,0 +1,55 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import { assertRevokeReviewerPolicy } from "./policy.ts";
+import {
+  createReviewCommandRepository,
+  type ReviewCommandRepository,
+} from "./repository.ts";
+import type {
+  ReviewCommandExecutionResult,
+  RevokeReviewerRequest,
+} from "./types.ts";
+import { parseRevokeReviewerRequest } from "./validation.ts";
+
+export function parseRevokeReviewerCommand(body: unknown) {
+  return parseRevokeReviewerRequest(body);
+}
+
+export async function executeRevokeReviewerCommand(
+  request: RevokeReviewerRequest,
+  actor: ActorContext,
+  repository: ReviewCommandRepository = createReviewCommandRepository(
+    actor.supabase,
+  ),
+): Promise<ReviewCommandExecutionResult> {
+  const policy = assertRevokeReviewerPolicy(request);
+  if (!policy.ok) {
+    return policy;
+  }
+
+  const audit = buildCommandAuditPayload({
+    command: "review_revoke_reviewer",
+    actorUserId: actor.userId,
+    targetTable: "reviews",
+    targetId: request.reviewId,
+    targetVersion: "",
+    payload: {
+      reviewerId: request.reviewerId,
+    },
+  });
+
+  const result = await repository.revokeReviewer(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "review_revoke_reviewer",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/review/save_assignment_draft.ts
+++ b/supabase/functions/_shared/commands/review/save_assignment_draft.ts
@@ -1,0 +1,60 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import { assertSaveAssignmentDraftPolicy } from "./policy.ts";
+import {
+  createReviewCommandRepository,
+  type ReviewCommandRepository,
+} from "./repository.ts";
+import type {
+  ReviewCommandExecutionResult,
+  SaveAssignmentDraftRequest,
+} from "./types.ts";
+import {
+  parseSaveAssignmentDraftRequest,
+  saveAssignmentDraftRequestSchema,
+} from "./validation.ts";
+
+export { saveAssignmentDraftRequestSchema };
+
+export function parseSaveAssignmentDraftCommand(body: unknown) {
+  return parseSaveAssignmentDraftRequest(body);
+}
+
+export async function executeSaveAssignmentDraftCommand(
+  request: SaveAssignmentDraftRequest,
+  actor: ActorContext,
+  repository: ReviewCommandRepository = createReviewCommandRepository(
+    actor.supabase,
+  ),
+): Promise<ReviewCommandExecutionResult> {
+  const policy = assertSaveAssignmentDraftPolicy(request);
+  if (!policy.ok) {
+    return policy;
+  }
+
+  const audit = buildCommandAuditPayload({
+    command: "review_save_assignment_draft",
+    actorUserId: actor.userId,
+    targetTable: "reviews",
+    targetId: request.reviewId,
+    targetVersion: "",
+    payload: {
+      reviewerIds: request.reviewerIds,
+    },
+  });
+
+  const result = await repository.saveAssignmentDraft(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "review_save_assignment_draft",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/review/save_comment_draft.ts
+++ b/supabase/functions/_shared/commands/review/save_comment_draft.ts
@@ -1,0 +1,55 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import { assertSaveCommentDraftPolicy } from "./policy.ts";
+import {
+  createReviewCommandRepository,
+  type ReviewCommandRepository,
+} from "./repository.ts";
+import type {
+  ReviewCommandExecutionResult,
+  SaveCommentDraftRequest,
+} from "./types.ts";
+import { parseSaveCommentDraftRequest } from "./validation.ts";
+
+export function parseSaveCommentDraftCommand(body: unknown) {
+  return parseSaveCommentDraftRequest(body);
+}
+
+export async function executeSaveCommentDraftCommand(
+  request: SaveCommentDraftRequest,
+  actor: ActorContext,
+  repository: ReviewCommandRepository = createReviewCommandRepository(
+    actor.supabase,
+  ),
+): Promise<ReviewCommandExecutionResult> {
+  const policy = assertSaveCommentDraftPolicy(request);
+  if (!policy.ok) {
+    return policy;
+  }
+
+  const audit = buildCommandAuditPayload({
+    command: "review_save_comment_draft",
+    actorUserId: actor.userId,
+    targetTable: "reviews",
+    targetId: request.reviewId,
+    targetVersion: "",
+    payload: {
+      hasJson: request.json !== undefined,
+    },
+  });
+
+  const result = await repository.saveCommentDraft(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "review_save_comment_draft",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/review/submit_comment.ts
+++ b/supabase/functions/_shared/commands/review/submit_comment.ts
@@ -1,0 +1,61 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import { assertSubmitCommentPolicy } from "./policy.ts";
+import {
+  createReviewCommandRepository,
+  type ReviewCommandRepository,
+} from "./repository.ts";
+import type {
+  ReviewCommandExecutionResult,
+  SubmitCommentRequest,
+} from "./types.ts";
+import {
+  parseSubmitCommentRequest,
+  submitCommentRequestSchema,
+} from "./validation.ts";
+
+export { submitCommentRequestSchema };
+
+export function parseSubmitCommentCommand(body: unknown) {
+  return parseSubmitCommentRequest(body);
+}
+
+export async function executeSubmitCommentCommand(
+  request: SubmitCommentRequest,
+  actor: ActorContext,
+  repository: ReviewCommandRepository = createReviewCommandRepository(
+    actor.supabase,
+  ),
+): Promise<ReviewCommandExecutionResult> {
+  const policy = assertSubmitCommentPolicy(request);
+  if (!policy.ok) {
+    return policy;
+  }
+
+  const audit = buildCommandAuditPayload({
+    command: "review_submit_comment",
+    actorUserId: actor.userId,
+    targetTable: "reviews",
+    targetId: request.reviewId,
+    targetVersion: "",
+    payload: {
+      hasJson: request.json !== undefined,
+      commentState: request.commentState ?? 1,
+    },
+  });
+
+  const result = await repository.submitComment(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "review_submit_comment",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/review/types.ts
+++ b/supabase/functions/_shared/commands/review/types.ts
@@ -1,0 +1,53 @@
+export const REVIEW_DECISION_TABLES = ["processes", "lifecyclemodels"] as const;
+
+export type ReviewDecisionTable = (typeof REVIEW_DECISION_TABLES)[number];
+
+export type SaveAssignmentDraftRequest = {
+  reviewId: string;
+  reviewerIds: string[];
+};
+
+export type AssignReviewersRequest = {
+  reviewId: string;
+  reviewerIds: string[];
+  deadline?: string | null;
+};
+
+export type RevokeReviewerRequest = {
+  reviewId: string;
+  reviewerId: string;
+};
+
+export type SaveCommentDraftRequest = {
+  reviewId: string;
+  json: unknown;
+};
+
+export type SubmitCommentRequest = {
+  reviewId: string;
+  json: unknown;
+  commentState?: 1 | -3;
+};
+
+export type ApproveReviewRequest = {
+  table: ReviewDecisionTable;
+  reviewId: string;
+};
+
+export type RejectReviewRequest = {
+  table: ReviewDecisionTable;
+  reviewId: string;
+  reason: string;
+};
+
+export type ReviewCommandFailure = {
+  ok: false;
+  code: string;
+  message: string;
+  status: number;
+  details?: unknown;
+};
+
+export type ReviewCommandExecutionResult =
+  | { ok: true; body: unknown; status?: number }
+  | ReviewCommandFailure;

--- a/supabase/functions/_shared/commands/review/validation.ts
+++ b/supabase/functions/_shared/commands/review/validation.ts
@@ -1,0 +1,179 @@
+import { z } from "zod";
+
+import type { CommandParseResult } from "../../command_runtime/command.ts";
+import {
+  type ApproveReviewRequest,
+  type AssignReviewersRequest,
+  type RejectReviewRequest,
+  REVIEW_DECISION_TABLES,
+  type RevokeReviewerRequest,
+  type SaveAssignmentDraftRequest,
+  type SaveCommentDraftRequest,
+  type SubmitCommentRequest,
+} from "./types.ts";
+
+const uuidSchema = z.string().uuid();
+const reviewerIdsSchema = z.array(uuidSchema);
+const commentStateSchema = z.union([z.literal(-3), z.literal(1)]);
+const isoDateTimeSchema = z
+  .string()
+  .refine(
+    (value) => !Number.isNaN(Date.parse(value)),
+    "deadline must be an ISO datetime string",
+  );
+
+const reviewBaseSchema = z
+  .object({
+    reviewId: uuidSchema,
+  })
+  .strict();
+
+export const saveAssignmentDraftRequestSchema = reviewBaseSchema
+  .extend({
+    reviewerIds: reviewerIdsSchema,
+  })
+  .strict();
+
+export const assignReviewersRequestSchema = reviewBaseSchema
+  .extend({
+    reviewerIds: reviewerIdsSchema,
+    deadline: isoDateTimeSchema.nullable().optional(),
+  })
+  .strict();
+
+export const revokeReviewerRequestSchema = reviewBaseSchema
+  .extend({
+    reviewerId: uuidSchema,
+  })
+  .strict();
+
+export const saveCommentDraftRequestSchema = reviewBaseSchema
+  .extend({
+    json: z.unknown(),
+  })
+  .strict();
+
+export const submitCommentRequestSchema = reviewBaseSchema
+  .extend({
+    json: z.unknown(),
+    commentState: commentStateSchema.optional(),
+  })
+  .strict();
+
+const decisionBaseSchema = z
+  .object({
+    table: z.enum(REVIEW_DECISION_TABLES),
+    reviewId: uuidSchema,
+  })
+  .strict();
+
+export const approveReviewRequestSchema = decisionBaseSchema.strict();
+
+export const rejectReviewRequestSchema = decisionBaseSchema
+  .extend({
+    reason: z.string().trim().min(1, "reason is required"),
+  })
+  .strict();
+
+function invalidPayload<T>(
+  message: string,
+  error: z.ZodError,
+): CommandParseResult<T> {
+  return {
+    ok: false,
+    message,
+    details: error.flatten(),
+  };
+}
+
+export function parseSaveAssignmentDraftRequest(
+  body: unknown,
+): CommandParseResult<SaveAssignmentDraftRequest> {
+  const parsed = saveAssignmentDraftRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload(
+      "Invalid review save-assignment-draft payload",
+      parsed.error,
+    );
+  }
+
+  return { ok: true, value: parsed.data };
+}
+
+export function parseAssignReviewersRequest(
+  body: unknown,
+): CommandParseResult<AssignReviewersRequest> {
+  const parsed = assignReviewersRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload(
+      "Invalid review assign-reviewers payload",
+      parsed.error,
+    );
+  }
+
+  return { ok: true, value: parsed.data };
+}
+
+export function parseRevokeReviewerRequest(
+  body: unknown,
+): CommandParseResult<RevokeReviewerRequest> {
+  const parsed = revokeReviewerRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload(
+      "Invalid review revoke-reviewer payload",
+      parsed.error,
+    );
+  }
+
+  return { ok: true, value: parsed.data };
+}
+
+export function parseSaveCommentDraftRequest(
+  body: unknown,
+): CommandParseResult<SaveCommentDraftRequest> {
+  const parsed = saveCommentDraftRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload(
+      "Invalid review save-comment-draft payload",
+      parsed.error,
+    );
+  }
+
+  return { ok: true, value: parsed.data };
+}
+
+export function parseSubmitCommentRequest(
+  body: unknown,
+): CommandParseResult<SubmitCommentRequest> {
+  const parsed = submitCommentRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload(
+      "Invalid review submit-comment payload",
+      parsed.error,
+    );
+  }
+
+  return { ok: true, value: parsed.data };
+}
+
+export function parseApproveReviewRequest(
+  body: unknown,
+): CommandParseResult<ApproveReviewRequest> {
+  const parsed = approveReviewRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload("Invalid review approve payload", parsed.error);
+  }
+
+  return { ok: true, value: parsed.data };
+}
+
+export function parseRejectReviewRequest(
+  body: unknown,
+): CommandParseResult<RejectReviewRequest> {
+  const parsed = rejectReviewRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload("Invalid review reject payload", parsed.error);
+  }
+
+  return { ok: true, value: parsed.data };
+}

--- a/supabase/functions/_shared/db_rpc/review_commands.ts
+++ b/supabase/functions/_shared/db_rpc/review_commands.ts
@@ -1,0 +1,251 @@
+import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+
+import type { CommandAuditPayload } from "../command_runtime/audit_log.ts";
+import type {
+  ApproveReviewRequest,
+  AssignReviewersRequest,
+  RejectReviewRequest,
+  ReviewCommandFailure,
+  RevokeReviewerRequest,
+  SaveAssignmentDraftRequest,
+  SaveCommentDraftRequest,
+  SubmitCommentRequest,
+} from "../commands/review/types.ts";
+
+type RpcClient = Pick<SupabaseClient, "rpc">;
+
+export type ReviewRpcResult =
+  | { ok: true; data: unknown }
+  | ReviewCommandFailure;
+
+function mapRpcError(
+  error: { code?: string; message?: string; details?: unknown },
+) {
+  const code = error.code ?? "RPC_ERROR";
+  const status = code === "42501"
+    ? 403
+    : code === "PGRST116"
+    ? 404
+    : code === "AUTH_REQUIRED"
+    ? 401
+    : 400;
+
+  return {
+    ok: false as const,
+    code,
+    status,
+    message: error.message ?? "Review command RPC failed",
+    details: error.details ?? null,
+  };
+}
+
+function isReviewCommandFailure(data: unknown): data is ReviewCommandFailure {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+
+  const candidate = data as Partial<ReviewCommandFailure> & { ok?: unknown };
+  return (
+    candidate.ok === false &&
+    typeof candidate.code === "string" &&
+    typeof candidate.message === "string" &&
+    typeof candidate.status === "number"
+  );
+}
+
+async function callReviewRpc(
+  supabase: RpcClient,
+  fn: string,
+  args: Record<string, unknown>,
+): Promise<ReviewRpcResult> {
+  const { data, error } = await supabase.rpc(fn, args);
+  if (error) {
+    return mapRpcError(error);
+  }
+
+  if (isReviewCommandFailure(data)) {
+    return data;
+  }
+
+  if (
+    data &&
+    typeof data === "object" &&
+    !Array.isArray(data) &&
+    (data as { ok?: unknown }).ok === true &&
+    "data" in (data as Record<string, unknown>)
+  ) {
+    return {
+      ok: true,
+      data: (data as Record<string, unknown>).data,
+    };
+  }
+
+  return {
+    ok: true,
+    data,
+  };
+}
+
+export function buildReviewSaveAssignmentDraftRpcArgs(
+  request: SaveAssignmentDraftRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_review_id: request.reviewId,
+    p_reviewer_ids: request.reviewerIds,
+    p_audit: audit,
+  };
+}
+
+export function buildReviewAssignReviewersRpcArgs(
+  request: AssignReviewersRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_review_id: request.reviewId,
+    p_reviewer_ids: request.reviewerIds,
+    p_deadline: request.deadline ?? null,
+    p_audit: audit,
+  };
+}
+
+export function buildReviewRevokeReviewerRpcArgs(
+  request: RevokeReviewerRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_review_id: request.reviewId,
+    p_reviewer_id: request.reviewerId,
+    p_audit: audit,
+  };
+}
+
+export function buildReviewSaveCommentDraftRpcArgs(
+  request: SaveCommentDraftRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_review_id: request.reviewId,
+    p_json: request.json,
+    p_audit: audit,
+  };
+}
+
+export function buildReviewSubmitCommentRpcArgs(
+  request: SubmitCommentRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_review_id: request.reviewId,
+    p_json: request.json,
+    p_comment_state: request.commentState ?? 1,
+    p_audit: audit,
+  };
+}
+
+export function buildReviewApproveRpcArgs(
+  request: ApproveReviewRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_table: request.table,
+    p_review_id: request.reviewId,
+    p_audit: audit,
+  };
+}
+
+export function buildReviewRejectRpcArgs(
+  request: RejectReviewRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_table: request.table,
+    p_review_id: request.reviewId,
+    p_reason: request.reason,
+    p_audit: audit,
+  };
+}
+
+export function callReviewSaveAssignmentDraftRpc(
+  supabase: RpcClient,
+  request: SaveAssignmentDraftRequest,
+  audit: CommandAuditPayload,
+) {
+  return callReviewRpc(
+    supabase,
+    "cmd_review_save_assignment_draft",
+    buildReviewSaveAssignmentDraftRpcArgs(request, audit),
+  );
+}
+
+export function callReviewAssignReviewersRpc(
+  supabase: RpcClient,
+  request: AssignReviewersRequest,
+  audit: CommandAuditPayload,
+) {
+  return callReviewRpc(
+    supabase,
+    "cmd_review_assign_reviewers",
+    buildReviewAssignReviewersRpcArgs(request, audit),
+  );
+}
+
+export function callReviewRevokeReviewerRpc(
+  supabase: RpcClient,
+  request: RevokeReviewerRequest,
+  audit: CommandAuditPayload,
+) {
+  return callReviewRpc(
+    supabase,
+    "cmd_review_revoke_reviewer",
+    buildReviewRevokeReviewerRpcArgs(request, audit),
+  );
+}
+
+export function callReviewSaveCommentDraftRpc(
+  supabase: RpcClient,
+  request: SaveCommentDraftRequest,
+  audit: CommandAuditPayload,
+) {
+  return callReviewRpc(
+    supabase,
+    "cmd_review_save_comment_draft",
+    buildReviewSaveCommentDraftRpcArgs(request, audit),
+  );
+}
+
+export function callReviewSubmitCommentRpc(
+  supabase: RpcClient,
+  request: SubmitCommentRequest,
+  audit: CommandAuditPayload,
+) {
+  return callReviewRpc(
+    supabase,
+    "cmd_review_submit_comment",
+    buildReviewSubmitCommentRpcArgs(request, audit),
+  );
+}
+
+export function callReviewApproveRpc(
+  supabase: RpcClient,
+  request: ApproveReviewRequest,
+  audit: CommandAuditPayload,
+) {
+  return callReviewRpc(
+    supabase,
+    "cmd_review_approve",
+    buildReviewApproveRpcArgs(request, audit),
+  );
+}
+
+export function callReviewRejectRpc(
+  supabase: RpcClient,
+  request: RejectReviewRequest,
+  audit: CommandAuditPayload,
+) {
+  return callReviewRpc(
+    supabase,
+    "cmd_review_reject",
+    buildReviewRejectRpcArgs(request, audit),
+  );
+}

--- a/supabase/functions/admin_review_approve/index.ts
+++ b/supabase/functions/admin_review_approve/index.ts
@@ -1,0 +1,27 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeApproveReviewCommand,
+  parseApproveReviewCommand,
+} from "../_shared/commands/review/approve_review.ts";
+import type { ApproveReviewRequest } from "../_shared/commands/review/types.ts";
+
+export function createAdminReviewApproveHandler(
+  overrides: Partial<CommandHandlerOptions<ApproveReviewRequest>> = {},
+) {
+  return createCommandHandler<ApproveReviewRequest>({
+    parse: parseApproveReviewCommand,
+    execute: executeApproveReviewCommand,
+    ...overrides,
+  });
+}
+
+export const handleAdminReviewApprove = createAdminReviewApproveHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAdminReviewApprove);
+}

--- a/supabase/functions/admin_review_assign_reviewers/index.ts
+++ b/supabase/functions/admin_review_assign_reviewers/index.ts
@@ -1,0 +1,28 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeAssignReviewersCommand,
+  parseAssignReviewersCommand,
+} from "../_shared/commands/review/assign_reviewers.ts";
+import type { AssignReviewersRequest } from "../_shared/commands/review/types.ts";
+
+export function createAdminReviewAssignReviewersHandler(
+  overrides: Partial<CommandHandlerOptions<AssignReviewersRequest>> = {},
+) {
+  return createCommandHandler<AssignReviewersRequest>({
+    parse: parseAssignReviewersCommand,
+    execute: executeAssignReviewersCommand,
+    ...overrides,
+  });
+}
+
+export const handleAdminReviewAssignReviewers =
+  createAdminReviewAssignReviewersHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAdminReviewAssignReviewers);
+}

--- a/supabase/functions/admin_review_reject/index.ts
+++ b/supabase/functions/admin_review_reject/index.ts
@@ -1,0 +1,27 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeRejectReviewCommand,
+  parseRejectReviewCommand,
+} from "../_shared/commands/review/reject_review.ts";
+import type { RejectReviewRequest } from "../_shared/commands/review/types.ts";
+
+export function createAdminReviewRejectHandler(
+  overrides: Partial<CommandHandlerOptions<RejectReviewRequest>> = {},
+) {
+  return createCommandHandler<RejectReviewRequest>({
+    parse: parseRejectReviewCommand,
+    execute: executeRejectReviewCommand,
+    ...overrides,
+  });
+}
+
+export const handleAdminReviewReject = createAdminReviewRejectHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAdminReviewReject);
+}

--- a/supabase/functions/admin_review_revoke_reviewer/index.ts
+++ b/supabase/functions/admin_review_revoke_reviewer/index.ts
@@ -1,0 +1,28 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeRevokeReviewerCommand,
+  parseRevokeReviewerCommand,
+} from "../_shared/commands/review/revoke_reviewer.ts";
+import type { RevokeReviewerRequest } from "../_shared/commands/review/types.ts";
+
+export function createAdminReviewRevokeReviewerHandler(
+  overrides: Partial<CommandHandlerOptions<RevokeReviewerRequest>> = {},
+) {
+  return createCommandHandler<RevokeReviewerRequest>({
+    parse: parseRevokeReviewerCommand,
+    execute: executeRevokeReviewerCommand,
+    ...overrides,
+  });
+}
+
+export const handleAdminReviewRevokeReviewer =
+  createAdminReviewRevokeReviewerHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAdminReviewRevokeReviewer);
+}

--- a/supabase/functions/admin_review_save_assignment_draft/index.ts
+++ b/supabase/functions/admin_review_save_assignment_draft/index.ts
@@ -1,0 +1,28 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeSaveAssignmentDraftCommand,
+  parseSaveAssignmentDraftCommand,
+} from "../_shared/commands/review/save_assignment_draft.ts";
+import type { SaveAssignmentDraftRequest } from "../_shared/commands/review/types.ts";
+
+export function createAdminReviewSaveAssignmentDraftHandler(
+  overrides: Partial<CommandHandlerOptions<SaveAssignmentDraftRequest>> = {},
+) {
+  return createCommandHandler<SaveAssignmentDraftRequest>({
+    parse: parseSaveAssignmentDraftCommand,
+    execute: executeSaveAssignmentDraftCommand,
+    ...overrides,
+  });
+}
+
+export const handleAdminReviewSaveAssignmentDraft =
+  createAdminReviewSaveAssignmentDraftHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAdminReviewSaveAssignmentDraft);
+}

--- a/supabase/functions/app_review_save_comment_draft/index.ts
+++ b/supabase/functions/app_review_save_comment_draft/index.ts
@@ -1,0 +1,28 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeSaveCommentDraftCommand,
+  parseSaveCommentDraftCommand,
+} from "../_shared/commands/review/save_comment_draft.ts";
+import type { SaveCommentDraftRequest } from "../_shared/commands/review/types.ts";
+
+export function createAppReviewSaveCommentDraftHandler(
+  overrides: Partial<CommandHandlerOptions<SaveCommentDraftRequest>> = {},
+) {
+  return createCommandHandler<SaveCommentDraftRequest>({
+    parse: parseSaveCommentDraftCommand,
+    execute: executeSaveCommentDraftCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppReviewSaveCommentDraft =
+  createAppReviewSaveCommentDraftHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppReviewSaveCommentDraft);
+}

--- a/supabase/functions/app_review_submit_comment/index.ts
+++ b/supabase/functions/app_review_submit_comment/index.ts
@@ -1,0 +1,28 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeSubmitCommentCommand,
+  parseSubmitCommentCommand,
+} from "../_shared/commands/review/submit_comment.ts";
+import type { SubmitCommentRequest } from "../_shared/commands/review/types.ts";
+
+export function createAppReviewSubmitCommentHandler(
+  overrides: Partial<CommandHandlerOptions<SubmitCommentRequest>> = {},
+) {
+  return createCommandHandler<SubmitCommentRequest>({
+    parse: parseSubmitCommentCommand,
+    execute: executeSubmitCommentCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppReviewSubmitComment =
+  createAppReviewSubmitCommentHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppReviewSubmitComment);
+}

--- a/test/admin_review_assignment_test.ts
+++ b/test/admin_review_assignment_test.ts
@@ -1,0 +1,145 @@
+import { assertEquals } from "jsr:@std/assert";
+import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+
+import { executeAssignReviewersCommand } from "../supabase/functions/_shared/commands/review/assign_reviewers.ts";
+import { executeRevokeReviewerCommand } from "../supabase/functions/_shared/commands/review/revoke_reviewer.ts";
+import { executeSaveAssignmentDraftCommand } from "../supabase/functions/_shared/commands/review/save_assignment_draft.ts";
+
+const TEST_USER_ID = "11111111-1111-4111-8111-111111111111";
+const TEST_REVIEW_ID = "22222222-2222-4222-8222-222222222222";
+const TEST_REVIEWER_A = "33333333-3333-4333-8333-333333333333";
+const TEST_REVIEWER_B = "44444444-4444-4444-8444-444444444444";
+
+class FakeRpcSupabase {
+  rpcCalls: Array<{ fn: string; args: unknown }> = [];
+
+  rpc(fn: string, args: unknown) {
+    this.rpcCalls.push({
+      fn,
+      args: structuredClone(args),
+    });
+
+    return Promise.resolve({
+      data: {
+        review_id: TEST_REVIEW_ID,
+      },
+      error: null,
+    });
+  }
+}
+
+function buildActor(supabase: FakeRpcSupabase) {
+  return {
+    userId: TEST_USER_ID,
+    accessToken: "access-token",
+    supabase: supabase as unknown as SupabaseClient,
+  };
+}
+
+Deno.test(
+  "executeSaveAssignmentDraftCommand forwards review assignment draft to cmd_review_save_assignment_draft",
+  async () => {
+    const supabase = new FakeRpcSupabase();
+    const result = await executeSaveAssignmentDraftCommand(
+      {
+        reviewId: TEST_REVIEW_ID,
+        reviewerIds: [TEST_REVIEWER_A, TEST_REVIEWER_B],
+      },
+      buildActor(supabase),
+    );
+
+    assertEquals(result.ok, true);
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: "cmd_review_save_assignment_draft",
+        args: {
+          p_review_id: TEST_REVIEW_ID,
+          p_reviewer_ids: [TEST_REVIEWER_A, TEST_REVIEWER_B],
+          p_audit: {
+            command: "review_save_assignment_draft",
+            actorUserId: TEST_USER_ID,
+            targetTable: "reviews",
+            targetId: TEST_REVIEW_ID,
+            targetVersion: "",
+            payload: {
+              reviewerIds: [TEST_REVIEWER_A, TEST_REVIEWER_B],
+            },
+          },
+        },
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  "executeAssignReviewersCommand forwards review assignment to cmd_review_assign_reviewers",
+  async () => {
+    const supabase = new FakeRpcSupabase();
+    const result = await executeAssignReviewersCommand(
+      {
+        reviewId: TEST_REVIEW_ID,
+        reviewerIds: [TEST_REVIEWER_A],
+        deadline: "2026-04-10T12:00:00.000Z",
+      },
+      buildActor(supabase),
+    );
+
+    assertEquals(result.ok, true);
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: "cmd_review_assign_reviewers",
+        args: {
+          p_review_id: TEST_REVIEW_ID,
+          p_reviewer_ids: [TEST_REVIEWER_A],
+          p_deadline: "2026-04-10T12:00:00.000Z",
+          p_audit: {
+            command: "review_assign_reviewers",
+            actorUserId: TEST_USER_ID,
+            targetTable: "reviews",
+            targetId: TEST_REVIEW_ID,
+            targetVersion: "",
+            payload: {
+              reviewerIds: [TEST_REVIEWER_A],
+              deadline: "2026-04-10T12:00:00.000Z",
+            },
+          },
+        },
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  "executeRevokeReviewerCommand forwards review revocation to cmd_review_revoke_reviewer",
+  async () => {
+    const supabase = new FakeRpcSupabase();
+    const result = await executeRevokeReviewerCommand(
+      {
+        reviewId: TEST_REVIEW_ID,
+        reviewerId: TEST_REVIEWER_B,
+      },
+      buildActor(supabase),
+    );
+
+    assertEquals(result.ok, true);
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: "cmd_review_revoke_reviewer",
+        args: {
+          p_review_id: TEST_REVIEW_ID,
+          p_reviewer_id: TEST_REVIEWER_B,
+          p_audit: {
+            command: "review_revoke_reviewer",
+            actorUserId: TEST_USER_ID,
+            targetTable: "reviews",
+            targetId: TEST_REVIEW_ID,
+            targetVersion: "",
+            payload: {
+              reviewerId: TEST_REVIEWER_B,
+            },
+          },
+        },
+      },
+    ]);
+  },
+);

--- a/test/admin_review_decision_test.ts
+++ b/test/admin_review_decision_test.ts
@@ -1,0 +1,117 @@
+import { assertEquals } from "jsr:@std/assert";
+import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+
+import { executeApproveReviewCommand } from "../supabase/functions/_shared/commands/review/approve_review.ts";
+import { executeRejectReviewCommand } from "../supabase/functions/_shared/commands/review/reject_review.ts";
+
+const TEST_USER_ID = "11111111-1111-4111-8111-111111111111";
+const TEST_REVIEW_ID = "22222222-2222-4222-8222-222222222222";
+
+class FakeRpcSupabase {
+  rpcCalls: Array<{ fn: string; args: unknown }> = [];
+
+  rpc(fn: string, args: unknown) {
+    this.rpcCalls.push({
+      fn,
+      args: structuredClone(args),
+    });
+
+    return Promise.resolve({
+      data: {
+        review_id: TEST_REVIEW_ID,
+      },
+      error: null,
+    });
+  }
+}
+
+function buildActor(supabase: FakeRpcSupabase) {
+  return {
+    userId: TEST_USER_ID,
+    accessToken: "access-token",
+    supabase: supabase as unknown as SupabaseClient,
+  };
+}
+
+Deno.test("executeApproveReviewCommand forwards approvals to cmd_review_approve", async () => {
+  const supabase = new FakeRpcSupabase();
+  const result = await executeApproveReviewCommand(
+    {
+      table: "processes",
+      reviewId: TEST_REVIEW_ID,
+    },
+    buildActor(supabase),
+  );
+
+  assertEquals(result.ok, true);
+  assertEquals(supabase.rpcCalls, [
+    {
+      fn: "cmd_review_approve",
+      args: {
+        p_table: "processes",
+        p_review_id: TEST_REVIEW_ID,
+        p_audit: {
+          command: "review_approve",
+          actorUserId: TEST_USER_ID,
+          targetTable: "processes",
+          targetId: TEST_REVIEW_ID,
+          targetVersion: "",
+          payload: {},
+        },
+      },
+    },
+  ]);
+});
+
+Deno.test("executeRejectReviewCommand forwards rejections to cmd_review_reject", async () => {
+  const supabase = new FakeRpcSupabase();
+  const result = await executeRejectReviewCommand(
+    {
+      table: "lifecyclemodels",
+      reviewId: TEST_REVIEW_ID,
+      reason: "Data quality issue",
+    },
+    buildActor(supabase),
+  );
+
+  assertEquals(result.ok, true);
+  assertEquals(supabase.rpcCalls, [
+    {
+      fn: "cmd_review_reject",
+      args: {
+        p_table: "lifecyclemodels",
+        p_review_id: TEST_REVIEW_ID,
+        p_reason: "Data quality issue",
+        p_audit: {
+          command: "review_reject",
+          actorUserId: TEST_USER_ID,
+          targetTable: "lifecyclemodels",
+          targetId: TEST_REVIEW_ID,
+          targetVersion: "",
+          payload: {
+            reason: "Data quality issue",
+          },
+        },
+      },
+    },
+  ]);
+});
+
+Deno.test("executeRejectReviewCommand rejects blank reason before RPC call", async () => {
+  const supabase = new FakeRpcSupabase();
+  const result = await executeRejectReviewCommand(
+    {
+      table: "processes",
+      reviewId: TEST_REVIEW_ID,
+      reason: "   ",
+    },
+    buildActor(supabase),
+  );
+
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.code, "REASON_REQUIRED");
+    assertEquals(result.status, 400);
+  }
+  assertEquals(supabase.rpcCalls.length, 0);
+});

--- a/test/app_review_comment_test.ts
+++ b/test/app_review_comment_test.ts
@@ -1,0 +1,169 @@
+import { assertEquals } from "jsr:@std/assert";
+import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+
+import { executeSaveCommentDraftCommand } from "../supabase/functions/_shared/commands/review/save_comment_draft.ts";
+import { executeSubmitCommentCommand } from "../supabase/functions/_shared/commands/review/submit_comment.ts";
+
+const TEST_USER_ID = "11111111-1111-4111-8111-111111111111";
+const TEST_REVIEW_ID = "22222222-2222-4222-8222-222222222222";
+
+class FakeRpcSupabase {
+  rpcCalls: Array<{ fn: string; args: unknown }> = [];
+
+  rpc(fn: string, args: unknown) {
+    this.rpcCalls.push({
+      fn,
+      args: structuredClone(args),
+    });
+
+    return Promise.resolve({
+      data: {
+        review_id: TEST_REVIEW_ID,
+      },
+      error: null,
+    });
+  }
+}
+
+function buildActor(supabase: FakeRpcSupabase) {
+  return {
+    userId: TEST_USER_ID,
+    accessToken: "access-token",
+    supabase: supabase as unknown as SupabaseClient,
+  };
+}
+
+Deno.test(
+  "executeSaveCommentDraftCommand forwards comment draft save to cmd_review_save_comment_draft",
+  async () => {
+    const supabase = new FakeRpcSupabase();
+    const json = { blocks: [{ type: "paragraph", text: "Needs adjustments" }] };
+    const result = await executeSaveCommentDraftCommand(
+      {
+        reviewId: TEST_REVIEW_ID,
+        json,
+      },
+      buildActor(supabase),
+    );
+
+    assertEquals(result.ok, true);
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: "cmd_review_save_comment_draft",
+        args: {
+          p_review_id: TEST_REVIEW_ID,
+          p_json: json,
+          p_audit: {
+            command: "review_save_comment_draft",
+            actorUserId: TEST_USER_ID,
+            targetTable: "reviews",
+            targetId: TEST_REVIEW_ID,
+            targetVersion: "",
+            payload: {
+              hasJson: true,
+            },
+          },
+        },
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  "executeSubmitCommentCommand forwards comment submission to cmd_review_submit_comment",
+  async () => {
+    const supabase = new FakeRpcSupabase();
+    const json = { summary: "Approved with comments" };
+    const result = await executeSubmitCommentCommand(
+      {
+        reviewId: TEST_REVIEW_ID,
+        json,
+      },
+      buildActor(supabase),
+    );
+
+    assertEquals(result.ok, true);
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: "cmd_review_submit_comment",
+        args: {
+          p_review_id: TEST_REVIEW_ID,
+          p_json: json,
+          p_comment_state: 1,
+          p_audit: {
+            command: "review_submit_comment",
+            actorUserId: TEST_USER_ID,
+            targetTable: "reviews",
+            targetId: TEST_REVIEW_ID,
+            targetVersion: "",
+            payload: {
+              hasJson: true,
+              commentState: 1,
+            },
+          },
+        },
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  "executeSubmitCommentCommand forwards reviewer rejection through cmd_review_submit_comment",
+  async () => {
+    const supabase = new FakeRpcSupabase();
+    const json = { summary: "Rejected by reviewer" };
+    const result = await executeSubmitCommentCommand(
+      {
+        reviewId: TEST_REVIEW_ID,
+        json,
+        commentState: -3,
+      },
+      buildActor(supabase),
+    );
+
+    assertEquals(result.ok, true);
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: "cmd_review_submit_comment",
+        args: {
+          p_review_id: TEST_REVIEW_ID,
+          p_json: json,
+          p_comment_state: -3,
+          p_audit: {
+            command: "review_submit_comment",
+            actorUserId: TEST_USER_ID,
+            targetTable: "reviews",
+            targetId: TEST_REVIEW_ID,
+            targetVersion: "",
+            payload: {
+              hasJson: true,
+              commentState: -3,
+            },
+          },
+        },
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  "executeSubmitCommentCommand rejects invalid commentState before RPC call",
+  async () => {
+    const supabase = new FakeRpcSupabase();
+    const result = await executeSubmitCommentCommand(
+      {
+        reviewId: TEST_REVIEW_ID,
+        json: { summary: "Invalid state" },
+        commentState: 0 as never,
+      },
+      buildActor(supabase),
+    );
+
+    assertEquals(result.ok, false);
+    if (!result.ok) {
+      assertEquals(result.code, "INVALID_COMMENT_STATE");
+      assertEquals(result.status, 400);
+    }
+    assertEquals(supabase.rpcCalls.length, 0);
+  },
+);

--- a/test/review_command_rpc_contract_test.ts
+++ b/test/review_command_rpc_contract_test.ts
@@ -1,0 +1,263 @@
+import { assertEquals, assertThrows } from "jsr:@std/assert";
+
+import { buildCommandAuditPayload } from "../supabase/functions/_shared/command_runtime/audit_log.ts";
+import { createReviewCommandRepository } from "../supabase/functions/_shared/commands/review/repository.ts";
+import {
+  rejectReviewRequestSchema,
+  saveAssignmentDraftRequestSchema,
+  submitCommentRequestSchema,
+} from "../supabase/functions/_shared/commands/review/validation.ts";
+import {
+  buildReviewApproveRpcArgs,
+  buildReviewRejectRpcArgs,
+  buildReviewSaveCommentDraftRpcArgs,
+  buildReviewSubmitCommentRpcArgs,
+  callReviewApproveRpc,
+  callReviewRejectRpc,
+  callReviewSaveAssignmentDraftRpc,
+  type ReviewRpcResult,
+} from "../supabase/functions/_shared/db_rpc/review_commands.ts";
+
+Deno.test("saveAssignmentDraftRequestSchema rejects unexpected fields", () => {
+  const parsed = saveAssignmentDraftRequestSchema.safeParse({
+    reviewId: "11111111-1111-4111-8111-111111111111",
+    reviewerIds: ["22222222-2222-4222-8222-222222222222"],
+    deadline: "2026-04-10T12:00:00.000Z",
+  });
+
+  assertEquals(parsed.success, false);
+});
+
+Deno.test("submitCommentRequestSchema rejects server-owned fields", () => {
+  const parsed = submitCommentRequestSchema.safeParse({
+    reviewId: "11111111-1111-4111-8111-111111111111",
+    json: {},
+    submittedAt: "2026-04-10T12:00:00.000Z",
+  });
+
+  assertEquals(parsed.success, false);
+});
+
+Deno.test("submitCommentRequestSchema rejects invalid commentState values", () => {
+  const parsed = submitCommentRequestSchema.safeParse({
+    reviewId: "11111111-1111-4111-8111-111111111111",
+    json: {},
+    commentState: 0,
+  });
+
+  assertEquals(parsed.success, false);
+});
+
+Deno.test("rejectReviewRequestSchema requires non-empty reason", () => {
+  const parsed = rejectReviewRequestSchema.safeParse({
+    table: "processes",
+    reviewId: "11111111-1111-4111-8111-111111111111",
+    reason: "   ",
+  });
+
+  assertEquals(parsed.success, false);
+});
+
+Deno.test("createReviewCommandRepository requires an explicit Supabase client", () => {
+  assertThrows(
+    () => createReviewCommandRepository(undefined as never),
+    Error,
+    "Review command repository requires an explicit Supabase client",
+  );
+});
+
+class FakeRpcSupabase {
+  constructor(private readonly result: { data: unknown; error: unknown }) {}
+
+  rpc() {
+    return Promise.resolve(this.result);
+  }
+}
+
+const saveAssignmentDraftRequest = {
+  reviewId: "11111111-1111-4111-8111-111111111111",
+  reviewerIds: ["22222222-2222-4222-8222-222222222222"],
+};
+
+const approveRequest = {
+  table: "processes" as const,
+  reviewId: "11111111-1111-4111-8111-111111111111",
+};
+
+const saveCommentDraftRequest = {
+  reviewId: "11111111-1111-4111-8111-111111111111",
+  json: { blocks: [] },
+};
+
+const submitCommentRequest = {
+  reviewId: "11111111-1111-4111-8111-111111111111",
+  json: { summary: "looks good" },
+  commentState: -3 as const,
+};
+
+const rejectRequest = {
+  table: "lifecyclemodels" as const,
+  reviewId: "11111111-1111-4111-8111-111111111111",
+  reason: "Insufficient evidence",
+};
+
+const auditPayload = buildCommandAuditPayload({
+  command: "review_save_assignment_draft",
+  actorUserId: "33333333-3333-4333-8333-333333333333",
+  targetTable: "reviews",
+  targetId: "11111111-1111-4111-8111-111111111111",
+  targetVersion: "",
+  payload: {},
+});
+
+Deno.test(
+  "callReviewSaveAssignmentDraftRpc unwraps success envelopes returned by cmd_review_* RPCs",
+  async () => {
+    const result = (await callReviewSaveAssignmentDraftRpc(
+      new FakeRpcSupabase({
+        data: {
+          ok: true,
+          data: {
+            review_id: saveAssignmentDraftRequest.reviewId,
+            reviewer_count: saveAssignmentDraftRequest.reviewerIds.length,
+          },
+        },
+        error: null,
+      }) as never,
+      saveAssignmentDraftRequest,
+      auditPayload,
+    )) as ReviewRpcResult;
+
+    assertEquals(result, {
+      ok: true,
+      data: {
+        review_id: saveAssignmentDraftRequest.reviewId,
+        reviewer_count: saveAssignmentDraftRequest.reviewerIds.length,
+      },
+    });
+  },
+);
+
+Deno.test(
+  "callReviewSaveAssignmentDraftRpc treats failure envelopes as command failures",
+  async () => {
+    const result = (await callReviewSaveAssignmentDraftRpc(
+      new FakeRpcSupabase({
+        data: {
+          ok: false,
+          code: "REVIEW_NOT_FOUND",
+          status: 404,
+          message: "Review not found",
+          details: {
+            review_id: saveAssignmentDraftRequest.reviewId,
+          },
+        },
+        error: null,
+      }) as never,
+      saveAssignmentDraftRequest,
+      auditPayload,
+    )) as ReviewRpcResult;
+
+    assertEquals(result, {
+      ok: false,
+      code: "REVIEW_NOT_FOUND",
+      status: 404,
+      message: "Review not found",
+      details: {
+        review_id: saveAssignmentDraftRequest.reviewId,
+      },
+    });
+  },
+);
+
+Deno.test("callReviewApproveRpc unwraps success envelopes returned by cmd_review_approve", async () => {
+  const result = (await callReviewApproveRpc(
+    new FakeRpcSupabase({
+      data: {
+        ok: true,
+        data: {
+          review_id: approveRequest.reviewId,
+          approved: true,
+        },
+      },
+      error: null,
+    }) as never,
+    approveRequest,
+    auditPayload,
+  )) as ReviewRpcResult;
+
+  assertEquals(result, {
+    ok: true,
+    data: {
+      review_id: approveRequest.reviewId,
+      approved: true,
+    },
+  });
+});
+
+Deno.test("callReviewRejectRpc treats failure envelopes as command failures", async () => {
+  const result = (await callReviewRejectRpc(
+    new FakeRpcSupabase({
+      data: {
+        ok: false,
+        code: "INVALID_STATE",
+        status: 409,
+        message: "Review is not in an approvable state",
+        details: {
+          review_id: rejectRequest.reviewId,
+          state_code: 10,
+        },
+      },
+      error: null,
+    }) as never,
+    rejectRequest,
+    auditPayload,
+  )) as ReviewRpcResult;
+
+  assertEquals(result, {
+    ok: false,
+    code: "INVALID_STATE",
+    status: 409,
+    message: "Review is not in an approvable state",
+    details: {
+      review_id: rejectRequest.reviewId,
+      state_code: 10,
+    },
+  });
+});
+
+Deno.test("review comment RPC arg builders use the DB contract field names", () => {
+  assertEquals(
+    buildReviewSaveCommentDraftRpcArgs(saveCommentDraftRequest, auditPayload),
+    {
+      p_review_id: saveCommentDraftRequest.reviewId,
+      p_json: saveCommentDraftRequest.json,
+      p_audit: auditPayload,
+    },
+  );
+
+  assertEquals(
+    buildReviewSubmitCommentRpcArgs(submitCommentRequest, auditPayload),
+    {
+      p_review_id: submitCommentRequest.reviewId,
+      p_json: submitCommentRequest.json,
+      p_comment_state: -3,
+      p_audit: auditPayload,
+    },
+  );
+});
+
+Deno.test("review decision RPC arg builders forward table and reason fields", () => {
+  assertEquals(buildReviewApproveRpcArgs(approveRequest, auditPayload), {
+    p_table: approveRequest.table,
+    p_review_id: approveRequest.reviewId,
+    p_audit: auditPayload,
+  });
+
+  assertEquals(buildReviewRejectRpcArgs(rejectRequest, auditPayload), {
+    p_table: rejectRequest.table,
+    p_review_id: rejectRequest.reviewId,
+    p_reason: rejectRequest.reason,
+    p_audit: auditPayload,
+  });
+});


### PR DESCRIPTION
Closes #50

## Summary
- add the review workflow command domain and RPC wrappers for assignment, comment, approve, and reject flows
- expose the new public edge handlers on top of the request-scoped command runtime
- cover the review workflow command contracts, including reviewer reject via `commentState: -3`

## Decisions
- keep the DB RPC contract aligned with `next/supabase` as the source of truth for review workflow commands
- route reviewer reject through `cmd_review_submit_comment` with `p_comment_state = -3`
- keep this PR stacked on top of #51 because review workflow commands depend on the Task 2 submit-review runtime boundary

## Validation
- `deno check --config supabase/functions/deno.json supabase/functions/_shared/commands/review/*.ts supabase/functions/_shared/db_rpc/review_commands.ts supabase/functions/admin_review_save_assignment_draft/index.ts supabase/functions/admin_review_assign_reviewers/index.ts supabase/functions/admin_review_revoke_reviewer/index.ts supabase/functions/app_review_save_comment_draft/index.ts supabase/functions/app_review_submit_comment/index.ts supabase/functions/admin_review_approve/index.ts supabase/functions/admin_review_reject/index.ts`
- `deno test --config supabase/functions/deno.json test/admin_review_assignment_test.ts test/app_review_comment_test.ts test/admin_review_decision_test.ts test/review_command_rpc_contract_test.ts`

## Notes
- Base branch is `codex/feature/issue-49-review-submit-command` until #51 merges.
