### PR TITLE
fix: ignore blank remote Supabase env values in shared clients

### DIFF
--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -3,25 +3,35 @@ import type {
   User,
   UserAppMetadata,
   UserMetadata,
-} from 'jsr:@supabase/supabase-js@2.98.0';
-import { createClient } from 'jsr:@supabase/supabase-js@2.98.0';
+} from "jsr:@supabase/supabase-js@2.98.0";
+import { createClient } from "jsr:@supabase/supabase-js@2.98.0";
 // import { Redis } from '@upstash/redis';
-import { authenticateCognitoToken } from './cognito_auth.ts';
-import { corsHeaders } from './cors.ts';
-import decodeApiKey from './decode_api_key.ts';
-import { redisGet, redisSet, type RedisClient } from './redis_client.ts';
+import { authenticateCognitoToken } from "./cognito_auth.ts";
+import { corsHeaders } from "./cors.ts";
+import decodeApiKey from "./decode_api_key.ts";
+import { type RedisClient, redisGet, redisSet } from "./redis_client.ts";
 
 const _defaultAppMetadata: UserAppMetadata = {
-  provider: '',
+  provider: "",
 };
 
 const _defaultUserMetadata: UserMetadata = {
-  provider: '',
+  provider: "",
 };
 
-const _defaultAud = '';
+const _defaultAud = "";
 
