### PR TITLE
feat: add membership and profile command handlers

### DIFF
--- a/supabase/functions/_shared/commands/membership/accept_invitation.ts
+++ b/supabase/functions/_shared/commands/membership/accept_invitation.ts
@@ -1,0 +1,49 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import {
+  createMembershipCommandRepository,
+  type MembershipCommandRepository,
+} from "./repository.ts";
+import type {
+  MembershipCommandExecutionResult,
+  TeamInvitationDecisionRequest,
+} from "./types.ts";
+import { parseTeamInvitationDecisionRequest } from "./validation.ts";
+
+export function parseTeamAcceptInvitationCommand(body: unknown) {
+  return parseTeamInvitationDecisionRequest(body);
+}
+
+export async function executeTeamAcceptInvitationCommand(
+  request: TeamInvitationDecisionRequest,
+  actor: ActorContext,
+  repository: MembershipCommandRepository = createMembershipCommandRepository(
+    actor.supabase,
+  ),
+): Promise<MembershipCommandExecutionResult> {
+  const audit = buildCommandAuditPayload({
+    command: "team_accept_invitation",
+    actorUserId: actor.userId,
+    targetTable: "roles",
+    targetId: actor.userId,
+    targetVersion: request.teamId,
+    payload: {
+      teamId: request.teamId,
+    },
+  });
+
+  const result = await repository.acceptInvitation(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "team_accept_invitation",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/membership/change_role.ts
+++ b/supabase/functions/_shared/commands/membership/change_role.ts
@@ -1,0 +1,148 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import {
+  createMembershipCommandRepository,
+  type MembershipCommandRepository,
+} from "./repository.ts";
+import type {
+  MembershipCommandExecutionResult,
+  ReviewChangeMemberRoleRequest,
+  SystemChangeMemberRoleRequest,
+  TeamChangeMemberRoleRequest,
+} from "./types.ts";
+import {
+  parseReviewChangeMemberRoleRequest,
+  parseSystemChangeMemberRoleRequest,
+  parseTeamChangeMemberRoleRequest,
+} from "./validation.ts";
+
+type ChangeMemberRoleScope = "team" | "system" | "review";
+
+function normalizeAction(action?: "set" | "remove") {
+  return action ?? "set";
+}
+
+function assertChangeRolePayload(
+  action: "set" | "remove",
+  role: string | null | undefined,
+): MembershipCommandExecutionResult | null {
+  if (action === "set" && (!role || role.trim().length === 0)) {
+    return {
+      ok: false,
+      code: "ROLE_REQUIRED",
+      status: 400,
+      message: "role is required when action is set",
+    };
+  }
+
+  if (action === "remove" && role && role.trim().length > 0) {
+    return {
+      ok: false,
+      code: "ROLE_NOT_ALLOWED",
+      status: 400,
+      message: "role must be omitted when action is remove",
+    };
+  }
+
+  return null;
+}
+
+export function parseTeamChangeMemberRoleCommand(body: unknown) {
+  return parseTeamChangeMemberRoleRequest(body);
+}
+
+export function parseSystemChangeMemberRoleCommand(body: unknown) {
+  return parseSystemChangeMemberRoleRequest(body);
+}
+
+export function parseReviewChangeMemberRoleCommand(body: unknown) {
+  return parseReviewChangeMemberRoleRequest(body);
+}
+
+export async function executeTeamChangeMemberRoleCommand(
+  request: TeamChangeMemberRoleRequest,
+  actor: ActorContext,
+  repository: MembershipCommandRepository = createMembershipCommandRepository(
+    actor.supabase,
+  ),
+): Promise<MembershipCommandExecutionResult> {
+  return executeChangeRoleByScope("team", request, actor, repository);
+}
+
+export async function executeSystemChangeMemberRoleCommand(
+  request: SystemChangeMemberRoleRequest,
+  actor: ActorContext,
+  repository: MembershipCommandRepository = createMembershipCommandRepository(
+    actor.supabase,
+  ),
+): Promise<MembershipCommandExecutionResult> {
+  return executeChangeRoleByScope("system", request, actor, repository);
+}
+
+export async function executeReviewChangeMemberRoleCommand(
+  request: ReviewChangeMemberRoleRequest,
+  actor: ActorContext,
+  repository: MembershipCommandRepository = createMembershipCommandRepository(
+    actor.supabase,
+  ),
+): Promise<MembershipCommandExecutionResult> {
+  return executeChangeRoleByScope("review", request, actor, repository);
+}
+
+async function executeChangeRoleByScope(
+  scope: ChangeMemberRoleScope,
+  request:
+    | TeamChangeMemberRoleRequest
+    | SystemChangeMemberRoleRequest
+    | ReviewChangeMemberRoleRequest,
+  actor: ActorContext,
+  repository: MembershipCommandRepository,
+): Promise<MembershipCommandExecutionResult> {
+  const action = normalizeAction(request.action);
+  const roleError = assertChangeRolePayload(action, request.role);
+  if (roleError) {
+    return roleError;
+  }
+
+  const audit = buildCommandAuditPayload({
+    command: `${scope}_change_member_role`,
+    actorUserId: actor.userId,
+    targetTable: "roles",
+    targetId: request.userId,
+    targetVersion: "teamId" in request ? request.teamId : "",
+    payload: {
+      action,
+      role: request.role ?? null,
+      teamId: "teamId" in request ? request.teamId : null,
+    },
+  });
+
+  const result = scope === "team"
+    ? await repository.changeTeamMemberRole(
+      request as TeamChangeMemberRoleRequest,
+      audit,
+    )
+    : scope === "system"
+    ? await repository.changeSystemMemberRole(
+      request as SystemChangeMemberRoleRequest,
+      audit,
+    )
+    : await repository.changeReviewMemberRole(
+      request as ReviewChangeMemberRoleRequest,
+      audit,
+    );
+
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: `${scope}_change_member_role`,
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/membership/reinvite_member.ts
+++ b/supabase/functions/_shared/commands/membership/reinvite_member.ts
@@ -1,0 +1,50 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import {
+  createMembershipCommandRepository,
+  type MembershipCommandRepository,
+} from "./repository.ts";
+import type {
+  MembershipCommandExecutionResult,
+  TeamReinviteMemberRequest,
+} from "./types.ts";
+import { parseTeamReinviteMemberRequest } from "./validation.ts";
+
+export function parseTeamReinviteMemberCommand(body: unknown) {
+  return parseTeamReinviteMemberRequest(body);
+}
+
+export async function executeTeamReinviteMemberCommand(
+  request: TeamReinviteMemberRequest,
+  actor: ActorContext,
+  repository: MembershipCommandRepository = createMembershipCommandRepository(
+    actor.supabase,
+  ),
+): Promise<MembershipCommandExecutionResult> {
+  const audit = buildCommandAuditPayload({
+    command: "team_reinvite_member",
+    actorUserId: actor.userId,
+    targetTable: "roles",
+    targetId: request.userId,
+    targetVersion: request.teamId,
+    payload: {
+      teamId: request.teamId,
+      userId: request.userId,
+    },
+  });
+
+  const result = await repository.reinviteTeamMember(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "team_reinvite_member",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/membership/reject_invitation.ts
+++ b/supabase/functions/_shared/commands/membership/reject_invitation.ts
@@ -1,0 +1,49 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import {
+  createMembershipCommandRepository,
+  type MembershipCommandRepository,
+} from "./repository.ts";
+import type {
+  MembershipCommandExecutionResult,
+  TeamInvitationDecisionRequest,
+} from "./types.ts";
+import { parseTeamInvitationDecisionRequest } from "./validation.ts";
+
+export function parseTeamRejectInvitationCommand(body: unknown) {
+  return parseTeamInvitationDecisionRequest(body);
+}
+
+export async function executeTeamRejectInvitationCommand(
+  request: TeamInvitationDecisionRequest,
+  actor: ActorContext,
+  repository: MembershipCommandRepository = createMembershipCommandRepository(
+    actor.supabase,
+  ),
+): Promise<MembershipCommandExecutionResult> {
+  const audit = buildCommandAuditPayload({
+    command: "team_reject_invitation",
+    actorUserId: actor.userId,
+    targetTable: "roles",
+    targetId: actor.userId,
+    targetVersion: request.teamId,
+    payload: {
+      teamId: request.teamId,
+    },
+  });
+
+  const result = await repository.rejectInvitation(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "team_reject_invitation",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/membership/repository.ts
+++ b/supabase/functions/_shared/commands/membership/repository.ts
@@ -1,0 +1,111 @@
+import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+
+import type { CommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import {
+  callReviewChangeMemberRoleRpc,
+  callSystemChangeMemberRoleRpc,
+  callTeamAcceptInvitationRpc,
+  callTeamChangeMemberRoleRpc,
+  callTeamCreateRpc,
+  callTeamRejectInvitationRpc,
+  callTeamReinviteMemberRpc,
+  callTeamSetRankRpc,
+  callTeamUpdateProfileRpc,
+  callUserUpdateContactRpc,
+  type MembershipRpcResult,
+} from "../../db_rpc/membership_commands.ts";
+import type {
+  ReviewChangeMemberRoleRequest,
+  SystemChangeMemberRoleRequest,
+  TeamChangeMemberRoleRequest,
+  TeamCreateRequest,
+  TeamInvitationDecisionRequest,
+  TeamReinviteMemberRequest,
+  TeamSetRankRequest,
+  TeamUpdateProfileRequest,
+  UserUpdateContactRequest,
+} from "./types.ts";
+
+type RpcClient = Pick<SupabaseClient, "rpc">;
+
+export type MembershipCommandRepository = {
+  createTeam: (
+    request: TeamCreateRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<MembershipRpcResult>;
+  updateTeamProfile: (
+    request: TeamUpdateProfileRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<MembershipRpcResult>;
+  setTeamRank: (
+    request: TeamSetRankRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<MembershipRpcResult>;
+  updateUserContact: (
+    request: UserUpdateContactRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<MembershipRpcResult>;
+  changeTeamMemberRole: (
+    request: TeamChangeMemberRoleRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<MembershipRpcResult>;
+  changeSystemMemberRole: (
+    request: SystemChangeMemberRoleRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<MembershipRpcResult>;
+  changeReviewMemberRole: (
+    request: ReviewChangeMemberRoleRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<MembershipRpcResult>;
+  reinviteTeamMember: (
+    request: TeamReinviteMemberRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<MembershipRpcResult>;
+  acceptInvitation: (
+    request: TeamInvitationDecisionRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<MembershipRpcResult>;
+  rejectInvitation: (
+    request: TeamInvitationDecisionRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<MembershipRpcResult>;
+};
+
+function requireExplicitClient(
+  supabase: RpcClient | null | undefined,
+): RpcClient {
+  if (!supabase || typeof supabase.rpc !== "function") {
+    throw new Error(
+      "Membership command repository requires an explicit Supabase client",
+    );
+  }
+
+  return supabase;
+}
+
+export function createMembershipCommandRepository(
+  supabase: RpcClient,
+): MembershipCommandRepository {
+  const client = requireExplicitClient(supabase);
+
+  return {
+    createTeam: (request, audit) => callTeamCreateRpc(client, request, audit),
+    updateTeamProfile: (request, audit) =>
+      callTeamUpdateProfileRpc(client, request, audit),
+    setTeamRank: (request, audit) => callTeamSetRankRpc(client, request, audit),
+    updateUserContact: (request, audit) =>
+      callUserUpdateContactRpc(client, request, audit),
+    changeTeamMemberRole: (request, audit) =>
+      callTeamChangeMemberRoleRpc(client, request, audit),
+    changeSystemMemberRole: (request, audit) =>
+      callSystemChangeMemberRoleRpc(client, request, audit),
+    changeReviewMemberRole: (request, audit) =>
+      callReviewChangeMemberRoleRpc(client, request, audit),
+    reinviteTeamMember: (request, audit) =>
+      callTeamReinviteMemberRpc(client, request, audit),
+    acceptInvitation: (request, audit) =>
+      callTeamAcceptInvitationRpc(client, request, audit),
+    rejectInvitation: (request, audit) =>
+      callTeamRejectInvitationRpc(client, request, audit),
+  };
+}

--- a/supabase/functions/_shared/commands/membership/types.ts
+++ b/supabase/functions/_shared/commands/membership/types.ts
@@ -1,0 +1,66 @@
+export const MEMBER_ROLE_ACTIONS = ["set", "remove"] as const;
+
+export type MemberRoleAction = (typeof MEMBER_ROLE_ACTIONS)[number];
+
+export type TeamChangeMemberRoleRequest = {
+  teamId: string;
+  userId: string;
+  role?: string | null;
+  action?: MemberRoleAction;
+};
+
+export type SystemChangeMemberRoleRequest = {
+  userId: string;
+  role?: string | null;
+  action?: MemberRoleAction;
+};
+
+export type ReviewChangeMemberRoleRequest = {
+  userId: string;
+  role?: string | null;
+  action?: MemberRoleAction;
+};
+
+export type TeamReinviteMemberRequest = {
+  teamId: string;
+  userId: string;
+};
+
+export type TeamInvitationDecisionRequest = {
+  teamId: string;
+};
+
+export type TeamCreateRequest = {
+  teamId: string;
+  json: unknown;
+  rank: number;
+  isPublic: boolean;
+};
+
+export type TeamUpdateProfileRequest = {
+  teamId: string;
+  json: unknown;
+  isPublic: boolean;
+};
+
+export type TeamSetRankRequest = {
+  teamId: string;
+  rank: number;
+};
+
+export type UserUpdateContactRequest = {
+  userId: string;
+  contact: unknown;
+};
+
+export type MembershipCommandFailure = {
+  ok: false;
+  code: string;
+  message: string;
+  status: number;
+  details?: unknown;
+};
+
+export type MembershipCommandExecutionResult =
+  | { ok: true; body: unknown; status?: number }
+  | MembershipCommandFailure;

--- a/supabase/functions/_shared/commands/membership/validation.ts
+++ b/supabase/functions/_shared/commands/membership/validation.ts
@@ -1,0 +1,190 @@
+import { z } from "zod";
+
+import type { CommandParseResult } from "../../command_runtime/command.ts";
+import {
+  MEMBER_ROLE_ACTIONS,
+  type ReviewChangeMemberRoleRequest,
+  type SystemChangeMemberRoleRequest,
+  type TeamChangeMemberRoleRequest,
+  type TeamCreateRequest,
+  type TeamInvitationDecisionRequest,
+  type TeamReinviteMemberRequest,
+  type TeamSetRankRequest,
+  type TeamUpdateProfileRequest,
+  type UserUpdateContactRequest,
+} from "./types.ts";
+
+const uuidSchema = z.string().uuid();
+const nonEmptyStringSchema = z.string().trim().min(1);
+const actionSchema = z.enum(MEMBER_ROLE_ACTIONS);
+
+const baseChangeMemberRoleSchema = z
+  .object({
+    userId: uuidSchema,
+    role: nonEmptyStringSchema.nullable().optional(),
+    action: actionSchema.optional(),
+  })
+  .strict();
+
+export const teamChangeMemberRoleRequestSchema = baseChangeMemberRoleSchema
+  .extend({
+    teamId: uuidSchema,
+  })
+  .strict();
+
+export const systemChangeMemberRoleRequestSchema =
+  baseChangeMemberRoleSchema.strict();
+
+export const reviewChangeMemberRoleRequestSchema =
+  baseChangeMemberRoleSchema.strict();
+
+export const teamReinviteMemberRequestSchema = z
+  .object({
+    teamId: uuidSchema,
+    userId: uuidSchema,
+  })
+  .strict();
+
+export const teamInvitationDecisionRequestSchema = z
+  .object({
+    teamId: uuidSchema,
+  })
+  .strict();
+
+export const teamCreateRequestSchema = z
+  .object({
+    teamId: uuidSchema,
+    json: z.unknown(),
+    rank: z.number().int(),
+    isPublic: z.boolean(),
+  })
+  .strict();
+
+export const teamUpdateProfileRequestSchema = z
+  .object({
+    teamId: uuidSchema,
+    json: z.unknown(),
+    isPublic: z.boolean(),
+  })
+  .strict();
+
+export const teamSetRankRequestSchema = z
+  .object({
+    teamId: uuidSchema,
+    rank: z.number().int(),
+  })
+  .strict();
+
+export const userUpdateContactRequestSchema = z
+  .object({
+    userId: uuidSchema,
+    contact: z.unknown(),
+  })
+  .strict();
+
+function invalidPayload<T>(
+  message: string,
+  error: z.ZodError,
+): CommandParseResult<T> {
+  return {
+    ok: false,
+    message,
+    details: error.flatten(),
+  };
+}
+
+export function parseTeamChangeMemberRoleRequest(
+  body: unknown,
+): CommandParseResult<TeamChangeMemberRoleRequest> {
+  const parsed = teamChangeMemberRoleRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload("Invalid team change-member-role payload", parsed.error);
+  }
+  return { ok: true, value: parsed.data };
+}
+
+export function parseSystemChangeMemberRoleRequest(
+  body: unknown,
+): CommandParseResult<SystemChangeMemberRoleRequest> {
+  const parsed = systemChangeMemberRoleRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload(
+      "Invalid system change-member-role payload",
+      parsed.error,
+    );
+  }
+  return { ok: true, value: parsed.data };
+}
+
+export function parseReviewChangeMemberRoleRequest(
+  body: unknown,
+): CommandParseResult<ReviewChangeMemberRoleRequest> {
+  const parsed = reviewChangeMemberRoleRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload(
+      "Invalid review change-member-role payload",
+      parsed.error,
+    );
+  }
+  return { ok: true, value: parsed.data };
+}
+
+export function parseTeamReinviteMemberRequest(
+  body: unknown,
+): CommandParseResult<TeamReinviteMemberRequest> {
+  const parsed = teamReinviteMemberRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload("Invalid team reinvite-member payload", parsed.error);
+  }
+  return { ok: true, value: parsed.data };
+}
+
+export function parseTeamInvitationDecisionRequest(
+  body: unknown,
+): CommandParseResult<TeamInvitationDecisionRequest> {
+  const parsed = teamInvitationDecisionRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload("Invalid team invitation payload", parsed.error);
+  }
+  return { ok: true, value: parsed.data };
+}
+
+export function parseTeamCreateRequest(
+  body: unknown,
+): CommandParseResult<TeamCreateRequest> {
+  const parsed = teamCreateRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload("Invalid team create payload", parsed.error);
+  }
+  return { ok: true, value: parsed.data };
+}
+
+export function parseTeamUpdateProfileRequest(
+  body: unknown,
+): CommandParseResult<TeamUpdateProfileRequest> {
+  const parsed = teamUpdateProfileRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload("Invalid team update-profile payload", parsed.error);
+  }
+  return { ok: true, value: parsed.data };
+}
+
+export function parseTeamSetRankRequest(
+  body: unknown,
+): CommandParseResult<TeamSetRankRequest> {
+  const parsed = teamSetRankRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload("Invalid team set-rank payload", parsed.error);
+  }
+  return { ok: true, value: parsed.data };
+}
+
+export function parseUserUpdateContactRequest(
+  body: unknown,
+): CommandParseResult<UserUpdateContactRequest> {
+  const parsed = userUpdateContactRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload("Invalid user update-contact payload", parsed.error);
+  }
+  return { ok: true, value: parsed.data };
+}

--- a/supabase/functions/_shared/commands/profile/update_team_profile.ts
+++ b/supabase/functions/_shared/commands/profile/update_team_profile.ts
@@ -1,0 +1,91 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import {
+  createMembershipCommandRepository,
+  type MembershipCommandRepository,
+} from "../membership/repository.ts";
+import type {
+  MembershipCommandExecutionResult,
+  TeamSetRankRequest,
+  TeamUpdateProfileRequest,
+} from "../membership/types.ts";
+import {
+  parseTeamSetRankRequest,
+  parseTeamUpdateProfileRequest,
+} from "../membership/validation.ts";
+
+export function parseTeamUpdateProfileCommand(body: unknown) {
+  return parseTeamUpdateProfileRequest(body);
+}
+
+export function parseTeamSetRankCommand(body: unknown) {
+  return parseTeamSetRankRequest(body);
+}
+
+export async function executeTeamUpdateProfileCommand(
+  request: TeamUpdateProfileRequest,
+  actor: ActorContext,
+  repository: MembershipCommandRepository = createMembershipCommandRepository(
+    actor.supabase,
+  ),
+): Promise<MembershipCommandExecutionResult> {
+  const audit = buildCommandAuditPayload({
+    command: "team_update_profile",
+    actorUserId: actor.userId,
+    targetTable: "teams",
+    targetId: request.teamId,
+    targetVersion: "",
+    payload: {
+      isPublic: request.isPublic,
+    },
+  });
+
+  const result = await repository.updateTeamProfile(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "team_update_profile",
+      data: result.data,
+    },
+  };
+}
+
+export async function executeTeamSetRankCommand(
+  request: TeamSetRankRequest,
+  actor: ActorContext,
+  repository: MembershipCommandRepository = createMembershipCommandRepository(
+    actor.supabase,
+  ),
+): Promise<MembershipCommandExecutionResult> {
+  const audit = buildCommandAuditPayload({
+    command: "team_set_rank",
+    actorUserId: actor.userId,
+    targetTable: "teams",
+    targetId: request.teamId,
+    targetVersion: "",
+    payload: {
+      rank: request.rank,
+    },
+  });
+
+  const result = await repository.setTeamRank(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "team_set_rank",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/profile/update_user_contact.ts
+++ b/supabase/functions/_shared/commands/profile/update_user_contact.ts
@@ -1,0 +1,49 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import {
+  createMembershipCommandRepository,
+  type MembershipCommandRepository,
+} from "../membership/repository.ts";
+import type {
+  MembershipCommandExecutionResult,
+  UserUpdateContactRequest,
+} from "../membership/types.ts";
+import { parseUserUpdateContactRequest } from "../membership/validation.ts";
+
+export function parseUserUpdateContactCommand(body: unknown) {
+  return parseUserUpdateContactRequest(body);
+}
+
+export async function executeUserUpdateContactCommand(
+  request: UserUpdateContactRequest,
+  actor: ActorContext,
+  repository: MembershipCommandRepository = createMembershipCommandRepository(
+    actor.supabase,
+  ),
+): Promise<MembershipCommandExecutionResult> {
+  const audit = buildCommandAuditPayload({
+    command: "user_update_contact",
+    actorUserId: actor.userId,
+    targetTable: "users",
+    targetId: request.userId,
+    targetVersion: "",
+    payload: {
+      hasContact: true,
+    },
+  });
+
+  const result = await repository.updateUserContact(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "user_update_contact",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/team/create_team.ts
+++ b/supabase/functions/_shared/commands/team/create_team.ts
@@ -1,0 +1,50 @@
+import type { ActorContext } from "../../command_runtime/actor_context.ts";
+import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import {
+  createMembershipCommandRepository,
+  type MembershipCommandRepository,
+} from "../membership/repository.ts";
+import type {
+  MembershipCommandExecutionResult,
+  TeamCreateRequest,
+} from "../membership/types.ts";
+import { parseTeamCreateRequest } from "../membership/validation.ts";
+
+export function parseTeamCreateCommand(body: unknown) {
+  return parseTeamCreateRequest(body);
+}
+
+export async function executeTeamCreateCommand(
+  request: TeamCreateRequest,
+  actor: ActorContext,
+  repository: MembershipCommandRepository = createMembershipCommandRepository(
+    actor.supabase,
+  ),
+): Promise<MembershipCommandExecutionResult> {
+  const audit = buildCommandAuditPayload({
+    command: "team_create",
+    actorUserId: actor.userId,
+    targetTable: "teams",
+    targetId: request.teamId,
+    targetVersion: "",
+    payload: {
+      rank: request.rank,
+      isPublic: request.isPublic,
+    },
+  });
+
+  const result = await repository.createTeam(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: "team_create",
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/db_rpc/membership_commands.ts
+++ b/supabase/functions/_shared/db_rpc/membership_commands.ts
@@ -1,0 +1,318 @@
+import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+
+import type { CommandAuditPayload } from "../command_runtime/audit_log.ts";
+import type {
+  MembershipCommandFailure,
+  ReviewChangeMemberRoleRequest,
+  SystemChangeMemberRoleRequest,
+  TeamChangeMemberRoleRequest,
+  TeamCreateRequest,
+  TeamInvitationDecisionRequest,
+  TeamReinviteMemberRequest,
+  TeamSetRankRequest,
+  TeamUpdateProfileRequest,
+  UserUpdateContactRequest,
+} from "../commands/membership/types.ts";
+
+type RpcClient = Pick<SupabaseClient, "rpc">;
+
+export type MembershipRpcResult =
+  | { ok: true; data: unknown }
+  | MembershipCommandFailure;
+
+function mapRpcError(
+  error: { code?: string; message?: string; details?: unknown },
+) {
+  const code = error.code ?? "RPC_ERROR";
+  const status = code === "42501"
+    ? 403
+    : code === "PGRST116"
+    ? 404
+    : code === "AUTH_REQUIRED"
+    ? 401
+    : 400;
+
+  return {
+    ok: false as const,
+    code,
+    status,
+    message: error.message ?? "Membership command RPC failed",
+    details: error.details ?? null,
+  };
+}
+
+function isMembershipCommandFailure(
+  data: unknown,
+): data is MembershipCommandFailure {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+
+  const candidate = data as Partial<MembershipCommandFailure> & {
+    ok?: unknown;
+  };
+  return (
+    candidate.ok === false &&
+    typeof candidate.code === "string" &&
+    typeof candidate.message === "string" &&
+    typeof candidate.status === "number"
+  );
+}
+
+async function callMembershipRpc(
+  supabase: RpcClient,
+  fn: string,
+  args: Record<string, unknown>,
+): Promise<MembershipRpcResult> {
+  const { data, error } = await supabase.rpc(fn, args);
+  if (error) {
+    return mapRpcError(error);
+  }
+
+  if (isMembershipCommandFailure(data)) {
+    return data;
+  }
+
+  if (
+    data &&
+    typeof data === "object" &&
+    !Array.isArray(data) &&
+    (data as { ok?: unknown }).ok === true &&
+    "data" in (data as Record<string, unknown>)
+  ) {
+    return {
+      ok: true,
+      data: (data as Record<string, unknown>).data,
+    };
+  }
+
+  return {
+    ok: true,
+    data,
+  };
+}
+
+export function buildTeamCreateRpcArgs(
+  request: TeamCreateRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_team_id: request.teamId,
+    p_json: request.json,
+    p_rank: request.rank,
+    p_is_public: request.isPublic,
+    p_audit: audit,
+  };
+}
+
+export function buildTeamUpdateProfileRpcArgs(
+  request: TeamUpdateProfileRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_team_id: request.teamId,
+    p_json: request.json,
+    p_is_public: request.isPublic,
+    p_audit: audit,
+  };
+}
+
+export function buildTeamSetRankRpcArgs(
+  request: TeamSetRankRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_team_id: request.teamId,
+    p_rank: request.rank,
+    p_audit: audit,
+  };
+}
+
+export function buildUserUpdateContactRpcArgs(
+  request: UserUpdateContactRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_user_id: request.userId,
+    p_contact: request.contact,
+    p_audit: audit,
+  };
+}
+
+export function buildTeamChangeMemberRoleRpcArgs(
+  request: TeamChangeMemberRoleRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_team_id: request.teamId,
+    p_user_id: request.userId,
+    p_role: request.role ?? null,
+    p_action: request.action ?? "set",
+    p_audit: audit,
+  };
+}
+
+export function buildSystemChangeMemberRoleRpcArgs(
+  request: SystemChangeMemberRoleRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_user_id: request.userId,
+    p_role: request.role ?? null,
+    p_action: request.action ?? "set",
+    p_audit: audit,
+  };
+}
+
+export function buildReviewChangeMemberRoleRpcArgs(
+  request: ReviewChangeMemberRoleRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_user_id: request.userId,
+    p_role: request.role ?? null,
+    p_action: request.action ?? "set",
+    p_audit: audit,
+  };
+}
+
+export function buildTeamReinviteMemberRpcArgs(
+  request: TeamReinviteMemberRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_team_id: request.teamId,
+    p_user_id: request.userId,
+    p_audit: audit,
+  };
+}
+
+export function buildTeamInvitationDecisionRpcArgs(
+  request: TeamInvitationDecisionRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_team_id: request.teamId,
+    p_audit: audit,
+  };
+}
+
+export function callTeamCreateRpc(
+  supabase: RpcClient,
+  request: TeamCreateRequest,
+  audit: CommandAuditPayload,
+) {
+  return callMembershipRpc(
+    supabase,
+    "cmd_team_create",
+    buildTeamCreateRpcArgs(request, audit),
+  );
+}
+
+export function callTeamUpdateProfileRpc(
+  supabase: RpcClient,
+  request: TeamUpdateProfileRequest,
+  audit: CommandAuditPayload,
+) {
+  return callMembershipRpc(
+    supabase,
+    "cmd_team_update_profile",
+    buildTeamUpdateProfileRpcArgs(request, audit),
+  );
+}
+
+export function callTeamSetRankRpc(
+  supabase: RpcClient,
+  request: TeamSetRankRequest,
+  audit: CommandAuditPayload,
+) {
+  return callMembershipRpc(
+    supabase,
+    "cmd_team_set_rank",
+    buildTeamSetRankRpcArgs(request, audit),
+  );
+}
+
+export function callUserUpdateContactRpc(
+  supabase: RpcClient,
+  request: UserUpdateContactRequest,
+  audit: CommandAuditPayload,
+) {
+  return callMembershipRpc(
+    supabase,
+    "cmd_user_update_contact",
+    buildUserUpdateContactRpcArgs(request, audit),
+  );
+}
+
+export function callTeamChangeMemberRoleRpc(
+  supabase: RpcClient,
+  request: TeamChangeMemberRoleRequest,
+  audit: CommandAuditPayload,
+) {
+  return callMembershipRpc(
+    supabase,
+    "cmd_team_change_member_role",
+    buildTeamChangeMemberRoleRpcArgs(request, audit),
+  );
+}
+
+export function callSystemChangeMemberRoleRpc(
+  supabase: RpcClient,
+  request: SystemChangeMemberRoleRequest,
+  audit: CommandAuditPayload,
+) {
+  return callMembershipRpc(
+    supabase,
+    "cmd_system_change_member_role",
+    buildSystemChangeMemberRoleRpcArgs(request, audit),
+  );
+}
+
+export function callReviewChangeMemberRoleRpc(
+  supabase: RpcClient,
+  request: ReviewChangeMemberRoleRequest,
+  audit: CommandAuditPayload,
+) {
+  return callMembershipRpc(
+    supabase,
+    "cmd_review_change_member_role",
+    buildReviewChangeMemberRoleRpcArgs(request, audit),
+  );
+}
+
+export function callTeamReinviteMemberRpc(
+  supabase: RpcClient,
+  request: TeamReinviteMemberRequest,
+  audit: CommandAuditPayload,
+) {
+  return callMembershipRpc(
+    supabase,
+    "cmd_team_reinvite_member",
+    buildTeamReinviteMemberRpcArgs(request, audit),
+  );
+}
+
+export function callTeamAcceptInvitationRpc(
+  supabase: RpcClient,
+  request: TeamInvitationDecisionRequest,
+  audit: CommandAuditPayload,
+) {
+  return callMembershipRpc(
+    supabase,
+    "cmd_team_accept_invitation",
+    buildTeamInvitationDecisionRpcArgs(request, audit),
+  );
+}
+
+export function callTeamRejectInvitationRpc(
+  supabase: RpcClient,
+  request: TeamInvitationDecisionRequest,
+  audit: CommandAuditPayload,
+) {
+  return callMembershipRpc(
+    supabase,
+    "cmd_team_reject_invitation",
+    buildTeamInvitationDecisionRpcArgs(request, audit),
+  );
+}

--- a/supabase/functions/admin_review_change_member_role/index.ts
+++ b/supabase/functions/admin_review_change_member_role/index.ts
@@ -1,0 +1,28 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeReviewChangeMemberRoleCommand,
+  parseReviewChangeMemberRoleCommand,
+} from "../_shared/commands/membership/change_role.ts";
+import type { ReviewChangeMemberRoleRequest } from "../_shared/commands/membership/types.ts";
+
+export function createAdminReviewChangeMemberRoleHandler(
+  overrides: Partial<CommandHandlerOptions<ReviewChangeMemberRoleRequest>> = {},
+) {
+  return createCommandHandler<ReviewChangeMemberRoleRequest>({
+    parse: parseReviewChangeMemberRoleCommand,
+    execute: executeReviewChangeMemberRoleCommand,
+    ...overrides,
+  });
+}
+
+export const handleAdminReviewChangeMemberRole =
+  createAdminReviewChangeMemberRoleHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAdminReviewChangeMemberRole);
+}

--- a/supabase/functions/admin_system_change_member_role/index.ts
+++ b/supabase/functions/admin_system_change_member_role/index.ts
@@ -1,0 +1,28 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeSystemChangeMemberRoleCommand,
+  parseSystemChangeMemberRoleCommand,
+} from "../_shared/commands/membership/change_role.ts";
+import type { SystemChangeMemberRoleRequest } from "../_shared/commands/membership/types.ts";
+
+export function createAdminSystemChangeMemberRoleHandler(
+  overrides: Partial<CommandHandlerOptions<SystemChangeMemberRoleRequest>> = {},
+) {
+  return createCommandHandler<SystemChangeMemberRoleRequest>({
+    parse: parseSystemChangeMemberRoleCommand,
+    execute: executeSystemChangeMemberRoleCommand,
+    ...overrides,
+  });
+}
+
+export const handleAdminSystemChangeMemberRole =
+  createAdminSystemChangeMemberRoleHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAdminSystemChangeMemberRole);
+}

