### PR TITLE
docs: formalize edge branch and deploy contract

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature-to-dev.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature-to-dev.md
@@ -1,0 +1,28 @@
+## Branch Contract
+
+- Base branch: `dev`
+- Validated environment: `dev` / `main` / `local serve`
+- Remote deploy expected?: `No` / `Yes (dev/main, explain)`
+- Back-merge required after merge?: `No` / `Yes (explain)`
+- Root workspace integration expected?: `No` / `Yes (explain)`
+
+- [ ] This PR targets `dev`.
+- [ ] I confirm this repo's GitHub default branch may still appear as `main`, but routine feature and fix PRs must target `dev`.
+- [ ] If remote deployment is part of this change, I used the repo-standard `--no-verify-jwt` deploy contract and documented which environment was deployed.
+- [ ] New or changed functions do not assume gateway-level JWT verification and still enforce runtime authentication / authorization.
+
+## Linked Issue
+
+Closes #
+
+## Functions Changed
+
+<!-- List the functions or shared modules changed in this PR. -->
+
+## Validation
+
+<!-- Commands run, local serve checks, Deno checks, deploy evidence, or request examples. -->
+
+## Risks / Follow-up
+
+<!-- Runtime auth notes, root integration notes, back-merge notes, or follow-up issues. -->

--- a/.github/PULL_REQUEST_TEMPLATE/promote-dev-to-main.md
+++ b/.github/PULL_REQUEST_TEMPLATE/promote-dev-to-main.md
@@ -1,0 +1,30 @@
+## Promotion Contract
+
+- Base branch: `main`
+- Source branch: `dev`
+- Validated environment before promotion: `dev` / `main` / `local serve`
+- Remote deploy expected?: `No` / `Yes (main, explain)`
+- Back-merge required after merge?: `No` / `Yes (main -> dev, explain)`
+- Root workspace integration expected?: `No` / `Yes (explain)`
+
+- [ ] This PR promotes `dev` into `main`.
+- [ ] I confirm this repo's GitHub default branch remaining `main` is a platform exception; routine feature and fix work still lands in `dev` first.
+- [ ] If remote deployment is part of this promotion, `main` deployment still uses the repo-standard `--no-verify-jwt` contract and the runtime auth boundary is documented.
+- [ ] I verified the integrated result in `dev` before requesting promotion to `main`.
+- [ ] If this PR includes a direct `main` hotfix path, I documented the required `main -> dev` back-merge plan.
+
+## Linked Issue
+
+Closes #
+
+## Release Summary
+
+<!-- What is being promoted, and which functions or shared modules are included? -->
+
+## Validation
+
+<!-- Evidence from dev validation, main-target checks, deploy evidence, or smoke tests. -->
+
+## Integration / Follow-up
+
+<!-- Root workspace submodule bump, release coordination, back-merge follow-up, or rollback notes. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - 'dev/**'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: 2.1.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint docs and config
+        run: npm run lint
+
+      - name: Deno check baseline
+        run: npm run check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,28 @@
 ## 2. Project Snapshot
 
 - 项目类型：Supabase Edge Functions（Deno 2.1.x）+ Node 工具链。
+- 分支模型：本仓库保持 GitHub default branch 为 `main` 这一平台层例外，但日常 trunk 是 Git `dev`；routine PR 默认回 `dev`，promote 路径是 `dev -> main`，hotfix 从 `main` 起并在合并后 `main -> dev` 回合并。
 - 入口目录：`supabase/functions/*/index.ts`。
 - 共享模块：`supabase/functions/_shared/*`。
 - Deno 测试文件统一放在仓库根目录 `test/*`，不要放在 `supabase/functions/**` 下。
 - 依赖锁定：`supabase/functions/deno.json` 的 `imports` 使用精确版本（exact pin），避免无版本映射。
+- 远端环境映射：
+  - Git `main` / 远端 `main` project ref：`qgzvkongdjqiiamzbbts`
+  - Git `dev` / 持久化远端 `dev` branch project ref：`culgbbvzltdodcpykupc`
 - 本地启动：
   - `npm install`
   - `npm start`（等价于 `supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt`）
