### PR TITLE
fix: harden auth diagnostics and add edge auth probe tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ deno.lock
 sqls
 
 .DS_Store
+
+tmp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - 本地启动：
   - `npm install`
   - `npm start`（等价于 `supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt`）
+  - `npm run probe:auth -- --remote`（远端 edge functions 连通性 / 鉴权探测；也可用 `--local` 或 `--base-url`）
 - 基线校验命令：
   - `npm run lint`
   - `npm run check`（依次对当前启用的 `supabase/functions/*/index.ts` 与 `test/*.ts` 执行 `deno check`；当前默认排除 README 中已标记为 not enabled 的 `antchain_*` 与 legacy 非 `*_ft` embedding/webhook 入口）
@@ -35,6 +36,7 @@
   - 函数运行时必须继续完成认证与授权
   - 新函数不得假设 gateway `verify_jwt=true` 已经帮你兜底
 - 主要测试样例：`test.example.http`
+- 鉴权排障脚本：`scripts/probe-functions-auth.cjs`
 - 主要说明文档：`README.md`
 
 ## 3. Directory Guide

--- a/README.md
+++ b/README.md
@@ -115,6 +115,55 @@ See `test.example.http` for local and remote examples, including:
 - `lca_contribution_path` / `lca_contribution_path_result`
 - `import_tidas_package` / `tidas_package_jobs`
 
+### Auth / connectivity probe
+
+当你怀疑远端出现“函数通了，但 auth 行为漂移”这类问题时，优先跑仓库内的统一探测脚本：
+
+```bash
+npm run probe:auth -- --remote
+```
+
+脚本会自动读取：
+
+- 根目录 `.env` 中的 `REMOTE_ENDPOINT` / `LOCAL_ENDPOINT`
+- `USER_JWT`
+- `USER_API_KEY`
+- `supabase/.env.local` 或 shell env 里的 `REMOTE_SERVICE_API_KEY` / `SERVICE_API_KEY`
+
+也可以显式覆盖：
+
+```bash
+EDGE_BASE_URL="https://<project-ref>.supabase.co/functions/v1" \
+USER_JWT="<your-user-jwt>" \
+npm run probe:auth -- --base-url "$EDGE_BASE_URL"
+```
+
+默认行为：
+
+- 默认跳过仓库中标记为 disabled 的 `antchain_*` 和 legacy 非 `*_ft` embedding / webhook 入口
+- 默认跳过仅供本地辅助使用的 `embedding_ft_local`
+- 对其余函数至少发一轮无鉴权最小请求，并在有对应凭据时继续发 JWT / user API key / service API key 探测
+- 结果会区分：
+  - `gateway_invalid_jwt`：大概率是请求在进入函数前就被平台层拦住
+  - `function_auth_failed`：请求已进入函数，但函数内鉴权拒绝了该凭据
+  - `reachable_but_payload_invalid`：连通性和鉴权大概率没问题，只是最小 probe body 不满足业务校验
+
+常用参数：
+
+```bash
+# 只看 lca_* 这组
+npm run probe:auth -- --remote --only lca_
+
+# 把默认跳过的 disabled / local-only 入口也带上
+npm run probe:auth -- --remote --include-disabled --include-local-only
+
+# 输出 JSON 报告，方便留存对比
+npm run probe:auth -- --remote --json-out ./tmp/edge-probe-report.json
+
+# 不发请求，只看当前脚本会如何分类和选择鉴权方式
+npm run probe:auth -- --dry-run
+```
+
 ## OpenAI Integration Baseline
 
 - No LangChain dependency in active path.
@@ -373,6 +422,27 @@ npx --yes supabase@2.85.0 secrets set --env-file ./supabase/.env.local --project
 ### Deploy examples
 
 把同一批函数部署到 `dev` 时，把下面命令里的 `deploy:main` 改成 `deploy:dev` 即可。
+
+### Redeply
+
+整体重新部署
+
+```shell
+set -euo pipefail && \
+for fn in $(find supabase/functions -mindepth 1 -maxdepth 1 -type d \
+  ! -name '_shared' \
+  ! -name 'antchain_get_local_ip' \
+  ! -name 'antchain_sign_request' \
+  ! -name 'embedding_ft_local' \
+  -exec basename {} \; | sort); do
+  echo "==> deploy $fn"
+  supabase functions deploy "$fn" \
+    --project-ref culgbbvzltdodcpykupc \
+    --no-verify-jwt \
+    --use-api \
+    --import-map supabase/functions/deno.json
+done
+```
 
 #### Search Functions
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check": "node ./scripts/deno-check-all.cjs",
     "deploy:dev": "node ./scripts/deploy-function.cjs dev",
     "deploy:main": "node ./scripts/deploy-function.cjs main",
