### PR TITLE
fix: normalize edge runtime imports for deployable functions

### DIFF
--- a/supabase/functions/admin_review_approve/index.ts
+++ b/supabase/functions/admin_review_approve/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeApproveReviewCommand,
   parseApproveReviewCommand,
-} from "../_shared/commands/review/approve_review.ts";
-import type { ApproveReviewRequest } from "../_shared/commands/review/types.ts";
+} from '../_shared/commands/review/approve_review.ts';
+import type { ApproveReviewRequest } from '../_shared/commands/review/types.ts';
 
 export function createAdminReviewApproveHandler(
   overrides: Partial<CommandHandlerOptions<ApproveReviewRequest>> = {},

--- a/supabase/functions/admin_review_assign_reviewers/index.ts
+++ b/supabase/functions/admin_review_assign_reviewers/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeAssignReviewersCommand,
   parseAssignReviewersCommand,
-} from "../_shared/commands/review/assign_reviewers.ts";
-import type { AssignReviewersRequest } from "../_shared/commands/review/types.ts";
+} from '../_shared/commands/review/assign_reviewers.ts';
+import type { AssignReviewersRequest } from '../_shared/commands/review/types.ts';
 
 export function createAdminReviewAssignReviewersHandler(
   overrides: Partial<CommandHandlerOptions<AssignReviewersRequest>> = {},
@@ -20,8 +20,7 @@ export function createAdminReviewAssignReviewersHandler(
   });
 }
 
-export const handleAdminReviewAssignReviewers =
-  createAdminReviewAssignReviewersHandler();
+export const handleAdminReviewAssignReviewers = createAdminReviewAssignReviewersHandler();
 
 if (import.meta.main) {
   Deno.serve(handleAdminReviewAssignReviewers);

--- a/supabase/functions/admin_review_change_member_role/index.ts
+++ b/supabase/functions/admin_review_change_member_role/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeReviewChangeMemberRoleCommand,
   parseReviewChangeMemberRoleCommand,
-} from "../_shared/commands/membership/change_role.ts";
-import type { ReviewChangeMemberRoleRequest } from "../_shared/commands/membership/types.ts";
+} from '../_shared/commands/membership/change_role.ts';
+import type { ReviewChangeMemberRoleRequest } from '../_shared/commands/membership/types.ts';
 
 export function createAdminReviewChangeMemberRoleHandler(
   overrides: Partial<CommandHandlerOptions<ReviewChangeMemberRoleRequest>> = {},
@@ -20,8 +20,7 @@ export function createAdminReviewChangeMemberRoleHandler(
   });
 }
 
-export const handleAdminReviewChangeMemberRole =
-  createAdminReviewChangeMemberRoleHandler();
+export const handleAdminReviewChangeMemberRole = createAdminReviewChangeMemberRoleHandler();
 
 if (import.meta.main) {
   Deno.serve(handleAdminReviewChangeMemberRole);

--- a/supabase/functions/admin_review_reject/index.ts
+++ b/supabase/functions/admin_review_reject/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeRejectReviewCommand,
   parseRejectReviewCommand,
-} from "../_shared/commands/review/reject_review.ts";
-import type { RejectReviewRequest } from "../_shared/commands/review/types.ts";
+} from '../_shared/commands/review/reject_review.ts';
+import type { RejectReviewRequest } from '../_shared/commands/review/types.ts';
 
 export function createAdminReviewRejectHandler(
   overrides: Partial<CommandHandlerOptions<RejectReviewRequest>> = {},

--- a/supabase/functions/admin_review_revoke_reviewer/index.ts
+++ b/supabase/functions/admin_review_revoke_reviewer/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeRevokeReviewerCommand,
   parseRevokeReviewerCommand,
-} from "../_shared/commands/review/revoke_reviewer.ts";
-import type { RevokeReviewerRequest } from "../_shared/commands/review/types.ts";
+} from '../_shared/commands/review/revoke_reviewer.ts';
+import type { RevokeReviewerRequest } from '../_shared/commands/review/types.ts';
 
 export function createAdminReviewRevokeReviewerHandler(
   overrides: Partial<CommandHandlerOptions<RevokeReviewerRequest>> = {},
@@ -20,8 +20,7 @@ export function createAdminReviewRevokeReviewerHandler(
   });
 }
 