+- 基线校验命令：
+  - `npm run lint`
+  - `npm run check`（依次对当前启用的 `supabase/functions/*/index.ts` 与 `test/*.ts` 执行 `deno check`；当前默认排除 README 中已标记为 not enabled 的 `antchain_*` 与 legacy 非 `*_ft` embedding/webhook 入口）
+- 正式远端部署入口：
+  - `npm run deploy:dev -- <function-name> [more-function-names...]`
+  - `npm run deploy:main -- <function-name> [more-function-names...]`
+  - 两类远端部署都固定追加 `--no-verify-jwt`
+- 安全边界：
+  - 远端 `main` 与 `dev` gateway 都不负责 JWT 校验
+  - 函数运行时必须继续完成认证与授权
+  - 新函数不得假设 gateway `verify_jwt=true` 已经帮你兜底
 - 主要测试样例：`test.example.http`
 - 主要说明文档：`README.md`
 
@@ -98,10 +113,12 @@
 
 1. 运行格式与规范脚本：
    - `npm run lint`
-2. 运行最小必要校验（按影响范围）：
-   - `deno check` 属于强制步骤：凡涉及 `supabase/functions` 下代码改动（`.ts`/`.js`），必须执行，不可跳过。
-   - 单函数改动：`deno check --config supabase/functions/deno.json <changed-file>`
-   - 共享模块改动：至少覆盖所有直接依赖该模块的函数。
+2. 运行校验脚本：
+   - `npm run check` 是默认基线，提交前 / PR 前应通过。
+   - 若涉及 `supabase/functions` 下代码改动（`.ts`/`.js`），`deno check` 属于强制步骤，不可跳过。
+   - scoped 迭代时仍按影响范围补跑针对性 `deno check`：
+     - 单函数改动：`deno check --config supabase/functions/deno.json <changed-file>`
+     - 共享模块改动：至少覆盖所有直接依赖该模块的函数。
 3. 同步文档：
    - 若改动影响开发流程、依赖版本、函数行为、验证方式，必须同步更新 `AGENTS.md`（必要时同时更新 `README.md`）。
 4. 输出结果时明确：
@@ -117,21 +134,25 @@
 - 变更核心依赖（如 OpenAI SDK、Supabase runtime 相关依赖）。
 - 变更统一开发命令、lint/format/test 命令。
 - 变更共享模块职责边界（`_shared` 下）。
-- 变更“必做流程”或发布流程。
+- 变更“必做流程”、分支模型或发布/部署流程。
 
 如果改动不涉及以上内容，可不改 `AGENTS.md`，但需要在最终说明中声明“本次无需更新 AGENTS.md”。
 
 ## 7. Validation Matrix
 
 - 混合检索相关改动（`flow/process/lifecyclemodel` 或其 shared 依赖）：
+  - `npm run check`
   - `deno check` 三个函数至少各跑一次。
   - 用 `test.example.http` 里的对应请求做 smoke test（本地或远程至少一端）。
 - OpenAI 共享层改动（`openai_structured.ts` / `openai_chat.ts`）：
+  - `npm run check`
   - 至少验证 `responses.create` 可用（`deno eval` 或实际函数调用）。
 - LCA 链路改动：
+  - `npm run check`
   - 优先用 `scripts/lca_submit_poll_fetch.sh` 验证端到端（本地需 `jq`）。
 - TIDAS package import 改动：
   - `npm run lint`
+  - `npm run check`
   - `deno check --config supabase/functions/deno.json supabase/functions/import_tidas_package/index.ts`
   - 如果改动触及 `_shared/auth.ts` / `_shared/tidas_package.ts` / `_shared/redis_client.ts`，至少补跑所有直接依赖这些共享模块的 package 相关函数
   - 用 `test.example.http` 中的 `import_tidas_package` / `tidas_package_jobs` 示例至少验证一组本地或远程请求

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Supabase Edge Functions for LCA search, embedding, and solving workflows.
 - Functions root: `supabase/functions`
 - Local serve command: `npm start`
 
+## Branch & Deployment Contract
+
+- 本仓库采用以下分支规则：Git `dev` 是日常 trunk，routine PR 默认回 `dev`，`dev -> main` 是 promote 路径，hotfix 从 `main` 起并在合并后回合并到 `dev`。
+- GitHub default branch 继续保持 `main`，这是平台层例外，不代表日常 trunk 改回 `main`。
+- 远端环境映射：
+  - `main` project ref：`qgzvkongdjqiiamzbbts`
+  - `dev` project ref：`culgbbvzltdodcpykupc`
+- 远端 `main` 与 `dev` 的函数部署都统一使用 `--no-verify-jwt`。这是正式仓库规则，不是临时口头 workaround。
+- 安全边界在函数运行时：gateway 不做 JWT 校验，不等于函数可以匿名执行。新函数不得假设 gateway `verify_jwt=true` 已经帮你兜底，必须继续显式做认证与授权。
+
 ## Prerequisites
 
 - Node.js 22