+    "probe:auth": "node ./scripts/probe-functions-auth.cjs",
     "lint": "prettier -c --write \"**/*.{cjs,js,jsx,tsx,ts,less,md,json,yml,yaml}\""
   },
   "devDependencies": {

--- a/scripts/probe-functions-auth.cjs
+++ b/scripts/probe-functions-auth.cjs
@@ -1,0 +1,718 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const functionsRoot = path.join(repoRoot, 'supabase', 'functions');
+
+const DISABLED_FUNCTIONS = new Set([
+  'embedding',
+  'webhook_flow_embedding',
+  'webhook_model_embedding',
+  'webhook_process_embedding',
+]);
+const LOCAL_ONLY_FUNCTIONS = new Set(['embedding_ft_local']);
+const DEFAULT_TIMEOUT_MS = 8000;
+const DEFAULT_CONCURRENCY = 4;
+const SUMMARY_ORDER = [
+  'ok',
+  'reachable_but_payload_invalid',
+  'reachable_other_client_error',
+  'legacy_removed',
+  'auth_required',
+  'gateway_invalid_jwt',
+  'function_auth_failed',
+  'not_deployed',
+  'server_error',
+  'network_error',
+  'skipped_missing_credential',
+];
+
+async function main() {
+  loadDefaultEnvFiles();
+
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const baseUrl = resolveBaseUrl(options);
+  if (!options.dryRun && !baseUrl) {
+    console.error(
+      'Missing base URL. Provide --base-url, --remote, --local, or set EDGE_BASE_URL / REMOTE_ENDPOINT / LOCAL_ENDPOINT.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const credentials = resolveCredentials();
+  const inventory = buildInventory({
+    includeDisabled: options.includeDisabled,
+    includeLocalOnly: options.includeLocalOnly,
+    onlyPatterns: options.onlyPatterns,
+  });
+
+  if (inventory.length === 0) {
+    console.error('No matching functions found for probing.');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Base URL: ${baseUrl ?? '(dry-run only)'}`);
+  console.log(
+    `Credentials: USER_JWT=${formatCredentialPresence(
+      credentials.userJwt,
+    )} USER_API_KEY=${formatCredentialPresence(
+      credentials.userApiKey,
+    )} SERVICE_API_KEY=${formatCredentialPresence(credentials.serviceApiKey)}`,
+  );
+  console.log(
+    `Functions: selected=${inventory.selected.length} total=${inventory.totalCount} default-filtered=${inventory.defaultFilteredCount} pattern-filtered=${inventory.patternFilteredCount}`,
+  );
+  console.log('');
+
+  if (options.dryRun) {
+    printDryRunPlan(inventory.selected, credentials);
+    return;
+  }
+
+  const results = await runWithConcurrency(
+    inventory.selected,
+    options.concurrency,
+    async (definition) =>
+      probeFunction(definition, {
+        baseUrl,
+        timeoutMs: options.timeoutMs,
+        credentials,
+      }),
+  );
+
+  printResults(results);
+
+  if (options.jsonOut) {
+    const outputPath = path.resolve(repoRoot, options.jsonOut);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(
+      outputPath,
+      JSON.stringify(
+        {
+          baseUrl,
+          generatedAt: new Date().toISOString(),
+          credentials: {
+            hasUserJwt: Boolean(credentials.userJwt),
+            hasUserApiKey: Boolean(credentials.userApiKey),
+            hasServiceApiKey: Boolean(credentials.serviceApiKey),
+          },
+          results,
+        },
+        null,
+        2,
+      ),
+    );
+    console.log('');
+    console.log(`JSON report written to ${outputPath}`);
+  }
+}
+
+function parseArgs(argv) {
+  const options = {
+    baseUrl: undefined,
+    remote: false,
+    local: false,
+    dryRun: false,
+    includeDisabled: false,
+    includeLocalOnly: false,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    concurrency: DEFAULT_CONCURRENCY,
+    onlyPatterns: [],
+    jsonOut: undefined,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--help' || argument === '-h') {
+      options.help = true;
+    } else if (argument === '--dry-run') {
+      options.dryRun = true;
+    } else if (argument === '--include-disabled') {
+      options.includeDisabled = true;
+    } else if (argument === '--include-local-only') {
+      options.includeLocalOnly = true;
+    } else if (argument === '--remote') {
+      options.remote = true;
+    } else if (argument === '--local') {
+      options.local = true;
+    } else if (argument === '--base-url') {
+      index += 1;
+      options.baseUrl = argv[index];
+    } else if (argument === '--timeout-ms') {
+      index += 1;
+      options.timeoutMs = parsePositiveInt(argv[index], '--timeout-ms');
+    } else if (argument === '--concurrency') {
+      index += 1;
+      options.concurrency = parsePositiveInt(argv[index], '--concurrency');
+    } else if (argument === '--only') {
+      index += 1;
+      options.onlyPatterns = splitPatterns(argv[index]);
+    } else if (argument === '--json-out') {
+      index += 1;
+      options.jsonOut = argv[index];
+    } else {
+      console.error(`Unknown argument: ${argument}`);
+      options.help = true;
+      process.exitCode = 1;
+      return options;
+    }
+  }
+
+  return options;
+}
+
+function parsePositiveInt(rawValue, flagName) {
+  const parsed = Number.parseInt(rawValue ?? '', 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${flagName} expects a positive integer, got: ${rawValue}`);
+  }
+  return parsed;
+}
+
+function splitPatterns(rawValue) {
+  return String(rawValue ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function printHelp() {
+  console.log(`Usage: npm run probe:auth -- [options]
+
+Options:
+  --remote                  Use REMOTE_ENDPOINT as the base URL.
+  --local                   Use LOCAL_ENDPOINT as the base URL.
+  --base-url <url>          Override the probe base URL.
+  --dry-run                 Print the planned probe matrix without sending requests.
+  --include-disabled        Include repo-marked disabled routes (antchain_*, legacy non-*_ft embedding/webhook).
+  --include-local-only      Include local-only helper routes such as embedding_ft_local.
+  --only <a,b>              Only probe function names containing one of the comma-separated fragments.
+  --timeout-ms <ms>         Per-request timeout in milliseconds. Default: ${DEFAULT_TIMEOUT_MS}.
+  --concurrency <n>         Parallel probes. Default: ${DEFAULT_CONCURRENCY}.
+  --json-out <path>         Write a JSON report relative to the repo root.
+  --help                    Show this help text.
+
+Environment variables:
+  EDGE_BASE_URL             Full functions base URL. Example: https://<project>.supabase.co/functions/v1
+  REMOTE_ENDPOINT           Existing repo env alias for a remote functions base URL.
+  LOCAL_ENDPOINT            Existing repo env alias for a local functions base URL.
+  USER_JWT                  Browser/user JWT used for JWT-protected functions.
+  USER_API_KEY              Optional user API key for functions that support it.
+  REMOTE_SERVICE_API_KEY    Optional service key for SERVICE_API_KEY routes.
+  SERVICE_API_KEY           Fallback service key env name.
+
+Classification hints:
+  gateway_invalid_jwt       The request was likely rejected before your function ran.
+  function_auth_failed      The request reached function runtime, but the function-side auth path rejected it.
+  reachable_but_payload_invalid
+                            Auth/connectivity is probably fine; the minimal probe body is not enough for business validation.
+`);
+}
+
+function loadDefaultEnvFiles() {
+  loadEnvFile(path.join(repoRoot, '.env'));
+  loadEnvFile(path.join(repoRoot, 'supabase', '.env.local'));
+}
+
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8');
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const normalizedLine = line.startsWith('export ') ? line.slice(7).trim() : line;
+    const equalsIndex = normalizedLine.indexOf('=');
+    if (equalsIndex <= 0) {
+      continue;
+    }
+
+    const key = normalizedLine.slice(0, equalsIndex).trim();
+    if (!key || process.env[key] !== undefined) {
+      continue;
+    }
+
+    let value = normalizedLine.slice(equalsIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    process.env[key] = value;
+  }
+}
+
+function resolveBaseUrl(options) {
+  const rawValue =
+    options.baseUrl ??
+    (options.remote ? process.env.REMOTE_ENDPOINT : undefined) ??
+    (options.local ? process.env.LOCAL_ENDPOINT : undefined) ??
+    process.env.EDGE_BASE_URL ??
+    process.env.BASE_URL ??
+    process.env.REMOTE_ENDPOINT ??
+    process.env.LOCAL_ENDPOINT;
+
+  if (!rawValue) {
+    return undefined;
+  }
+
+  const trimmed = rawValue.trim().replace(/\/+$/, '');
+  if (!trimmed) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!parsed.pathname || parsed.pathname === '/') {
+      return `${trimmed}/functions/v1`;
+    }
+  } catch (_error) {
+    return trimmed;
+  }
+
+  return trimmed;
+}
+
+function resolveCredentials() {
+  return {
+    userJwt: readEnv('USER_JWT'),
+    userApiKey: readEnv('USER_API_KEY'),
+    serviceApiKey: readEnv('REMOTE_SERVICE_API_KEY') ?? readEnv('SERVICE_API_KEY'),
+  };
+}
+
+function readEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function buildInventory({ includeDisabled, includeLocalOnly, onlyPatterns }) {
+  const entries = fs
+    .readdirSync(functionsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== '_shared')
+    .map((entry) => buildFunctionDefinition(entry.name));
+
+  const afterDefaultFilters = entries.filter((entry) => {
+    if (!includeDisabled && entry.defaultSkipped === 'disabled') {
+      return false;
+    }
+    if (!includeLocalOnly && entry.defaultSkipped === 'local_only') {
+      return false;
+    }
+    return true;
+  });
+
+  const selected = afterDefaultFilters.filter((entry) => {
+    if (onlyPatterns.length > 0 && !onlyPatterns.some((pattern) => entry.name.includes(pattern))) {
+      return false;
+    }
+    return true;
+  });
+
+  return {
+    selected,
+    totalCount: entries.length,
+    defaultFilteredCount: entries.length - afterDefaultFilters.length,
+    patternFilteredCount: afterDefaultFilters.length - selected.length,
+  };
+}
+
+function buildFunctionDefinition(name) {
+  const directory = path.join(functionsRoot, name);
+  const source = readFunctionSource(directory);
+  const authMethods = inferAuthMethods(source);
+  const preferredMethod = inferHttpMethod(source);
+  const isLegacyRemoved = source.includes('createLegacyEndpointRemovedHandler');
+  const isCommandRuntime =
+    source.includes('createCommandHandler') || source.includes('command_runtime/command.ts');
+
+  let defaultSkipped = null;
+  if (name.startsWith('antchain_') || DISABLED_FUNCTIONS.has(name)) {
+    defaultSkipped = 'disabled';
+  } else if (LOCAL_ONLY_FUNCTIONS.has(name)) {
+    defaultSkipped = 'local_only';
+  }
+
+  return {
+    name,
+    directory,
+    defaultSkipped,
+    authMethods,
+    preferredMethod,
+    isLegacyRemoved,
+    isCommandRuntime,
+  };
+}
+
+function readFunctionSource(directory) {
+  const files = [];
+  walkDirectory(directory, files);
+  return files
+    .filter((filePath) => filePath.endsWith('.ts') || filePath.endsWith('.js'))
+    .map((filePath) => fs.readFileSync(filePath, 'utf8'))
+    .join('\n');
+}
+
+function walkDirectory(directory, bucket) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      walkDirectory(fullPath, bucket);
+      continue;
+    }
+    bucket.push(fullPath);
+  }
+}
+
+function inferAuthMethods(source) {
+  if (source.includes('createLegacyEndpointRemovedHandler')) {
+    return [];
+  }
+
+  if (source.includes('createCommandHandler') || source.includes('command_runtime/command.ts')) {
+    return ['JWT'];
+  }
+
+  const discoveredMethods = new Set();
+  const matches = source.matchAll(/allowedMethods:\s*\[([\s\S]*?)\]/g);
+  for (const match of matches) {
+    const block = match[1];
+    for (const methodMatch of block.matchAll(/AuthMethod\.([A-Z_]+)/g)) {
+      discoveredMethods.add(methodMatch[1]);
+    }
+  }
+
+  if (discoveredMethods.size > 0) {
+    return ['JWT', 'USER_API_KEY', 'SERVICE_API_KEY'].filter((method) =>
+      discoveredMethods.has(method),
+    );
+  }
+
+  if (source.includes('authenticateRequest(')) {
+    return ['JWT', 'USER_API_KEY', 'SERVICE_API_KEY'];
+  }
+
+  return [];
+}
+
+function inferHttpMethod(source) {
+  if (source.includes('Only POST is supported')) {
+    return 'POST';
+  }
+  if (
+    source.includes("req.method !== 'GET' && req.method !== 'POST'") ||
+    source.includes('req.method !== "GET" && req.method !== "POST"')
+  ) {
+    return 'GET';
+  }
+  if (source.includes("req.method !== 'POST'") || source.includes('req.method !== "POST"')) {
+    return 'POST';
+  }
+  if (source.includes("req.method !== 'GET'") || source.includes('req.method !== "GET"')) {
+    return 'GET';
+  }
+  if (source.includes('expected POST request')) {
+    return 'POST';
+  }
+  return 'POST';
+}
+
+function formatCredentialPresence(value) {
+  return value ? 'yes' : 'no';
+}
+
+function buildProbeVariants(definition, credentials) {
+  const variants = [{ type: 'none', label: 'no-auth' }];
+
+  for (const method of definition.authMethods) {
+    if (method === 'JWT' && credentials.userJwt) {
+      variants.push({ type: 'JWT', label: 'jwt' });
+    } else if (method === 'USER_API_KEY' && credentials.userApiKey) {
+      variants.push({ type: 'USER_API_KEY', label: 'user-api-key' });
+    } else if (method === 'SERVICE_API_KEY' && credentials.serviceApiKey) {
+      variants.push({ type: 'SERVICE_API_KEY', label: 'service-api-key' });
+    }
+  }
+
+  const missing = definition.authMethods.filter((method) => {
+    if (method === 'JWT') {
+      return !credentials.userJwt;
+    }
+    if (method === 'USER_API_KEY') {
+      return !credentials.userApiKey;
+    }
+    if (method === 'SERVICE_API_KEY') {
+      return !credentials.serviceApiKey;
+    }
+    return false;
+  });
+
+  return { variants, missing };
+}
+
+function printDryRunPlan(inventory, credentials) {
+  for (const definition of inventory) {
+    const { variants, missing } = buildProbeVariants(definition, credentials);
+    const authLabel =
+      definition.authMethods.length > 0 ? definition.authMethods.join('|') : 'public-or-unknown';
+    const probeLabels = variants.map((variant) => variant.label).join(', ');
+    const missingLabel = missing.length > 0 ? ` missing=${missing.join('|')}` : '';
+    const defaultSkipLabel =
+      definition.defaultSkipped === 'disabled'
+        ? ' disabled-by-default'
+        : definition.defaultSkipped === 'local_only'
+          ? ' local-only-by-default'
+          : '';
+    console.log(
+      `${definition.name.padEnd(36)} method=${definition.preferredMethod.padEnd(
+        4,
+      )} auth=${authLabel.padEnd(28)} probes=${probeLabels}${missingLabel}${defaultSkipLabel}`,
+    );
+  }
+}
+
+async function probeFunction(definition, context) {
+  const { variants, missing } = buildProbeVariants(definition, context.credentials);
+  const probes = [];
+
+  for (const variant of variants) {
+    probes.push(await runProbe(definition, variant, context));
+  }
+
+  for (const missingMethod of missing) {
+    probes.push({
+      label: missingMethod.toLowerCase(),
+      variant: missingMethod,
+      skipped: true,
+      classification: 'skipped_missing_credential',
+      summary: `missing credential for ${missingMethod}`,
+    });
+  }
+
+  const primaryProbe =
+    probes.find((probe) => !probe.skipped && probe.variant !== 'none') ??
+    probes.find((probe) => !probe.skipped) ??
+    probes[0];
+
+  return {
+    ...definition,
+    probes,
+    primaryClassification: primaryProbe?.classification ?? 'skipped_missing_credential',
+  };
+}
+
+async function runProbe(definition, variant, context) {
+  const url = `${context.baseUrl}/${definition.name}`;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), context.timeoutMs);
+  const startedAt = Date.now();
+
+  const headers = { Accept: 'application/json' };
+  let body;
+
+  if (definition.preferredMethod === 'POST') {
+    headers['Content-Type'] = 'application/json';
+    body = JSON.stringify(getProbeBody(definition.name));
+  }
+
+  if (variant.type === 'JWT') {
+    headers.Authorization = `Bearer ${context.credentials.userJwt}`;
+  } else if (variant.type === 'USER_API_KEY') {
+    headers.Authorization = `Bearer ${context.credentials.userApiKey}`;
+  } else if (variant.type === 'SERVICE_API_KEY') {
+    headers.apikey = context.credentials.serviceApiKey;
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: definition.preferredMethod,
+      headers,
+      body,
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    const text = await response.text();
+    const excerpt = summarizeBody(text);
+    const classification = classifyResponse(response.status, text, variant.type);
+
+    return {
+      label: variant.label,
+      variant: variant.type,
+      skipped: false,
+      durationMs: Date.now() - startedAt,
+      status: response.status,
+      classification,
+      summary: excerpt,
+    };
+  } catch (error) {
+    clearTimeout(timeoutId);
+    const message =
+      error && typeof error === 'object' && 'name' in error && error.name === 'AbortError'
+        ? `request timed out after ${context.timeoutMs}ms`
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    return {
+      label: variant.label,
+      variant: variant.type,
+      skipped: false,
+      durationMs: Date.now() - startedAt,
+      classification: 'network_error',
+      summary: message,
+    };
+  }
+}
+
+function getProbeBody(functionName) {
+  if (
+    functionName === 'embedding' ||
+    functionName === 'embedding_ft' ||
+    functionName === 'embedding_ft_local'
+  ) {
+    return [];
+  }
+  return {};
+}
+
+function summarizeBody(text) {
+  const normalized = String(text ?? '')
+    .trim()
+    .replace(/\s+/g, ' ');
+  if (!normalized) {
+    return '(empty response body)';
+  }
+  return normalized.length > 160 ? `${normalized.slice(0, 157)}...` : normalized;
+}
+
+function classifyResponse(status, rawBody, variantType) {
+  const body = String(rawBody ?? '').toLowerCase();
+
+  if (status >= 200 && status < 300) {
+    return 'ok';
+  }
+  if (status === 404) {
+    return 'not_deployed';
+  }
+  if (status === 410 && body.includes('legacy_endpoint_removed')) {
+    return 'legacy_removed';
+  }
+  if (status === 401 || status === 403) {
+    if (body.includes('invalid jwt')) {
+      return 'gateway_invalid_jwt';
+    }
+    if (
+      body.includes('authentication required') ||
+      body.includes('unauthorized request') ||
+      body.includes('user not found') ||
+      body.includes('forbidden') ||
+      body.includes('unauthorized') ||
+      body.includes('invalid service api key') ||
+      body.includes('service api key not configured') ||
+      body.includes('auth client not configured')
+    ) {
+      return variantType === 'none' ? 'auth_required' : 'function_auth_failed';
+    }
+    return variantType === 'none' ? 'auth_required' : 'function_auth_failed';
+  }
+  if (status === 400 || status === 405 || status === 422) {
+    return 'reachable_but_payload_invalid';
+  }
+  if (status >= 500) {
+    return 'server_error';
+  }
+  return 'reachable_other_client_error';
+}
+
+function printResults(results) {
+  const counts = new Map();
+  for (const result of results) {
+    counts.set(result.primaryClassification, (counts.get(result.primaryClassification) ?? 0) + 1);
+  }
+
+  console.log('Summary');
+  for (const key of SUMMARY_ORDER) {
+    if (counts.has(key)) {
+      console.log(`  ${key.padEnd(28)} ${counts.get(key)}`);
+    }
+  }
+
+  console.log('');
+  console.log('Per function');
+  for (const result of results) {
+    const authLabel = result.authMethods.length > 0 ? result.authMethods.join('|') : 'PUBLIC';
+    const probeSummary = result.probes
+      .map((probe) => {
+        if (probe.skipped) {
+          return `${probe.label}=skip(${probe.summary})`;
+        }
+        const statusLabel = probe.status ?? '-';
+        return `${probe.label}=${statusLabel}/${probe.classification}`;
+      })
+      .join(' ');
+
+    console.log(
+      `${result.name.padEnd(36)} method=${result.preferredMethod.padEnd(4)} auth=${authLabel.padEnd(
+        28,
+      )} ${probeSummary}`,
+    );
+
+    for (const probe of result.probes) {
+      if (probe.summary) {
+        const prefix = probe.skipped ? 'skip' : probe.label;
+        console.log(`  - ${prefix}: ${probe.summary}`);
+      }
+    }
+  }
+
+  console.log('');
+  console.log('Legend');
+  console.log('  gateway_invalid_jwt: likely blocked before function runtime');
+  console.log('  function_auth_failed: function runtime rejected the provided credential');
+  console.log(
+    '  reachable_but_payload_invalid: function is reachable and auth likely passed, but the minimal probe body is insufficient',
+  );
+}
+
+async function runWithConcurrency(items, limit, worker) {
+  const results = new Array(items.length);
+  let cursor = 0;
+
+  async function runner() {
+    while (cursor < items.length) {
+      const current = cursor;
+      cursor += 1;
+      results[current] = await worker(items[current], current);
+    }
+  }
+
+  const runnerCount = Math.min(limit, items.length);
+  await Promise.all(Array.from({ length: runnerCount }, () => runner()));
+  return results;
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -9,7 +9,7 @@ import { authenticateCognitoToken } from './cognito_auth.ts';
 import { corsHeaders } from './cors.ts';
 import decodeApiKey from './decode_api_key.ts';
 import { type RedisClient, redisGet, redisSet } from './redis_client.ts';
-import { createSupabaseAuthClient } from './supabase_client.ts';
+import { createSupabaseAuthClient, getSupabaseUrl } from './supabase_client.ts';
 
 const _defaultAppMetadata: UserAppMetadata = {
   provider: '',
@@ -22,6 +22,7 @@ const _defaultUserMetadata: UserMetadata = {
 const _defaultAud = '';
 
 const _defaultCreatedAt = '';
+const textEncoder = new TextEncoder();
 
 function readOptionalEnv(name: string): string | undefined {
   const value = Deno.env.get(name);
@@ -67,6 +68,48 @@ function extractBearerToken(authHeader: string | null): string | undefined {
 
 function isJwtLikeToken(token: string): boolean {
   return JWT_PATTERN.test(token);
+}
+
+function createAuthResponse(message: string, status: number): Response {
+  return new Response(message, {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const message = Reflect.get(error, 'message');
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message;
+    }
+  }
+
+  return fallback;
+}
+
+function getErrorStatus(error: unknown, fallback: number): number {
+  if (typeof error === 'object' && error !== null) {
+    const status = Reflect.get(error, 'status');
+    if (typeof status === 'number' && Number.isFinite(status)) {
+      return status;
+    }
+  }
+
+  return fallback;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function createUserApiKeyCacheKey(email: string, password: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', textEncoder.encode(`${email}\0${password}`));
+  return `lca_${email}_${bytesToHex(new Uint8Array(digest))}`;
 }
 
 export interface AuthedUser extends User {
@@ -274,10 +317,7 @@ async function finalizeAuthResults(
 function authClientNotConfiguredResult(): AuthResult {
   return {
     isAuthenticated: false,
-    response: new Response('Auth client not configured', {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    }),
+    response: createAuthResponse('Auth client not configured', 500),
   };
 }
 
@@ -316,33 +356,46 @@ async function authenticateSupabaseJWT(
     return await authenticateCognitoToken(token);
   }
 
-  const { data: authData } = await supabase.auth.getUser(token);
-  console.log('Supabase JWT authentication result:', authData);
+  try {
+    const { data: authData, error } = await supabase.auth.getUser(token);
+    if (error) {
+      console.error('Supabase JWT authentication failed:', error);
+      return {
+        isAuthenticated: false,
+        response: createAuthResponse(
+          getErrorMessage(error, 'JWT authentication failed'),
+          getErrorStatus(error, 401),
+        ),
+      };
+    }
 
-  if (!authData?.user) {
+    console.log('Supabase JWT authentication result:', authData);
+
+    if (!authData?.user) {
+      return {
+        isAuthenticated: false,
+        response: createAuthResponse('User Not Found', 401),
+      };
+    }
+
+    if (authData.user.role !== 'authenticated') {
+      return {
+        isAuthenticated: false,
+        response: createAuthResponse('Forbidden', 403),
+      };
+    }
+
+    return {
+      isAuthenticated: true,
+      user: authData.user,
+    };
+  } catch (error) {
+    console.error('Supabase JWT authentication threw:', error);
     return {
       isAuthenticated: false,
-      response: new Response('User Not Found', {
-        status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }),
+      response: createAuthResponse(getErrorMessage(error, 'JWT authentication failed'), 500),
     };
   }
-
-  if (authData.user.role !== 'authenticated') {
-    return {
-      isAuthenticated: false,
-      response: new Response('Forbidden', {
-        status: 403,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }),
-    };
-  }
-
-  return {
-    isAuthenticated: true,
-    user: authData.user,
-  };
 }
 
 /**
@@ -364,7 +417,7 @@ async function authenticateUserApiKey(apiKey: string, redis: RedisClient): Promi
   }
 
   const { email = '', password = '' } = credentials;
-  const cacheKey = `lca_${email}`;
+  const cacheKey = await createUserApiKeyCacheKey(email, password);
   const cachedUserId = await redisGet(redis, cacheKey);
 
   if (cachedUserId) {
@@ -385,52 +438,68 @@ async function authenticateUserApiKey(apiKey: string, redis: RedisClient): Promi
   if (!authClient) {
     return {
       isAuthenticated: false,
-      response: new Response('Auth client not configured', {
-        status: 500,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }),
+      response: createAuthResponse('Auth client not configured', 500),
     };
   }
 
-  const { data, error } = await authClient.auth.signInWithPassword({
-    email: email,
-    password: password,
-  });
+  try {
+    const { data, error } = await authClient.auth.signInWithPassword({
+      email: email,
+      password: password,
+    });
 
-  if (error || !data.user) {
+    if (error) {
+      console.error('Supabase user API key sign-in failed:', error);
+      const status = getErrorStatus(error, 401);
+      return {
+        isAuthenticated: false,
+        response: createAuthResponse(
+          status >= 500
+            ? getErrorMessage(error, 'User API key authentication failed')
+            : 'Unauthorized',
+          status,
+        ),
+      };
+    }
+
+    if (!data.user) {
+      return {
+        isAuthenticated: false,
+        response: createAuthResponse('Unauthorized', 401),
+      };
+    }
+
+    if (data.user.role !== 'authenticated') {
+      return {
+        isAuthenticated: false,
+        response: createAuthResponse('You are not an authenticated user.', 401),
+      };
+    }
+
+    // Cache the user ID for 1 hour.
+    await redisSet(redis, cacheKey, data.user.id, { ex: 3600 });
+
+    return {
+      isAuthenticated: true,
+      user: {
+        id: data.user.id,
+        email: data.user.email,
+        app_metadata: _defaultAppMetadata,
+        user_metadata: _defaultUserMetadata,
+        aud: _defaultAud,
+        created_at: _defaultCreatedAt,
+      },
+    };
+  } catch (error) {
+    console.error('Supabase user API key sign-in threw:', error);
     return {
       isAuthenticated: false,
-      response: new Response('Unauthorized', {
-        status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }),
+      response: createAuthResponse(
+        getErrorMessage(error, 'User API key authentication failed'),
+        500,
+      ),
     };
   }
-
-  if (data.user.role !== 'authenticated') {
-    return {
-      isAuthenticated: false,
-      response: new Response('You are not an authenticated user.', {
-        status: 401,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }),
-    };
-  }
-
-  // Cache the user ID for 1 hour.
-  await redisSet(redis, cacheKey, data.user.id, { ex: 3600 });
-
-  return {
-    isAuthenticated: true,
-    user: {
-      id: data.user.id,
-      email: data.user.email,
-      app_metadata: _defaultAppMetadata,
-      user_metadata: _defaultUserMetadata,
-      aud: _defaultAud,
-      created_at: _defaultCreatedAt,
-    },
-  };
 }
 
 function createAuthClientForUserApiKey(): SupabaseClient | null {
@@ -502,7 +571,6 @@ export function handleCors(req: Request): Response | null {
  */
 export async function createAuthenticatedSupabaseClient(apiKey: string): Promise<SupabaseClient> {
   const { createClient } = await import('jsr:@supabase/supabase-js@2.98.0');
-  const supabaseUrl =
-    readOptionalEnv('REMOTE_SUPABASE_URL') ?? readOptionalEnv('SUPABASE_URL') ?? '';
+  const supabaseUrl = getSupabaseUrl();
   return createClient(supabaseUrl, apiKey);
 }

--- a/supabase/functions/_shared/supabase_client.ts
+++ b/supabase/functions/_shared/supabase_client.ts
@@ -14,8 +14,6 @@ function readEnv(name: string): string | undefined {
   }
 }
 
-const FALLBACK_SUPABASE_URL = 'http://127.0.0.1:54321';
-const FALLBACK_SUPABASE_KEY = 'placeholder-key';
 const SHARED_CLIENT_OPTIONS = {
   auth: {
     autoRefreshToken: false,
@@ -24,27 +22,60 @@ const SHARED_CLIENT_OPTIONS = {
   },
 };
 
+const SUPABASE_URL_ENV_NAMES = ['REMOTE_SUPABASE_URL', 'SUPABASE_URL'];
+const SUPABASE_SERVICE_KEY_ENV_NAMES = [
+  'REMOTE_SUPABASE_SERVICE_ROLE_KEY',
+  'REMOTE_SUPABASE_SECRET_KEY',
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'SUPABASE_SECRET_KEY',
+];
+const SUPABASE_PUBLISHABLE_KEY_ENV_NAMES = [
+  'REMOTE_SUPABASE_PUBLISHABLE_KEY',
+  'REMOTE_SUPABASE_ANON_KEY',
+  'SUPABASE_PUBLISHABLE_KEY',
+  'SUPABASE_ANON_KEY',
+];
+
+function requireFirstDefinedEnv(candidates: string[], label: string): string {
+  for (const name of candidates) {
+    const value = readEnv(name);
+    if (value) {
+      return value;
+    }
+  }
+
+  throw new Error(`Missing ${label}. Set one of: ${candidates.join(', ')}`);
+}
+
+// Avoid silently targeting localhost or placeholder credentials when runtime env is missing.
+// Some unit tests import handlers before injecting deps, so delay client construction until first use.
+function createDeferredClient(factory: () => SupabaseClient): SupabaseClient {
+  let client: SupabaseClient | undefined;
+
+  return new Proxy({} as SupabaseClient, {
+    get(_target, property) {
+      client ??= factory();
+      const value = Reflect.get(client as unknown as object, property);
+      return typeof value === 'function' ? value.bind(client) : value;
+    },
+  });
+}
+
 export function getSupabaseUrl(): string {
-  return readEnv('REMOTE_SUPABASE_URL') ?? readEnv('SUPABASE_URL') ?? FALLBACK_SUPABASE_URL;
+  return requireFirstDefinedEnv(SUPABASE_URL_ENV_NAMES, 'Supabase URL');
 }
 
 export function getSupabaseServiceRoleKey(): string {
-  return (
-    readEnv('REMOTE_SUPABASE_SERVICE_ROLE_KEY') ??
-    readEnv('REMOTE_SUPABASE_SECRET_KEY') ??
-    readEnv('SUPABASE_SERVICE_ROLE_KEY') ??
-    readEnv('SUPABASE_SECRET_KEY') ??
-    FALLBACK_SUPABASE_KEY
+  return requireFirstDefinedEnv(
+    SUPABASE_SERVICE_KEY_ENV_NAMES,
+    'Supabase service-role or secret key',
   );
 }
 
 export function getSupabasePublishableKey(): string {
-  return (
-    readEnv('REMOTE_SUPABASE_PUBLISHABLE_KEY') ??
-    readEnv('REMOTE_SUPABASE_ANON_KEY') ??
-    readEnv('SUPABASE_PUBLISHABLE_KEY') ??
-    readEnv('SUPABASE_ANON_KEY') ??
-    FALLBACK_SUPABASE_KEY
+  return requireFirstDefinedEnv(
+    SUPABASE_PUBLISHABLE_KEY_ENV_NAMES,
+    'Supabase publishable or anon key',
   );
 }
 
@@ -69,8 +100,8 @@ export function createRequestSupabaseClient(accessToken?: string): SupabaseClien
   });
 }
 
-export const supabaseAuthClient = createSupabaseAuthClient();
-export const supabaseServiceClient = createSupabaseServiceClient();
+export const supabaseAuthClient = createDeferredClient(createSupabaseAuthClient);
+export const supabaseServiceClient = createDeferredClient(createSupabaseServiceClient);
 
 // Backward-compatible aliases for existing service-role call sites.
 export const getServiceRoleKey = getSupabaseServiceRoleKey;

--- a/test/auth_test.ts
+++ b/test/auth_test.ts
@@ -1,8 +1,10 @@
-import { assertEquals } from 'jsr:@std/assert';
+import { assertEquals, assertRejects } from 'jsr:@std/assert';
 
 const MODULE_PATH = '../supabase/functions/_shared/auth.ts';
 const TEST_PUBLISHABLE_KEY = 'sb_publishable_test_key';
 const TEST_SERVICE_API_KEY = 'service-secret';
+const TEST_USER_EMAIL = 'user@example.com';
+const TEST_USER_PASSWORD = 'secret-password';
 
 function restoreEnvVar(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -38,6 +40,18 @@ async function withEnv<T>(
 
 async function importAuthModule() {
   return await import(`${MODULE_PATH}?case=${crypto.randomUUID()}`);
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function createExpectedUserApiCacheKey(email: string, password: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(`${email}\0${password}`),
+  );
+  return `lca_${email}_${bytesToHex(new Uint8Array(digest))}`;
 }
 
 Deno.test(
@@ -105,6 +119,46 @@ Deno.test(
 );
 
 Deno.test(
+  'jwt auth surfaces upstream auth-client errors instead of masking them as missing users',
+  async () => {
+    await withEnv(
+      {
+        SERVICE_API_KEY: TEST_SERVICE_API_KEY,
+        SUPABASE_ANON_KEY: TEST_PUBLISHABLE_KEY,
+      },
+      async () => {
+        const module = await importAuthModule();
+        const req = new Request('https://example.com', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer header.payload.signature',
+          },
+        });
+
+        const result = await module.authenticateRequest(req, {
+          authClient: {
+            auth: {
+              getUser: async () => ({
+                data: { user: null },
+                error: {
+                  message: 'Invalid JWT secret / wrong project',
+                  status: 401,
+                },
+              }),
+            },
+          } as any,
+          allowedMethods: [module.AuthMethod.JWT],
+        });
+
+        assertEquals(result.isAuthenticated, false);
+        assertEquals(result.response?.status, 401);
+        assertEquals(await result.response?.text(), 'Invalid JWT secret / wrong project');
+      },
+    );
+  },
+);
+
+Deno.test(
   'jwt-like bearer tokens use JWT auth instead of user API key auth when both are allowed',
   async () => {
     await withEnv(
@@ -166,6 +220,63 @@ Deno.test('jwt auth returns a server error when authClient wiring is missing', a
 });
 
 Deno.test(
+  'createAuthenticatedSupabaseClient fails fast when Supabase URL env is missing',
+  async () => {
+    await withEnv(
+      {
+        REMOTE_SUPABASE_URL: undefined,
+        SUPABASE_URL: undefined,
+      },
+      async () => {
+        const module = await importAuthModule();
+
+        await assertRejects(
+          () => module.createAuthenticatedSupabaseClient('service-secret'),
+          Error,
+          'Missing Supabase URL',
+        );
+      },
+    );
+  },
+);
+
+Deno.test('user API key cache key includes the password-derived hash', async () => {
+  const expectedCacheKey = await createExpectedUserApiCacheKey(TEST_USER_EMAIL, TEST_USER_PASSWORD);
+  let seenCacheKey: string | undefined;
+
+  const module = await importAuthModule();
+  const bearerToken = btoa(
+    JSON.stringify({
+      email: TEST_USER_EMAIL,
+      password: TEST_USER_PASSWORD,
+    }),
+  );
+
+  const result = await module.authenticateRequest(
+    new Request('https://example.com', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${bearerToken}`,
+      },
+    }),
+    {
+      redis: {
+        get: async (key: string) => {
+          seenCacheKey = key;
+          return 'cached-user-id';
+        },
+        set: async () => undefined,
+      } as any,
+      allowedMethods: [module.AuthMethod.USER_API_KEY],
+    },
+  );
+
+  assertEquals(result.isAuthenticated, true);
+  assertEquals(seenCacheKey, expectedCacheKey);
+  assertEquals(seenCacheKey === `lca_${TEST_USER_EMAIL}`, false);
+});
+
+Deno.test(
   'user API key auth signs in with the publishable Supabase key instead of SERVICE_API_KEY',
   async () => {
     await withEnv(
@@ -178,6 +289,12 @@ Deno.test(
         const module = await importAuthModule();
         const originalFetch = globalThis.fetch;
         const fetchCalls: Request[] = [];
+        const expectedCacheKey = await createExpectedUserApiCacheKey(
+          TEST_USER_EMAIL,
+          TEST_USER_PASSWORD,
+        );
+        let cacheGetKey: string | undefined;
+        let cacheSetKey: string | undefined;
 
         globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
           const request = new Request(input, init);
@@ -190,7 +307,7 @@ Deno.test(
               expires_in: 3600,
               user: {
                 id: '11111111-1111-4111-8111-111111111111',
-                email: 'user@example.com',
+                email: TEST_USER_EMAIL,
                 role: 'authenticated',
                 aud: 'authenticated',
                 app_metadata: { provider: 'email' },
@@ -210,8 +327,8 @@ Deno.test(
         try {
           const bearerToken = btoa(
             JSON.stringify({
-              email: 'user@example.com',
-              password: 'secret-password',
+              email: TEST_USER_EMAIL,
+              password: TEST_USER_PASSWORD,
             }),
           );
 
@@ -224,8 +341,14 @@ Deno.test(
             }),
             {
               redis: {
-                get: async () => null,
-                set: async () => undefined,
+                get: async (key: string) => {
+                  cacheGetKey = key;
+                  return null;
+                },
+                set: async (key: string) => {
+                  cacheSetKey = key;
+                  return undefined;
+                },
               } as any,
               allowedMethods: [module.AuthMethod.USER_API_KEY],
             },
@@ -236,6 +359,8 @@ Deno.test(
           assertEquals(fetchCalls[0].url.includes('/auth/v1/token'), true);
           assertEquals(fetchCalls[0].headers.get('apikey'), TEST_PUBLISHABLE_KEY);
           assertEquals(fetchCalls[0].headers.get('apikey') === TEST_SERVICE_API_KEY, false);
+          assertEquals(cacheGetKey, expectedCacheKey);
+          assertEquals(cacheSetKey, expectedCacheKey);
         } finally {
           globalThis.fetch = originalFetch;
         }

--- a/test/supabase_client_test.ts
+++ b/test/supabase_client_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from 'jsr:@std/assert';
+import { assertEquals, assertThrows } from 'jsr:@std/assert';
 
 const MODULE_PATH = '../supabase/functions/_shared/supabase_client.ts';
 const TEST_SUPABASE_URL = 'https://example.supabase.co';
@@ -70,6 +70,47 @@ Deno.test('shared Supabase client falls back when remote env vars are blank', as
       if (!module.createRequestSupabaseClient()) {
         throw new Error('expected request-scoped client to be created');
       }
+    },
+  );
+});
+
+Deno.test('shared Supabase client fails fast when all Supabase env vars are missing', async () => {
+  await withSupabaseEnv(
+    {
+      REMOTE_SUPABASE_URL: undefined,
+      SUPABASE_URL: undefined,
+      REMOTE_SUPABASE_SERVICE_ROLE_KEY: undefined,
+      REMOTE_SUPABASE_SECRET_KEY: undefined,
+      SUPABASE_SERVICE_ROLE_KEY: undefined,
+      SUPABASE_SECRET_KEY: undefined,
+      REMOTE_SUPABASE_PUBLISHABLE_KEY: undefined,
+      REMOTE_SUPABASE_ANON_KEY: undefined,
+      SUPABASE_PUBLISHABLE_KEY: undefined,
+      SUPABASE_ANON_KEY: undefined,
+    },
+    async () => {
+      const module = await importSupabaseClientModule();
+
+      assertThrows(() => module.getSupabaseUrl(), Error, 'Missing Supabase URL');
+      assertThrows(
+        () => module.getSupabaseServiceRoleKey(),
+        Error,
+        'Missing Supabase service-role or secret key',
+      );
+      assertThrows(
+        () => module.getSupabasePublishableKey(),
+        Error,
+        'Missing Supabase publishable or anon key',
+      );
+
+      assertThrows(() => module.createRequestSupabaseClient(), Error, 'Missing Supabase URL');
+      assertThrows(
+        () => {
+          void module.supabaseAuthClient.auth;
+        },
+        Error,
+        'Missing Supabase URL',
+      );
     },
   );
 });


### PR DESCRIPTION
Closes linancn/tiangong-lca-edge-functions#76

## Summary
- Expose actionable upstream JWT and user-api-key auth failures instead of flattening them into misleading generic responses.
- Require explicit Supabase runtime envs in shared clients and remove silent localhost or placeholder fallbacks.
- Add a repo-level edge auth probe command plus docs, and tighten USER_API_KEY Redis cache identity with a password-derived hash.

## Key Decisions
- Keep the deployed no-verify-jwt gateway policy unchanged and harden only the function-runtime auth boundary.
- Preserve the USER_API_KEY Redis fast path, but make cache hits depend on both email and password without storing plaintext passwords in Redis keys.
- Use deferred shared Supabase client construction so import-time test wiring still works while first use fails fast on missing envs.

## Validation
- npm run lint
- npm run check
- deno test --config supabase/functions/deno.json --allow-env --allow-net --allow-read test/auth_test.ts test/supabase_client_test.ts test/auth_client_wiring_test.ts
- node ./scripts/probe-functions-auth.cjs --help

## Risks / Rollback
- The probe script classifications are heuristic and meant for auth triage, not as a substitute for business-level endpoint validation.

## Follow-ups
- Redeploy the affected functions to dev if you want the hardened auth behavior and probe tooling to be reflected remotely immediately.
- Track the later lca-workspace submodule bump after this repo-level PR merges.

## Workspace Integration
- Requires a later lca-workspace submodule pointer bump after merge.