-export const handleAdminReviewRevokeReviewer =
-  createAdminReviewRevokeReviewerHandler();
+export const handleAdminReviewRevokeReviewer = createAdminReviewRevokeReviewerHandler();
 
 if (import.meta.main) {
   Deno.serve(handleAdminReviewRevokeReviewer);

--- a/supabase/functions/admin_review_save_assignment_draft/index.ts
+++ b/supabase/functions/admin_review_save_assignment_draft/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeSaveAssignmentDraftCommand,
   parseSaveAssignmentDraftCommand,
-} from "../_shared/commands/review/save_assignment_draft.ts";
-import type { SaveAssignmentDraftRequest } from "../_shared/commands/review/types.ts";
+} from '../_shared/commands/review/save_assignment_draft.ts';
+import type { SaveAssignmentDraftRequest } from '../_shared/commands/review/types.ts';
 
 export function createAdminReviewSaveAssignmentDraftHandler(
   overrides: Partial<CommandHandlerOptions<SaveAssignmentDraftRequest>> = {},
@@ -20,8 +20,7 @@ export function createAdminReviewSaveAssignmentDraftHandler(
   });
 }
 
-export const handleAdminReviewSaveAssignmentDraft =
-  createAdminReviewSaveAssignmentDraftHandler();
+export const handleAdminReviewSaveAssignmentDraft = createAdminReviewSaveAssignmentDraftHandler();
 
 if (import.meta.main) {
   Deno.serve(handleAdminReviewSaveAssignmentDraft);

--- a/supabase/functions/admin_system_change_member_role/index.ts
+++ b/supabase/functions/admin_system_change_member_role/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeSystemChangeMemberRoleCommand,
   parseSystemChangeMemberRoleCommand,
-} from "../_shared/commands/membership/change_role.ts";
-import type { SystemChangeMemberRoleRequest } from "../_shared/commands/membership/types.ts";
+} from '../_shared/commands/membership/change_role.ts';
+import type { SystemChangeMemberRoleRequest } from '../_shared/commands/membership/types.ts';
 
 export function createAdminSystemChangeMemberRoleHandler(
   overrides: Partial<CommandHandlerOptions<SystemChangeMemberRoleRequest>> = {},
@@ -20,8 +20,7 @@ export function createAdminSystemChangeMemberRoleHandler(
   });
 }
 
-export const handleAdminSystemChangeMemberRole =
-  createAdminSystemChangeMemberRoleHandler();
+export const handleAdminSystemChangeMemberRole = createAdminSystemChangeMemberRoleHandler();
 
 if (import.meta.main) {
   Deno.serve(handleAdminSystemChangeMemberRole);

--- a/supabase/functions/admin_team_change_member_role/index.ts
+++ b/supabase/functions/admin_team_change_member_role/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeTeamChangeMemberRoleCommand,
   parseTeamChangeMemberRoleCommand,
-} from "../_shared/commands/membership/change_role.ts";
-import type { TeamChangeMemberRoleRequest } from "../_shared/commands/membership/types.ts";
+} from '../_shared/commands/membership/change_role.ts';
+import type { TeamChangeMemberRoleRequest } from '../_shared/commands/membership/types.ts';
 
 export function createAdminTeamChangeMemberRoleHandler(
   overrides: Partial<CommandHandlerOptions<TeamChangeMemberRoleRequest>> = {},
@@ -20,8 +20,7 @@ export function createAdminTeamChangeMemberRoleHandler(
   });
 }
 
-export const handleAdminTeamChangeMemberRole =
-  createAdminTeamChangeMemberRoleHandler();
+export const handleAdminTeamChangeMemberRole = createAdminTeamChangeMemberRoleHandler();
 
 if (import.meta.main) {
   Deno.serve(handleAdminTeamChangeMemberRole);

--- a/supabase/functions/admin_team_reinvite_member/index.ts
+++ b/supabase/functions/admin_team_reinvite_member/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeTeamReinviteMemberCommand,
   parseTeamReinviteMemberCommand,
-} from "../_shared/commands/membership/reinvite_member.ts";
-import type { TeamReinviteMemberRequest } from "../_shared/commands/membership/types.ts";
+} from '../_shared/commands/membership/reinvite_member.ts';
+import type { TeamReinviteMemberRequest } from '../_shared/commands/membership/types.ts';
 
 export function createAdminTeamReinviteMemberHandler(
   overrides: Partial<CommandHandlerOptions<TeamReinviteMemberRequest>> = {},
@@ -20,8 +20,7 @@ export function createAdminTeamReinviteMemberHandler(
   });
 }
 