@@ -67,7 +77,7 @@ npm start
 `npm start` is equivalent to:
 
 ```bash
-supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt
+./node_modules/.bin/supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt
 ```
 
 ### Optional: Start full local Supabase stack
@@ -125,13 +135,21 @@ After any code or document update:
 npm run lint
 ```
 
-2. Run minimal checks for affected files:
+2. Run the repo baseline Deno checks:
+
+```bash
+npm run check
+```
+
+This baseline intentionally skips the currently disabled `antchain_*` functions and the legacy non-`*_ft` embedding/webhook entrypoints (`embedding`, `webhook_flow_embedding`, `webhook_process_embedding`, `webhook_model_embedding`). If you reactivate any of them, bring them back into the baseline and fix their type-check state in the same change.
+
+3. Run minimal checks for affected files when you need scoped verification during iteration:
 
 ```bash
 deno check --config supabase/functions/deno.json <changed-file>
 ```
 
-3. Keep docs synced:
+4. Keep docs synced:
 
 - Update `README.md` for human-facing workflow changes.
 - Update `AGENTS.md` for AI workflow/dependency/process changes.
@@ -325,77 +343,76 @@ Optional envs:
 - `UNIT_BATCH_SIZE` (optional; used only when `DEMAND_MODE=all_unit`)
 - auth: set one of `USER_JWT` or `USER_API_KEY`
 
-## Remote Config
+## Remote Config & Deploy
+
+### CLI baseline
+
+- 标准 CLI 版本固定为 `supabase@2.85.0`。
+- 远端部署统一使用仓库脚本，不要直接依赖裸 `npx supabase` 的隐式版本解析。
+- 标准部署入口：
+  - `npm run deploy:dev -- <function-name> [more-function-names...]`
+  - `npm run deploy:main -- <function-name> [more-function-names...]`
+- 这两个脚本都会自动：
+  - 使用固定的 `supabase@2.85.0`
+  - 读取仓库内登记的 `dev` / `main` project ref
+  - 固定追加 `--no-verify-jwt`
+
+部署前需要先满足以下其一：
+
+- 已执行 `npx --yes supabase@2.85.0 login`
+- 或已显式提供 `SUPABASE_ACCESS_TOKEN`
+
+### Push secrets
 
 ```bash
-npx supabase login
-
-## Dangerous: make sure you are in the correct project context before running the following command, as it will overwrite secrets in the target project.
-npx supabase secrets set --env-file ./supabase/.env.local --project-ref qgzvkongdjqiiamzbbts
+# Dangerous: make sure you are targeting the correct project before overwriting secrets.
+npx --yes supabase@2.85.0 secrets set --env-file ./supabase/.env.local --project-ref culgbbvzltdodcpykupc
+npx --yes supabase@2.85.0 secrets set --env-file ./supabase/.env.local --project-ref qgzvkongdjqiiamzbbts
 ```
 
-### Search Functions
+### Deploy examples
+
+把同一批函数部署到 `dev` 时，把下面命令里的 `deploy:main` 改成 `deploy:dev` 即可。
+
+#### Search Functions
 
 ```bash
-npx supabase functions deploy flow_hybrid_search --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-npx supabase functions deploy process_hybrid_search --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-npx supabase functions deploy lifecyclemodel_hybrid_search --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
+npm run deploy:main -- flow_hybrid_search process_hybrid_search lifecyclemodel_hybrid_search
 ```
 
-### LCA Functions
+#### LCA Functions
 
 ```bash
-npx supabase functions deploy lca_solve --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-npx supabase functions deploy lca_jobs --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-npx supabase functions deploy lca_results --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-npx supabase functions deploy lca_query_results --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-npx supabase functions deploy lca_contribution_path --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-npx supabase functions deploy lca_contribution_path_result --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
+npm run deploy:main -- lca_solve lca_jobs lca_results lca_query_results lca_contribution_path lca_contribution_path_result
 ```
 
-### Embedding Functions
+#### Embedding Functions
 
 ```bash