-const _defaultCreatedAt = '';
+const _defaultCreatedAt = "";
+
+function readOptionalEnv(name: string): string | undefined {
+  const value = Deno.env.get(name);
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
 
 export interface AuthedUser extends User {
   role?: string;
@@ -57,11 +67,11 @@ export interface AuthConfig {
  */
 export enum AuthMethod {
   /** Supabase JWT token via Authorization header, used in TianGong LCA Web App. */
-  JWT = 'jwt',
+  JWT = "jwt",
   /** User API key via Authorization header, used in openAPI Service and MCP Service. */
-  USER_API_KEY = 'user_api_key',
+  USER_API_KEY = "user_api_key",
   /** Service API key via apiKey header, used in database webhooks, backend services, etc. */
-  SERVICE_API_KEY = 'service_api_key',
+  SERVICE_API_KEY = "service_api_key",
 }
 
 /**
@@ -102,56 +112,66 @@ export async function authenticateRequest(
     supabase,
     redis,
     requireAuth = true,
-    allowedMethods = [AuthMethod.JWT, AuthMethod.USER_API_KEY, AuthMethod.SERVICE_API_KEY],
+    allowedMethods = [
+      AuthMethod.JWT,
+      AuthMethod.USER_API_KEY,
+      AuthMethod.SERVICE_API_KEY,
+    ],
     serviceApiKey,
   } = config;
 
-  const resolvedServiceApiKey =
-    serviceApiKey ?? Deno.env.get('REMOTE_SERVICE_API_KEY') ?? Deno.env.get('SERVICE_API_KEY');
+  const resolvedServiceApiKey = serviceApiKey ??
+    readOptionalEnv("REMOTE_SERVICE_API_KEY") ??
+    readOptionalEnv("SERVICE_API_KEY");
 
   // If authentication is not required, return success
   if (!requireAuth) {
-    console.log('Authentication is not required');
+    console.log("Authentication is not required");
     return { isAuthenticated: true };
   }
 
-  const authHeader = req.headers.get('Authorization');
-  const apiKey = req.headers.get('apikey');
+  const authHeader = req.headers.get("Authorization");
+  const apiKey = req.headers.get("apikey");
 
   // Collect all possible authentication results
-  const authResults: Array<{ method: AuthMethod; result: AuthResult | Promise<AuthResult> }> = [];
+  const authResults: Array<
+    { method: AuthMethod; result: AuthResult | Promise<AuthResult> }
+  > = [];
 
   // Check Service API key
   if (allowedMethods.includes(AuthMethod.SERVICE_API_KEY) && apiKey) {
-    console.log('Checking Service API key authentication');
+    console.log("Checking Service API key authentication");
     const result = authenticateServiceApiKey(apiKey, resolvedServiceApiKey);
     authResults.push({ method: AuthMethod.SERVICE_API_KEY, result });
   }
 
   // Check User API key
-  if (allowedMethods.includes(AuthMethod.USER_API_KEY) && supabase && redis && authHeader) {
-    console.log('Checking User API key authentication');
-    const apiKeyValue = authHeader.replace('Bearer ', '');
+  if (
+    allowedMethods.includes(AuthMethod.USER_API_KEY) && supabase && redis &&
+    authHeader
+  ) {
+    console.log("Checking User API key authentication");
+    const apiKeyValue = authHeader.replace("Bearer ", "");
     const result = authenticateUserApiKey(apiKeyValue, redis);
     authResults.push({ method: AuthMethod.USER_API_KEY, result });
   }
 
   // Check Supabase JWT
   if (allowedMethods.includes(AuthMethod.JWT) && supabase && authHeader) {
-    console.log('Checking Supabase JWT authentication');
-    const token = authHeader.replace('Bearer ', '');
+    console.log("Checking Supabase JWT authentication");
+    const token = authHeader.replace("Bearer ", "");
     const result = authenticateSupabaseJWT(token, supabase);
     authResults.push({ method: AuthMethod.JWT, result });
   }
 
   // If no authentication method is found, return unauthorized
   if (authResults.length === 0) {
-    console.log('No valid authentication method found');
+    console.log("No valid authentication method found");
     return {
       isAuthenticated: false,
-      response: new Response('Unauthorized Request', {
+      response: new Response("Unauthorized Request", {
         status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
       }),
     };
   }
@@ -165,7 +185,9 @@ export async function authenticateRequest(
   );
 
   // Count successful and failed authentication methods
-  const successfulAuths = resolvedResults.filter((r) => r.result.isAuthenticated);
+  const successfulAuths = resolvedResults.filter((r) =>
+    r.result.isAuthenticated
+  );
   const failedAuths = resolvedResults.filter((r) => !r.result.isAuthenticated);
 
   console.log(
@@ -174,12 +196,14 @@ export async function authenticateRequest(
 
   // If multiple methods succeed, return error (only one method is allowed)
   if (successfulAuths.length > 1) {
-    console.log('Multiple authentication methods succeeded, which is not allowed');
+    console.log(
+      "Multiple authentication methods succeeded, which is not allowed",
+    );
     return {
       isAuthenticated: false,
-      response: new Response('Multiple authentication methods provided', {
+      response: new Response("Multiple authentication methods provided", {
         status: 400,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
       }),
     };
   }
@@ -192,7 +216,7 @@ export async function authenticateRequest(
   }
 
   // If all methods fail, return the first failed result
-  console.log('All authentication methods failed');
+  console.log("All authentication methods failed");
   return failedAuths[0].result;
 }
 
@@ -201,21 +225,21 @@ export async function authenticateRequest(
  * @param bearerKey - The bearer token to analyze
  * @returns Token type: 'cognito' or 'supabase'
  */
-function getTokenType(bearerKey: string): 'cognito' | 'supabase' {
+function getTokenType(bearerKey: string): "cognito" | "supabase" {
   const jwtPattern = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 
   if (jwtPattern.test(bearerKey)) {
     try {
-      const payload = JSON.parse(atob(bearerKey.split('.')[1]));
-      if (payload.iss && payload.iss.includes('cognito')) {
-        return 'cognito';
+      const payload = JSON.parse(atob(bearerKey.split(".")[1]));
+      if (payload.iss && payload.iss.includes("cognito")) {
+        return "cognito";
       }
     } catch (_error) {
       // If parsing fails, we assume it's not a Cognito token
-      return 'supabase';
+      return "supabase";
     }
   }
-  return 'supabase';
+  return "supabase";
 }
 
 /**
@@ -228,30 +252,30 @@ async function authenticateSupabaseJWT(
   token: string,
   supabase: SupabaseClient,
 ): Promise<AuthResult> {
-  if (getTokenType(token) === 'cognito') {
-    console.log('Detected Cognito token, delegating to Cognito authentication');
+  if (getTokenType(token) === "cognito") {
+    console.log("Detected Cognito token, delegating to Cognito authentication");
     return await authenticateCognitoToken(token);
   }
 
   const { data: authData } = await supabase.auth.getUser(token);
-  console.log('Supabase JWT authentication result:', authData);
+  console.log("Supabase JWT authentication result:", authData);
 
   if (!authData?.user) {
     return {
       isAuthenticated: false,
-      response: new Response('User Not Found', {
+      response: new Response("User Not Found", {
         status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
       }),
     };
   }
 
-  if (authData.user.role !== 'authenticated') {
+  if (authData.user.role !== "authenticated") {
     return {
       isAuthenticated: false,
-      response: new Response('Forbidden', {
+      response: new Response("Forbidden", {
         status: 403,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
       }),
     };
   }
@@ -268,19 +292,25 @@ async function authenticateSupabaseJWT(
  * @param redis - The Redis client
  * @returns The authentication result
  */
-async function authenticateUserApiKey(apiKey: string, redis: RedisClient): Promise<AuthResult> {
+async function authenticateUserApiKey(
+  apiKey: string,
+  redis: RedisClient,
+): Promise<AuthResult> {
   const credentials = decodeApiKey(apiKey);
   if (!credentials) {
     return {
       isAuthenticated: false,
-      response: new Response(JSON.stringify({ error: 'The Credentials from user are invalid.' }), {
-        status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }),
+      response: new Response(
+        JSON.stringify({ error: "The Credentials from user are invalid." }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      ),
     };
   }
 
-  const { email = '', password = '' } = credentials;
+  const { email = "", password = "" } = credentials;
   const cacheKey = `lca_${email}`;
   const cachedUserId = await redisGet(redis, cacheKey);
 
@@ -302,9 +332,9 @@ async function authenticateUserApiKey(apiKey: string, redis: RedisClient): Promi
   if (!authClient) {
     return {
       isAuthenticated: false,
-      response: new Response('Auth client not configured', {
+      response: new Response("Auth client not configured", {
         status: 500,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
       }),
     };
   }
@@ -317,19 +347,19 @@ async function authenticateUserApiKey(apiKey: string, redis: RedisClient): Promi
   if (error || !data.user) {
     return {
       isAuthenticated: false,
-      response: new Response('Unauthorized', {
+      response: new Response("Unauthorized", {
         status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
       }),
     };
   }
 
-  if (data.user.role !== 'authenticated') {
+  if (data.user.role !== "authenticated") {
     return {
       isAuthenticated: false,
-      response: new Response('You are not an authenticated user.', {
+      response: new Response("You are not an authenticated user.", {
         status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
       }),
     };
   }
@@ -351,9 +381,10 @@ async function authenticateUserApiKey(apiKey: string, redis: RedisClient): Promi
 }
 
 function createAuthClientForUserApiKey(): SupabaseClient | null {
-  const supabaseUrl = Deno.env.get('REMOTE_SUPABASE_URL') ?? Deno.env.get('SUPABASE_URL') ?? '';
-  const serviceApiKey =
-    Deno.env.get('REMOTE_SERVICE_API_KEY') ?? Deno.env.get('SERVICE_API_KEY') ?? '';
+  const supabaseUrl = readOptionalEnv("REMOTE_SUPABASE_URL") ??
+    readOptionalEnv("SUPABASE_URL") ?? "";
+  const serviceApiKey = readOptionalEnv("REMOTE_SERVICE_API_KEY") ??
+    readOptionalEnv("SERVICE_API_KEY") ?? "";
 
   if (!supabaseUrl || !serviceApiKey) {
     return null;
@@ -374,13 +405,16 @@ function createAuthClientForUserApiKey(): SupabaseClient | null {
  * @param expectedKey - The expected API key
  * @returns The authentication result
  */
-function authenticateServiceApiKey(providedKey: string, expectedKey?: string): AuthResult {
+function authenticateServiceApiKey(
+  providedKey: string,
+  expectedKey?: string,
+): AuthResult {
   if (!expectedKey) {
     return {
       isAuthenticated: false,
-      response: new Response('Service API key not configured', {
+      response: new Response("Service API key not configured", {
         status: 500,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
       }),
     };
   }
@@ -388,9 +422,9 @@ function authenticateServiceApiKey(providedKey: string, expectedKey?: string): A
   if (providedKey !== expectedKey) {
     return {
       isAuthenticated: false,
-      response: new Response('Invalid service API key', {
+      response: new Response("Invalid service API key", {
         status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
       }),
     };
   }
@@ -399,8 +433,8 @@ function authenticateServiceApiKey(providedKey: string, expectedKey?: string): A
     isAuthenticated: true,
     // Service requests don't have a specific user
     user: {
-      id: 'service',
-      role: 'service',
+      id: "service",
+      role: "service",
       app_metadata: _defaultAppMetadata,
       user_metadata: _defaultUserMetadata,
       aud: _defaultAud,
@@ -413,8 +447,8 @@ function authenticateServiceApiKey(providedKey: string, expectedKey?: string): A
  * Helper function to handle CORS preflight requests
  */
 export function handleCors(req: Request): Response | null {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders });
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
   }
   return null;
 }
@@ -423,8 +457,11 @@ export function handleCors(req: Request): Response | null {
  * Create an authenticated Supabase client using webhook API key
  * Used for webhook endpoints that need to perform database operations
  */
-export async function createAuthenticatedSupabaseClient(apiKey: string): Promise<SupabaseClient> {
-  const { createClient } = await import('jsr:@supabase/supabase-js@2.98.0');
-  const supabaseUrl = Deno.env.get('REMOTE_SUPABASE_URL') ?? Deno.env.get('SUPABASE_URL') ?? '';
+export async function createAuthenticatedSupabaseClient(
+  apiKey: string,
+): Promise<SupabaseClient> {
+  const { createClient } = await import("jsr:@supabase/supabase-js@2.98.0");
+  const supabaseUrl = readOptionalEnv("REMOTE_SUPABASE_URL") ??
+    readOptionalEnv("SUPABASE_URL") ?? "";
   return createClient(supabaseUrl, apiKey);
 }

--- a/supabase/functions/_shared/supabase_client.ts
+++ b/supabase/functions/_shared/supabase_client.ts
@@ -1,42 +1,60 @@
-import { createClient } from 'jsr:@supabase/supabase-js@2.98.0';
+import { createClient } from "jsr:@supabase/supabase-js@2.98.0";
 
 function readEnv(name: string): string | undefined {
   try {
-    return Deno.env.get(name) ?? undefined;
+    const value = Deno.env.get(name);
+    if (value === undefined) {
+      return undefined;
+    }
+
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : undefined;
   } catch (_error) {
     return undefined;
   }
 }
 
-const FALLBACK_SUPABASE_URL = 'http://127.0.0.1:54321';
-const FALLBACK_SUPABASE_KEY = 'placeholder-key';
+const FALLBACK_SUPABASE_URL = "http://127.0.0.1:54321";
+const FALLBACK_SUPABASE_KEY = "placeholder-key";
+const SERVICE_ROLE_CLIENT_OPTIONS = {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+    detectSessionInUrl: false,
+  },
+};
 
 export function getSupabaseUrl(): string {
-  return readEnv('REMOTE_SUPABASE_URL') ?? readEnv('SUPABASE_URL') ?? FALLBACK_SUPABASE_URL;
+  return readEnv("REMOTE_SUPABASE_URL") ?? readEnv("SUPABASE_URL") ??
+    FALLBACK_SUPABASE_URL;
 }
 
 export function getServiceRoleKey(): string {
   return (
-    readEnv('REMOTE_SERVICE_API_KEY') ??
-    readEnv('SERVICE_API_KEY') ??
-    readEnv('REMOTE_SUPABASE_SERVICE_ROLE_KEY') ??
-    readEnv('SUPABASE_SERVICE_ROLE_KEY') ??
-    FALLBACK_SUPABASE_KEY
+    readEnv("REMOTE_SERVICE_API_KEY") ??
+      readEnv("SERVICE_API_KEY") ??
+      readEnv("REMOTE_SUPABASE_SERVICE_ROLE_KEY") ??
+      readEnv("SUPABASE_SERVICE_ROLE_KEY") ??
+      FALLBACK_SUPABASE_KEY
   );
 }
 
 export function getPublishableKey(): string {
   return (
-    readEnv('REMOTE_SUPABASE_PUBLISHABLE_KEY') ??
-    readEnv('REMOTE_SUPABASE_ANON_KEY') ??
-    readEnv('SUPABASE_PUBLISHABLE_KEY') ??
-    readEnv('SUPABASE_ANON_KEY') ??
-    FALLBACK_SUPABASE_KEY
+    readEnv("REMOTE_SUPABASE_PUBLISHABLE_KEY") ??
+      readEnv("REMOTE_SUPABASE_ANON_KEY") ??
+      readEnv("SUPABASE_PUBLISHABLE_KEY") ??
+      readEnv("SUPABASE_ANON_KEY") ??
+      FALLBACK_SUPABASE_KEY
   );
 }
 
 export function createServiceRoleClient() {
-  return createClient(getSupabaseUrl(), getServiceRoleKey());
+  return createClient(
+    getSupabaseUrl(),
+    getServiceRoleKey(),
+    SERVICE_ROLE_CLIENT_OPTIONS,
+  );
 }
 
 export function createRequestSupabaseClient(accessToken?: string) {
@@ -56,4 +74,8 @@ export function createRequestSupabaseClient(accessToken?: string) {
   });
 }
 
-export const supabaseClient = createClient(getSupabaseUrl(), getServiceRoleKey());
+export const supabaseClient = createClient(
+  getSupabaseUrl(),
+  getServiceRoleKey(),
+  SERVICE_ROLE_CLIENT_OPTIONS,
+);

--- a/test/supabase_client_test.ts
+++ b/test/supabase_client_test.ts
@@ -1,0 +1,71 @@
+import { assertEquals } from "jsr:@std/assert";
+
+const MODULE_PATH = "../supabase/functions/_shared/supabase_client.ts";
+const TEST_SUPABASE_URL = "https://example.supabase.co";
+const TEST_SERVICE_ROLE_KEY = "service-role-key-for-tests";
+const TEST_PUBLISHABLE_KEY = "publishable-key-for-tests";
+
+function restoreEnvVar(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    Deno.env.delete(name);
+    return;
+  }
+
+  Deno.env.set(name, value);
+}
+
+async function withSupabaseEnv<T>(
+  overrides: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+
+  for (const name of Object.keys(overrides)) {
+    previous.set(name, Deno.env.get(name));
+  }
+
+  for (const [name, value] of Object.entries(overrides)) {
+    restoreEnvVar(name, value);
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [name, value] of previous.entries()) {
+      restoreEnvVar(name, value);
+    }
+  }
+}
+
+async function importSupabaseClientModule() {
+  return await import(`${MODULE_PATH}?case=${crypto.randomUUID()}`);
+}
+
+Deno.test("shared Supabase client falls back when remote env vars are blank", async () => {
+  await withSupabaseEnv(
+    {
+      REMOTE_SUPABASE_URL: "   ",
+      REMOTE_SERVICE_API_KEY: "",
+      REMOTE_SUPABASE_PUBLISHABLE_KEY: "\n",
+      REMOTE_SUPABASE_ANON_KEY: " ",
+      SUPABASE_URL: TEST_SUPABASE_URL,
+      SUPABASE_SERVICE_ROLE_KEY: TEST_SERVICE_ROLE_KEY,
+      SUPABASE_ANON_KEY: TEST_PUBLISHABLE_KEY,
+    },
+    async () => {
+      const module = await importSupabaseClientModule();
+
+      assertEquals(module.getSupabaseUrl(), TEST_SUPABASE_URL);
+      assertEquals(module.getServiceRoleKey(), TEST_SERVICE_ROLE_KEY);
+      assertEquals(module.getPublishableKey(), TEST_PUBLISHABLE_KEY);
+
+      if (!module.supabaseClient) {
+        throw new Error("expected shared service-role client to be created");
+      }
+
+      if (!module.createRequestSupabaseClient()) {
+        throw new Error("expected request-scoped client to be created");
+      }
+    },
+  );
+});


### PR DESCRIPTION
Closes linancn/tiangong-lca-edge-functions#66

## Summary
- Treat blank REMOTE_* Supabase env values as unset before resolving service-role and publishable credentials.
- Harden the shared service-role client with explicit server-side auth options and add regression coverage for blank env fallbacks.

## Key Decisions
- Keep the shared service-role client in place for privileged RPC execution; this change only fixes env resolution and boot-time client construction.
- Cover the bug with a focused helper test instead of relying only on full function boot checks.

## Validation
- deno test /Users/biao/Code/lca-workspace/lca-workspace/tiangong-lca-edge-functions/test/supabase_client_test.ts --allow-env --allow-read
- OPTIONS https://culgbbvzltdodcpykupc.supabase.co/functions/v1/save_lifecycle_model_bundle -> 200 ok
- POST {} to save_lifecycle_model_bundle on Supabase dev -> 401 AUTH_REQUIRED (runtime init succeeds, no cold-start crash)
- OPTIONS https://culgbbvzltdodcpykupc.supabase.co/functions/v1/delete_lifecycle_model_bundle -> 200 ok
- POST {} to delete_lifecycle_model_bundle on Supabase dev -> 401 AUTH_REQUIRED (runtime init succeeds, no cold-start crash)

## Risks / Rollback
- Low risk: changes are limited to shared env resolution and client construction paths, with no RPC contract changes.

## Follow-ups
- After merge, bump the edge-functions submodule pointer where the dev workspace integration expects this fix.

## Workspace Integration
- Workspace integration remains pending after this repo-level PR merges.