-export const handleAdminTeamReinviteMember =
-  createAdminTeamReinviteMemberHandler();
+export const handleAdminTeamReinviteMember = createAdminTeamReinviteMemberHandler();
 
 if (import.meta.main) {
   Deno.serve(handleAdminTeamReinviteMember);

--- a/supabase/functions/admin_team_set_rank/index.ts
+++ b/supabase/functions/admin_team_set_rank/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
+import type { TeamSetRankRequest } from '../_shared/commands/membership/types.ts';
 import {
   executeTeamSetRankCommand,
   parseTeamSetRankCommand,
-} from "../_shared/commands/profile/update_team_profile.ts";
-import type { TeamSetRankRequest } from "../_shared/commands/membership/types.ts";
+} from '../_shared/commands/profile/update_team_profile.ts';
 
 export function createAdminTeamSetRankHandler(
   overrides: Partial<CommandHandlerOptions<TeamSetRankRequest>> = {},

--- a/supabase/functions/app_dataset_assign_team/index.ts
+++ b/supabase/functions/app_dataset_assign_team/index.ts
@@ -1,4 +1,4 @@
-import '@supabase/functions-js/edge-runtime.d.ts';
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   createCommandHandler,

--- a/supabase/functions/app_dataset_create/index.ts
+++ b/supabase/functions/app_dataset_create/index.ts
@@ -1,14 +1,11 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
-import {
-  executeCreateCommand,
-  parseCreateCommand,
-} from "../_shared/commands/dataset/create.ts";
-import type { CreateRequest } from "../_shared/commands/dataset/types.ts";
+} from '../_shared/command_runtime/command.ts';
+import { executeCreateCommand, parseCreateCommand } from '../_shared/commands/dataset/create.ts';
+import type { CreateRequest } from '../_shared/commands/dataset/types.ts';
 
 export function createAppDatasetCreateHandler(
   overrides: Partial<CommandHandlerOptions<CreateRequest>> = {},

--- a/supabase/functions/app_dataset_delete/index.ts
+++ b/supabase/functions/app_dataset_delete/index.ts
@@ -1,14 +1,11 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
-import {
-  executeDeleteCommand,
-  parseDeleteCommand,
-} from "../_shared/commands/dataset/delete.ts";
-import type { DeleteRequest } from "../_shared/commands/dataset/types.ts";
+} from '../_shared/command_runtime/command.ts';
+import { executeDeleteCommand, parseDeleteCommand } from '../_shared/commands/dataset/delete.ts';
+import type { DeleteRequest } from '../_shared/commands/dataset/types.ts';
 
 export function createAppDatasetDeleteHandler(
   overrides: Partial<CommandHandlerOptions<DeleteRequest>> = {},

--- a/supabase/functions/app_dataset_publish/index.ts
+++ b/supabase/functions/app_dataset_publish/index.ts
@@ -1,4 +1,4 @@
-import '@supabase/functions-js/edge-runtime.d.ts';
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   createCommandHandler,

--- a/supabase/functions/app_dataset_save_draft/index.ts
+++ b/supabase/functions/app_dataset_save_draft/index.ts
@@ -1,4 +1,4 @@
-import '@supabase/functions-js/edge-runtime.d.ts';
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   createCommandHandler,

--- a/supabase/functions/app_dataset_submit_review/index.ts
+++ b/supabase/functions/app_dataset_submit_review/index.ts
@@ -1,4 +1,4 @@
-import '@supabase/functions-js/edge-runtime.d.ts';
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   createCommandHandler,

--- a/supabase/functions/app_notification_send_validation_issue/index.ts
+++ b/supabase/functions/app_notification_send_validation_issue/index.ts
@@ -1,19 +1,17 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeNotificationSendValidationIssueCommand,
   parseNotificationSendValidationIssueCommand,
-} from "../_shared/commands/notification/send_validation_issue.ts";
-import type { NotificationSendValidationIssueRequest } from "../_shared/commands/notification/types.ts";
+} from '../_shared/commands/notification/send_validation_issue.ts';
+import type { NotificationSendValidationIssueRequest } from '../_shared/commands/notification/types.ts';
 
 export function createAppNotificationSendValidationIssueHandler(
-  overrides: Partial<
-    CommandHandlerOptions<NotificationSendValidationIssueRequest>
-  > = {},
+  overrides: Partial<CommandHandlerOptions<NotificationSendValidationIssueRequest>> = {},
 ) {
   return createCommandHandler<NotificationSendValidationIssueRequest>({
     parse: parseNotificationSendValidationIssueCommand,

--- a/supabase/functions/app_review_save_comment_draft/index.ts
+++ b/supabase/functions/app_review_save_comment_draft/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeSaveCommentDraftCommand,
   parseSaveCommentDraftCommand,
-} from "../_shared/commands/review/save_comment_draft.ts";
-import type { SaveCommentDraftRequest } from "../_shared/commands/review/types.ts";
+} from '../_shared/commands/review/save_comment_draft.ts';
+import type { SaveCommentDraftRequest } from '../_shared/commands/review/types.ts';
 
 export function createAppReviewSaveCommentDraftHandler(
   overrides: Partial<CommandHandlerOptions<SaveCommentDraftRequest>> = {},
@@ -20,8 +20,7 @@ export function createAppReviewSaveCommentDraftHandler(
   });
 }
 