-# npx supabase functions deploy embedding --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-# npx supabase functions deploy webhook_flow_embedding --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-# npx supabase functions deploy webhook_process_embedding --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-# npx supabase functions deploy webhook_model_embedding --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-
-npx supabase functions deploy embedding_ft --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-
-npx supabase functions deploy webhook_process_embedding_ft --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-npx supabase functions deploy webhook_model_embedding_ft --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-npx supabase functions deploy webhook_flow_embedding_ft --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
+npm run deploy:main -- embedding_ft webhook_process_embedding_ft webhook_model_embedding_ft webhook_flow_embedding_ft
 ```
 
-### Data Operation Functions
+#### Data Operation Functions
 
 ```bash
-npx supabase functions deploy update_data --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
+npm run deploy:main -- update_data
 ```
 
-### Cognito Functions
+#### Cognito Functions
 
 ```bash
-npx supabase functions deploy sign_up_cognito --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-npx supabase functions deploy change_password_cognito --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-npx supabase functions deploy change_email_cognito --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
+npm run deploy:main -- sign_up_cognito change_password_cognito change_email_cognito
 ```
 
-### AI Related Functions
+#### AI Related Functions
 
 ```bash
-npx supabase functions deploy ai_suggest --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
+npm run deploy:main -- ai_suggest
 ```
 
-### Antchain Related Functions (not enabled)
+#### Antchain Related Functions (not enabled)
 
 ```bash
