### PR TITLE
fix: unblock CI without npm lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: npm
+          package-manager-cache: false
 
       - name: Setup Deno
         uses: denoland/setup-deno@v1
@@ -31,7 +31,7 @@ jobs:
           deno-version: 2.1.x
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install --no-package-lock
 
       - name: Lint docs and config
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           package-manager-cache: false
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: 2.1.x
 


### PR DESCRIPTION
Closes linancn/tiangong-lca-edge-functions#74

## Summary
- Disable setup-node package-manager caching and install dependencies without requiring a tracked package-lock.json.
- Upgrade `denoland/setup-deno` from `@v1` to `@v2` so the workflow uses the current supported major.

## Key Decisions
- Match the workflow to the repo policy by treating npm dependencies as lockfile-less in CI instead of introducing a tracked lockfile in this fix.
- Keep the Deno action pinned at the major tag to match the existing workflow style used for other GitHub Actions in this repo.

## Validation
- npm install --no-package-lock
- npx prettier -c .github/workflows/ci.yml
- npm run check
- GitHub Actions CI passed on PR #75 after the workflow updates.

## Risks / Rollback
- The repo lint script currently includes --write and rewrites many files during validation; this PR does not change that separate behavior.

## Follow-ups
- If deterministic npm installs become required later, track a separate change to stop ignoring package-lock.json and switch CI back to npm ci.

## Workspace Integration
- Requires the normal workspace submodule integration flow after merge.
