### PR TITLE
fix: restore rule verification on save draft

### DIFF
--- a/supabase/functions/_shared/commands/dataset/types.ts
+++ b/supabase/functions/_shared/commands/dataset/types.ts
@@ -16,6 +16,7 @@ export type SaveDraftRequest = {
   version: string;
   jsonOrdered: unknown;
   modelId?: string;
+  ruleVerification?: boolean | null;
 };
 
 export type CreateRequest = {

--- a/supabase/functions/_shared/commands/dataset/validation.ts
+++ b/supabase/functions/_shared/commands/dataset/validation.ts
@@ -37,6 +37,7 @@ export const saveDraftRequestSchema = datasetBaseRequestSchema
   .extend({
     jsonOrdered: z.unknown(),
     modelId: z.string().uuid().optional(),
+    ruleVerification: z.boolean().nullable().optional(),
   })
   .strict();
 

--- a/supabase/functions/_shared/db_rpc/dataset_commands.ts
+++ b/supabase/functions/_shared/db_rpc/dataset_commands.ts
@@ -96,6 +96,7 @@ export function buildDatasetSaveDraftRpcArgs(
     p_json_ordered: request.jsonOrdered,
     p_model_id: request.modelId ?? null,
     p_audit: audit,
+    p_rule_verification: request.ruleVerification ?? null,
   };
 }
 

--- a/test/app_dataset_save_draft_test.ts
+++ b/test/app_dataset_save_draft_test.ts
@@ -45,6 +45,7 @@ Deno.test(
         version: "01.00.000",
         jsonOrdered: { foo: "bar" },
         modelId: TEST_MODEL_ID,
+        ruleVerification: false,
       },
       buildActor(supabase),
     );
@@ -59,6 +60,7 @@ Deno.test(
           p_version: "01.00.000",
           p_json_ordered: { foo: "bar" },
           p_model_id: TEST_MODEL_ID,
+          p_rule_verification: false,
           p_audit: {
             command: "dataset_save_draft",
             actorUserId: TEST_USER_ID,
@@ -97,6 +99,7 @@ Deno.test("executeSaveDraftCommand allows process drafts without modelId", async
         p_version: "01.00.000",
         p_json_ordered: { foo: "bar" },
         p_model_id: null,
+        p_rule_verification: null,
         p_audit: {
           command: "dataset_save_draft",
           actorUserId: TEST_USER_ID,

--- a/test/dataset_command_rpc_contract_test.ts
+++ b/test/dataset_command_rpc_contract_test.ts
@@ -14,16 +14,16 @@ import {
   type DatasetRpcResult,
 } from "../supabase/functions/_shared/db_rpc/dataset_commands.ts";
 
-Deno.test("saveDraftRequestSchema rejects server-owned ruleVerification input", () => {
+Deno.test("saveDraftRequestSchema accepts optional ruleVerification metadata", () => {
   const parsed = saveDraftRequestSchema.safeParse({
     table: "flows",
     id: "11111111-1111-4111-8111-111111111111",
     version: "01.00.000",
     jsonOrdered: {},
-    ruleVerification: true,
+    ruleVerification: false,
   });
 
-  assertEquals(parsed.success, false);
+  assertEquals(parsed.success, true);
 });
 
 Deno.test("submitReviewRequestSchema rejects unexpected payload fields", () => {


### PR DESCRIPTION
Closes #48

## Summary
- Restore optional ruleVerification on the save-draft edge request and RPC args.
- Forward missing values as null so save_draft clears stale rule_verification state instead of preserving it.

## Key Decisions
- Keep rule_verification out of authorization decisions in this follow-up.

## Validation
- deno test --config supabase/functions/deno.json test/app_dataset_save_draft_test.ts test/dataset_command_rpc_contract_test.ts

## Risks / Rollback
- Low risk: scope is limited to save-draft request validation and RPC argument forwarding.

## Workspace Integration
- Requires later lca-workspace submodule integration after merge.