-export const handleAppReviewSaveCommentDraft =
-  createAppReviewSaveCommentDraftHandler();
+export const handleAppReviewSaveCommentDraft = createAppReviewSaveCommentDraftHandler();
 
 if (import.meta.main) {
   Deno.serve(handleAppReviewSaveCommentDraft);

--- a/supabase/functions/app_review_submit_comment/index.ts
+++ b/supabase/functions/app_review_submit_comment/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeSubmitCommentCommand,
   parseSubmitCommentCommand,
-} from "../_shared/commands/review/submit_comment.ts";
-import type { SubmitCommentRequest } from "../_shared/commands/review/types.ts";
+} from '../_shared/commands/review/submit_comment.ts';
+import type { SubmitCommentRequest } from '../_shared/commands/review/types.ts';
 
 export function createAppReviewSubmitCommentHandler(
   overrides: Partial<CommandHandlerOptions<SubmitCommentRequest>> = {},
@@ -20,8 +20,7 @@ export function createAppReviewSubmitCommentHandler(
   });
 }
 
-export const handleAppReviewSubmitComment =
-  createAppReviewSubmitCommentHandler();
+export const handleAppReviewSubmitComment = createAppReviewSubmitCommentHandler();
 
 if (import.meta.main) {
   Deno.serve(handleAppReviewSubmitComment);

--- a/supabase/functions/app_team_accept_invitation/index.ts
+++ b/supabase/functions/app_team_accept_invitation/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeTeamAcceptInvitationCommand,
   parseTeamAcceptInvitationCommand,
-} from "../_shared/commands/membership/accept_invitation.ts";
-import type { TeamInvitationDecisionRequest } from "../_shared/commands/membership/types.ts";
+} from '../_shared/commands/membership/accept_invitation.ts';
+import type { TeamInvitationDecisionRequest } from '../_shared/commands/membership/types.ts';
 
 export function createAppTeamAcceptInvitationHandler(
   overrides: Partial<CommandHandlerOptions<TeamInvitationDecisionRequest>> = {},
@@ -20,8 +20,7 @@ export function createAppTeamAcceptInvitationHandler(
   });
 }
 
-export const handleAppTeamAcceptInvitation =
-  createAppTeamAcceptInvitationHandler();
+export const handleAppTeamAcceptInvitation = createAppTeamAcceptInvitationHandler();
 
 if (import.meta.main) {
   Deno.serve(handleAppTeamAcceptInvitation);

--- a/supabase/functions/app_team_create/index.ts
+++ b/supabase/functions/app_team_create/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
+import type { TeamCreateRequest } from '../_shared/commands/membership/types.ts';
 import {
   executeTeamCreateCommand,
   parseTeamCreateCommand,
-} from "../_shared/commands/team/create_team.ts";
-import type { TeamCreateRequest } from "../_shared/commands/membership/types.ts";
+} from '../_shared/commands/team/create_team.ts';
 
 export function createAppTeamCreateHandler(
   overrides: Partial<CommandHandlerOptions<TeamCreateRequest>> = {},

--- a/supabase/functions/app_team_reject_invitation/index.ts
+++ b/supabase/functions/app_team_reject_invitation/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
 import {
   executeTeamRejectInvitationCommand,
   parseTeamRejectInvitationCommand,
-} from "../_shared/commands/membership/reject_invitation.ts";
-import type { TeamInvitationDecisionRequest } from "../_shared/commands/membership/types.ts";
+} from '../_shared/commands/membership/reject_invitation.ts';
+import type { TeamInvitationDecisionRequest } from '../_shared/commands/membership/types.ts';
 
 export function createAppTeamRejectInvitationHandler(
   overrides: Partial<CommandHandlerOptions<TeamInvitationDecisionRequest>> = {},
@@ -20,8 +20,7 @@ export function createAppTeamRejectInvitationHandler(
   });
 }
 