--- a/supabase/functions/admin_team_change_member_role/index.ts
+++ b/supabase/functions/admin_team_change_member_role/index.ts
@@ -1,0 +1,28 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeTeamChangeMemberRoleCommand,
+  parseTeamChangeMemberRoleCommand,
+} from "../_shared/commands/membership/change_role.ts";
+import type { TeamChangeMemberRoleRequest } from "../_shared/commands/membership/types.ts";
+
+export function createAdminTeamChangeMemberRoleHandler(
+  overrides: Partial<CommandHandlerOptions<TeamChangeMemberRoleRequest>> = {},
+) {
+  return createCommandHandler<TeamChangeMemberRoleRequest>({
+    parse: parseTeamChangeMemberRoleCommand,
+    execute: executeTeamChangeMemberRoleCommand,
+    ...overrides,
+  });
+}
+
+export const handleAdminTeamChangeMemberRole =
+  createAdminTeamChangeMemberRoleHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAdminTeamChangeMemberRole);
+}

--- a/supabase/functions/admin_team_reinvite_member/index.ts
+++ b/supabase/functions/admin_team_reinvite_member/index.ts
@@ -1,0 +1,28 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeTeamReinviteMemberCommand,
+  parseTeamReinviteMemberCommand,
+} from "../_shared/commands/membership/reinvite_member.ts";
+import type { TeamReinviteMemberRequest } from "../_shared/commands/membership/types.ts";
+
+export function createAdminTeamReinviteMemberHandler(
+  overrides: Partial<CommandHandlerOptions<TeamReinviteMemberRequest>> = {},
+) {
+  return createCommandHandler<TeamReinviteMemberRequest>({
+    parse: parseTeamReinviteMemberCommand,
+    execute: executeTeamReinviteMemberCommand,
+    ...overrides,
+  });
+}
+
+export const handleAdminTeamReinviteMember =
+  createAdminTeamReinviteMemberHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAdminTeamReinviteMember);
+}