-# npx supabase functions deploy antchain_request_process_data --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-# npx supabase functions deploy antchain_sign_request --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-# npx supabase functions deploy antchain_run_antchain_calculation --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-# npx supabase functions deploy antchain_get_local_ip --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-# npx supabase functions deploy antchain_create_calculation --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-# npx supabase functions deploy antchain_query_calculation_status --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
-# npx supabase functions deploy antchain_query_calculation_results --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt
+# npm run deploy:main -- antchain_request_process_data antchain_sign_request antchain_run_antchain_calculation
+# npm run deploy:main -- antchain_get_local_ip antchain_create_calculation antchain_query_calculation_status antchain_query_calculation_results
 ```

--- a/package.json
+++ b/package.json
@@ -1,13 +1,21 @@
 {
+  "config": {
+    "supabaseCliVersion": "2.85.0",
+    "supabaseProjectRefDev": "culgbbvzltdodcpykupc",
+    "supabaseProjectRefMain": "qgzvkongdjqiiamzbbts"
+  },
   "scripts": {
     "prestart": "[ -x node_modules/.bin/supabase ] && node_modules/.bin/supabase --version >/dev/null 2>&1 || npm rebuild supabase --foreground-scripts || true",
-    "start": "supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt",
-    "lint": "prettier -c --write \"**/**.{js,jsx,tsx,ts,less,md,json}\""
+    "start": "node_modules/.bin/supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt",
+    "check": "node ./scripts/deno-check-all.cjs",
+    "deploy:dev": "node ./scripts/deploy-function.cjs dev",
+    "deploy:main": "node ./scripts/deploy-function.cjs main",
+    "lint": "prettier -c --write \"**/*.{cjs,js,jsx,tsx,ts,less,md,json,yml,yaml}\""
   },
   "devDependencies": {
     "prettier": "^3.8.1",
     "prettier-plugin-organize-imports": "^4.3.0",
-    "supabase": "^2.77.0",
+    "supabase": "2.85.0",
     "typescript": "^5.9.3"
   }
 }

--- a/scripts/deno-check-all.cjs
+++ b/scripts/deno-check-all.cjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const functionsRoot = path.join(repoRoot, 'supabase', 'functions');
+const testRoot = path.join(repoRoot, 'test');
+const configPath = path.join('supabase', 'functions', 'deno.json');
+const disabledFunctionPrefixes = ['antchain_'];
+const disabledFunctionNames = new Set([
+  'embedding',
+  'webhook_flow_embedding',
+  'webhook_model_embedding',
+  'webhook_process_embedding',
+]);
+
+const functionEntryPoints = fs
+  .readdirSync(functionsRoot, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && entry.name !== '_shared')
+  .filter((entry) => !disabledFunctionPrefixes.some((prefix) => entry.name.startsWith(prefix)))
+  .filter((entry) => !disabledFunctionNames.has(entry.name))
+  .map((entry) => path.join('supabase', 'functions', entry.name, 'index.ts'))
+  .filter((entryPoint) => fs.existsSync(path.join(repoRoot, entryPoint)))
+  .sort();
+
+const testFiles = fs
+  .readdirSync(testRoot, { withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.endsWith('.ts'))
+  .map((entry) => path.join('test', entry.name))
+  .sort();
+
+const targets = [...functionEntryPoints, ...testFiles];
+
+console.log(`Running deno check for ${targets.length} targets...`);
+console.log(`Skipped disabled function prefixes: ${disabledFunctionPrefixes.join(', ')}`);
+console.log(`Skipped disabled function names: ${Array.from(disabledFunctionNames).join(', ')}`);
+
+for (const target of targets) {
+  console.log(`- ${target}`);
+  const result = spawnSync('deno', ['check', '--config', configPath, target], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/scripts/deploy-function.cjs
+++ b/scripts/deploy-function.cjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const [, , target, ...functionNames] = process.argv;
+const validTargets = new Set(['dev', 'main']);
+
+if (!validTargets.has(target) || functionNames.length === 0) {
+  console.error('Usage: npm run deploy:<dev|main> -- <function-name> [more-function-names...]');
+  process.exit(1);
+}
+
+const repoRoot = path.resolve(__dirname, '..');
+const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+const cliVersion = packageJson.config?.supabaseCliVersion;
+const projectRefs = {
+  dev: packageJson.config?.supabaseProjectRefDev,
+  main: packageJson.config?.supabaseProjectRefMain,
+};
+const projectRef = projectRefs[target];
+
+if (!cliVersion || !projectRef) {
+  console.error('Missing Supabase CLI version or project ref config in package.json.');
+  process.exit(1);
+}
+
+for (const functionName of functionNames) {
+  console.log(`[deploy:${target}] ${functionName} -> ${projectRef}`);
+  const result = spawnSync(
+    'npx',
+    [
+      '--yes',
+      `supabase@${cliVersion}`,
+      'functions',
+      'deploy',
+      functionName,
+      '--project-ref',
+      projectRef,
+      '--no-verify-jwt',
+    ],
+    {
+      cwd: repoRoot,
+      stdio: 'inherit',
+      env: process.env,
+    },
+  );
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,3 +1,10 @@
+# Git / Supabase branch contract for this repo:
+# - GitHub default branch remains `main` as a platform exception.
+# - Daily trunk is Git `dev`; `dev -> main` is the promote path.
+# - Root config below is the `main` / production baseline that preview branches inherit.
+# - Persistent Git `dev` maps to the remote branch project `culgbbvzltdodcpykupc` via `[remotes.dev]`.
+# - The production / `main` project ref used by deploy scripts is `qgzvkongdjqiiamzbbts`.
+#
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
 project_id = "tiangong-lca-edge-function"
@@ -149,6 +156,10 @@ redirect_uri = ""
 url = ""
 # If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
 skip_nonce_check = false
+
+[remotes.dev]
+# Persistent Supabase branch project used by Git `dev`.
+project_id = "culgbbvzltdodcpykupc"
 
 [analytics]
 enabled = false


### PR DESCRIPTION
## Branch Contract

- Base branch: `dev`
- Validated environment: `local serve`
- Remote deploy expected?: `No`
- Back-merge required after merge?: `No`
- Root workspace integration expected?: `Yes`

- [x] This PR targets `dev`.
- [x] I confirm this repo's GitHub default branch may still appear as `main`, but routine feature and fix PRs must target `dev`.
- [x] New or changed functions do not assume gateway-level JWT verification and still enforce runtime authentication / authorization.

## Linked Issue

Closes #72

## Functions Changed

- formalize the repo's dev-first routine branch contract in `AGENTS.md` and `README.md`
- add `deploy:dev` / `deploy:main` helper scripts with fixed project refs and `--no-verify-jwt`
- add a Deno baseline `check` script and CI workflow
- record Git/Supabase branch mapping in `supabase/config.toml`
- add feature-to-dev and promote-dev-to-main PR templates

## Validation

- `npm run check`

## Risks / Follow-up

- `npm run lint` in this repo is a write-mode Prettier command that rewrites many unrelated files; it was intentionally not used as the validation gate for this PR.
- Root workspace docs and integration policy are being tracked separately in the workspace repo.