-export const handleAppTeamRejectInvitation =
-  createAppTeamRejectInvitationHandler();
+export const handleAppTeamRejectInvitation = createAppTeamRejectInvitationHandler();
 
 if (import.meta.main) {
   Deno.serve(handleAppTeamRejectInvitation);

--- a/supabase/functions/app_team_update_profile/index.ts
+++ b/supabase/functions/app_team_update_profile/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
+import type { TeamUpdateProfileRequest } from '../_shared/commands/membership/types.ts';
 import {
   executeTeamUpdateProfileCommand,
   parseTeamUpdateProfileCommand,
-} from "../_shared/commands/profile/update_team_profile.ts";
-import type { TeamUpdateProfileRequest } from "../_shared/commands/membership/types.ts";
+} from '../_shared/commands/profile/update_team_profile.ts';
 
 export function createAppTeamUpdateProfileHandler(
   overrides: Partial<CommandHandlerOptions<TeamUpdateProfileRequest>> = {},

--- a/supabase/functions/app_user_update_contact/index.ts
+++ b/supabase/functions/app_user_update_contact/index.ts
@@ -1,14 +1,14 @@
-import "@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
 import {
   type CommandHandlerOptions,
   createCommandHandler,
-} from "../_shared/command_runtime/command.ts";
+} from '../_shared/command_runtime/command.ts';
+import type { UserUpdateContactRequest } from '../_shared/commands/membership/types.ts';
 import {
   executeUserUpdateContactCommand,
   parseUserUpdateContactCommand,
-} from "../_shared/commands/profile/update_user_contact.ts";
-import type { UserUpdateContactRequest } from "../_shared/commands/membership/types.ts";
+} from '../_shared/commands/profile/update_user_contact.ts';
 
 export function createAppUserUpdateContactHandler(
   overrides: Partial<CommandHandlerOptions<UserUpdateContactRequest>> = {},


### PR DESCRIPTION
## Summary
- normalize access-control command/function entrypoints to import `jsr:@supabase/functions-js/edge-runtime.d.ts`
- fix the remote Supabase bundler failure hit while deploying the merged `dev` access-control stack
- keep the hotfix scoped to the affected deployable function entrypoints only

## Why
Deploying the merged `dev` branch to Supabase dev failed immediately on `app_dataset_assign_team` because the remote bundler rejects bare `@supabase/functions-js/edge-runtime.d.ts` imports. The command/function stack added in the access-control rollout still had that import form on multiple entrypoints, so deployment could not proceed until those entrypoints were normalized.

## Validation
- `npm run lint`
- `deno check --config supabase/functions/deno.json supabase/functions/app_dataset_assign_team/index.ts supabase/functions/app_dataset_create/index.ts supabase/functions/app_dataset_delete/index.ts supabase/functions/app_dataset_publish/index.ts supabase/functions/app_dataset_save_draft/index.ts supabase/functions/app_dataset_submit_review/index.ts supabase/functions/admin_review_approve/index.ts supabase/functions/admin_review_assign_reviewers/index.ts supabase/functions/admin_review_change_member_role/index.ts supabase/functions/admin_review_reject/index.ts supabase/functions/admin_review_revoke_reviewer/index.ts supabase/functions/admin_review_save_assignment_draft/index.ts supabase/functions/admin_system_change_member_role/index.ts supabase/functions/admin_team_change_member_role/index.ts supabase/functions/admin_team_reinvite_member/index.ts supabase/functions/admin_team_set_rank/index.ts supabase/functions/app_notification_send_validation_issue/index.ts supabase/functions/app_review_save_comment_draft/index.ts supabase/functions/app_review_submit_comment/index.ts supabase/functions/app_team_accept_invitation/index.ts supabase/functions/app_team_create/index.ts supabase/functions/app_team_reject_invitation/index.ts supabase/functions/app_team_update_profile/index.ts supabase/functions/app_user_update_contact/index.ts`

## Follow-up
- after merge, redeploy the access-control edge functions to Supabase dev project `culgbbvzltdodcpykupc`