--- a/supabase/functions/admin_team_set_rank/index.ts
+++ b/supabase/functions/admin_team_set_rank/index.ts
@@ -1,0 +1,27 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeTeamSetRankCommand,
+  parseTeamSetRankCommand,
+} from "../_shared/commands/profile/update_team_profile.ts";
+import type { TeamSetRankRequest } from "../_shared/commands/membership/types.ts";
+
+export function createAdminTeamSetRankHandler(
+  overrides: Partial<CommandHandlerOptions<TeamSetRankRequest>> = {},
+) {
+  return createCommandHandler<TeamSetRankRequest>({
+    parse: parseTeamSetRankCommand,
+    execute: executeTeamSetRankCommand,
+    ...overrides,
+  });
+}
+
+export const handleAdminTeamSetRank = createAdminTeamSetRankHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAdminTeamSetRank);
+}

--- a/supabase/functions/app_team_accept_invitation/index.ts
+++ b/supabase/functions/app_team_accept_invitation/index.ts
@@ -1,0 +1,28 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeTeamAcceptInvitationCommand,
+  parseTeamAcceptInvitationCommand,
+} from "../_shared/commands/membership/accept_invitation.ts";
+import type { TeamInvitationDecisionRequest } from "../_shared/commands/membership/types.ts";
+
+export function createAppTeamAcceptInvitationHandler(
+  overrides: Partial<CommandHandlerOptions<TeamInvitationDecisionRequest>> = {},
+) {
+  return createCommandHandler<TeamInvitationDecisionRequest>({
+    parse: parseTeamAcceptInvitationCommand,
+    execute: executeTeamAcceptInvitationCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppTeamAcceptInvitation =
+  createAppTeamAcceptInvitationHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppTeamAcceptInvitation);
+}

--- a/supabase/functions/app_team_create/index.ts
+++ b/supabase/functions/app_team_create/index.ts
@@ -1,0 +1,27 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeTeamCreateCommand,
+  parseTeamCreateCommand,
+} from "../_shared/commands/team/create_team.ts";
+import type { TeamCreateRequest } from "../_shared/commands/membership/types.ts";
+
+export function createAppTeamCreateHandler(
+  overrides: Partial<CommandHandlerOptions<TeamCreateRequest>> = {},
+) {
+  return createCommandHandler<TeamCreateRequest>({
+    parse: parseTeamCreateCommand,
+    execute: executeTeamCreateCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppTeamCreate = createAppTeamCreateHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppTeamCreate);
+}

--- a/supabase/functions/app_team_reject_invitation/index.ts
+++ b/supabase/functions/app_team_reject_invitation/index.ts
@@ -1,0 +1,28 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeTeamRejectInvitationCommand,
+  parseTeamRejectInvitationCommand,
+} from "../_shared/commands/membership/reject_invitation.ts";
+import type { TeamInvitationDecisionRequest } from "../_shared/commands/membership/types.ts";
+
+export function createAppTeamRejectInvitationHandler(
+  overrides: Partial<CommandHandlerOptions<TeamInvitationDecisionRequest>> = {},
+) {
+  return createCommandHandler<TeamInvitationDecisionRequest>({
+    parse: parseTeamRejectInvitationCommand,
+    execute: executeTeamRejectInvitationCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppTeamRejectInvitation =
+  createAppTeamRejectInvitationHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppTeamRejectInvitation);
+}

--- a/supabase/functions/app_team_update_profile/index.ts
+++ b/supabase/functions/app_team_update_profile/index.ts
@@ -1,0 +1,27 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeTeamUpdateProfileCommand,
+  parseTeamUpdateProfileCommand,
+} from "../_shared/commands/profile/update_team_profile.ts";
+import type { TeamUpdateProfileRequest } from "../_shared/commands/membership/types.ts";
+
+export function createAppTeamUpdateProfileHandler(
+  overrides: Partial<CommandHandlerOptions<TeamUpdateProfileRequest>> = {},
+) {
+  return createCommandHandler<TeamUpdateProfileRequest>({
+    parse: parseTeamUpdateProfileCommand,
+    execute: executeTeamUpdateProfileCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppTeamUpdateProfile = createAppTeamUpdateProfileHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppTeamUpdateProfile);
+}

--- a/supabase/functions/app_user_update_contact/index.ts
+++ b/supabase/functions/app_user_update_contact/index.ts
@@ -1,0 +1,27 @@
+import "@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from "../_shared/command_runtime/command.ts";
+import {
+  executeUserUpdateContactCommand,
+  parseUserUpdateContactCommand,
+} from "../_shared/commands/profile/update_user_contact.ts";
+import type { UserUpdateContactRequest } from "../_shared/commands/membership/types.ts";
+
+export function createAppUserUpdateContactHandler(
+  overrides: Partial<CommandHandlerOptions<UserUpdateContactRequest>> = {},
+) {
+  return createCommandHandler<UserUpdateContactRequest>({
+    parse: parseUserUpdateContactCommand,
+    execute: executeUserUpdateContactCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppUserUpdateContact = createAppUserUpdateContactHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppUserUpdateContact);
+}

--- a/test/membership_command_test.ts
+++ b/test/membership_command_test.ts
@@ -1,0 +1,258 @@
+import { assertEquals, assertThrows } from "jsr:@std/assert";
+import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+
+import {
+  parseTeamAcceptInvitationCommand,
+} from "../supabase/functions/_shared/commands/membership/accept_invitation.ts";
+import {
+  executeTeamChangeMemberRoleCommand,
+} from "../supabase/functions/_shared/commands/membership/change_role.ts";
+import {
+  createMembershipCommandRepository,
+} from "../supabase/functions/_shared/commands/membership/repository.ts";
+import {
+  parseTeamRejectInvitationCommand,
+} from "../supabase/functions/_shared/commands/membership/reject_invitation.ts";
+import {
+  executeTeamCreateCommand,
+} from "../supabase/functions/_shared/commands/team/create_team.ts";
+import {
+  executeTeamSetRankCommand,
+  executeTeamUpdateProfileCommand,
+} from "../supabase/functions/_shared/commands/profile/update_team_profile.ts";
+import {
+  executeUserUpdateContactCommand,
+} from "../supabase/functions/_shared/commands/profile/update_user_contact.ts";
+
+const TEST_ACTOR_ID = "11111111-1111-4111-8111-111111111111";
+const TEST_TEAM_ID = "22222222-2222-4222-8222-222222222222";
+const TEST_USER_ID = "33333333-3333-4333-8333-333333333333";
+
+class FakeRpcSupabase {
+  rpcCalls: Array<{ fn: string; args: unknown }> = [];
+
+  rpc(fn: string, args: unknown) {
+    this.rpcCalls.push({
+      fn,
+      args: structuredClone(args),
+    });
+
+    return Promise.resolve({
+      data: {
+        ok: true,
+        data: {
+          accepted: true,
+        },
+      },
+      error: null,
+    });
+  }
+}
+
+function buildActor(supabase: FakeRpcSupabase) {
+  return {
+    userId: TEST_ACTOR_ID,
+    accessToken: "access-token",
+    supabase: supabase as unknown as SupabaseClient,
+  };
+}
+
+Deno.test("accept invitation payload parser is strict", () => {
+  const parsed = parseTeamAcceptInvitationCommand({
+    teamId: TEST_TEAM_ID,
+    extra: "nope",
+  });
+
+  assertEquals(parsed.ok, false);
+});
+
+Deno.test("reject invitation payload parser is strict", () => {
+  const parsed = parseTeamRejectInvitationCommand({
+    teamId: TEST_TEAM_ID,
+    unexpected: true,
+  });
+
+  assertEquals(parsed.ok, false);
+});
+
+Deno.test("createMembershipCommandRepository requires an explicit Supabase client", () => {
+  assertThrows(
+    () => createMembershipCommandRepository(undefined as never),
+    Error,
+    "Membership command repository requires an explicit Supabase client",
+  );
+});
+
+Deno.test(
+  "executeTeamChangeMemberRoleCommand supports remove action and forwards cmd_team_change_member_role args",
+  async () => {
+    const supabase = new FakeRpcSupabase();
+    const result = await executeTeamChangeMemberRoleCommand(
+      {
+        teamId: TEST_TEAM_ID,
+        userId: TEST_USER_ID,
+        action: "remove",
+      },
+      buildActor(supabase),
+    );
+
+    assertEquals(result.ok, true);
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: "cmd_team_change_member_role",
+        args: {
+          p_team_id: TEST_TEAM_ID,
+          p_user_id: TEST_USER_ID,
+          p_role: null,
+          p_action: "remove",
+          p_audit: {
+            command: "team_change_member_role",
+            actorUserId: TEST_ACTOR_ID,
+            targetTable: "roles",
+            targetId: TEST_USER_ID,
+            targetVersion: TEST_TEAM_ID,
+            payload: {
+              action: "remove",
+              role: null,
+              teamId: TEST_TEAM_ID,
+            },
+          },
+        },
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  "executeTeamCreateCommand forwards cmd_team_create args with audit payload",
+  async () => {
+    const supabase = new FakeRpcSupabase();
+    const teamJson = { title: [{ "@xml:lang": "en", "#text": "Team A" }] };
+
+    const result = await executeTeamCreateCommand(
+      {
+        teamId: TEST_TEAM_ID,
+        json: teamJson,
+        rank: 1,
+        isPublic: false,
+      },
+      buildActor(supabase),
+    );
+
+    assertEquals(result.ok, true);
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: "cmd_team_create",
+        args: {
+          p_team_id: TEST_TEAM_ID,
+          p_json: teamJson,
+          p_rank: 1,
+          p_is_public: false,
+          p_audit: {
+            command: "team_create",
+            actorUserId: TEST_ACTOR_ID,
+            targetTable: "teams",
+            targetId: TEST_TEAM_ID,
+            targetVersion: "",
+            payload: {
+              rank: 1,
+              isPublic: false,
+            },
+          },
+        },
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  "profile and user commands forward exact RPC names and args",
+  async () => {
+    const supabase = new FakeRpcSupabase();
+    const actor = buildActor(supabase);
+
+    await executeTeamUpdateProfileCommand(
+      {
+        teamId: TEST_TEAM_ID,
+        json: { description: [{ "@xml:lang": "en", "#text": "Updated" }] },
+        isPublic: true,
+      },
+      actor,
+    );
+
+    await executeTeamSetRankCommand(
+      {
+        teamId: TEST_TEAM_ID,
+        rank: 5,
+      },
+      actor,
+    );
+
+    await executeUserUpdateContactCommand(
+      {
+        userId: TEST_USER_ID,
+        contact: {
+          "@refObjectId": "44444444-4444-4444-8444-444444444444",
+        },
+      },
+      actor,
+    );
+
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: "cmd_team_update_profile",
+        args: {
+          p_team_id: TEST_TEAM_ID,
+          p_json: { description: [{ "@xml:lang": "en", "#text": "Updated" }] },
+          p_is_public: true,
+          p_audit: {
+            command: "team_update_profile",
+            actorUserId: TEST_ACTOR_ID,
+            targetTable: "teams",
+            targetId: TEST_TEAM_ID,
+            targetVersion: "",
+            payload: {
+              isPublic: true,
+            },
+          },
+        },
+      },
+      {
+        fn: "cmd_team_set_rank",
+        args: {
+          p_team_id: TEST_TEAM_ID,
+          p_rank: 5,
+          p_audit: {
+            command: "team_set_rank",
+            actorUserId: TEST_ACTOR_ID,
+            targetTable: "teams",
+            targetId: TEST_TEAM_ID,
+            targetVersion: "",
+            payload: {
+              rank: 5,
+            },
+          },
+        },
+      },
+      {
+        fn: "cmd_user_update_contact",
+        args: {
+          p_user_id: TEST_USER_ID,
+          p_contact: {
+            "@refObjectId": "44444444-4444-4444-8444-444444444444",
+          },
+          p_audit: {
+            command: "user_update_contact",
+            actorUserId: TEST_ACTOR_ID,
+            targetTable: "users",
+            targetId: TEST_USER_ID,
+            targetVersion: "",
+            payload: {
+              hasContact: true,
+            },
+          },
+        },
+      },
+    ]);
+  },
+);


### PR DESCRIPTION
Closes #57

## Summary
- add Task 4 membership/profile command modules for team/system/review role changes, invitation response, team create/profile, team rank, and user contact update
- expose the public `admin_*` and `app_*` handler surfaces needed by the next-side membership/profile cutover
- cover the RPC envelope forwarding and payload validation in focused Deno tests

## Key Decisions
- keep the edge layer thin: request parsing, auth/runtime handoff, and structured RPC envelopes only
- centralize the new RPC invocations in `_shared/db_rpc/membership_commands.ts` so the individual handlers stay declarative
- align handler names one-for-one with the design document command surfaces to make the next service wrapper mapping auditable

## Validation
- `deno check --config supabase/functions/deno.json supabase/functions/_shared/db_rpc/membership_commands.ts supabase/functions/_shared/commands/membership/accept_invitation.ts supabase/functions/_shared/commands/membership/change_role.ts supabase/functions/_shared/commands/membership/reinvite_member.ts supabase/functions/_shared/commands/membership/reject_invitation.ts supabase/functions/_shared/commands/profile/update_team_profile.ts supabase/functions/_shared/commands/profile/update_user_contact.ts supabase/functions/_shared/commands/team/create_team.ts supabase/functions/admin_review_change_member_role/index.ts supabase/functions/admin_system_change_member_role/index.ts supabase/functions/admin_team_change_member_role/index.ts supabase/functions/admin_team_reinvite_member/index.ts supabase/functions/admin_team_set_rank/index.ts supabase/functions/app_team_accept_invitation/index.ts supabase/functions/app_team_create/index.ts supabase/functions/app_team_reject_invitation/index.ts supabase/functions/app_team_update_profile/index.ts supabase/functions/app_user_update_contact/index.ts`
- `deno test --config supabase/functions/deno.json test/membership_command_test.ts`

## Dependency
- stacked on top of #60 because the Task 3 review workflow command branch remains the canonical base for the new command runtime sequence.
