### PR TITLE
chore: align repo files with prettier baseline

### DIFF
--- a/supabase/functions/_shared/commands/dataset/create.ts
+++ b/supabase/functions/_shared/commands/dataset/create.ts
@@ -1,12 +1,9 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
-import { assertCreatePolicy } from "./policy.ts";
-import {
-  createDatasetCommandRepository,
-  type DatasetCommandRepository,
-} from "./repository.ts";
-import type { CreateRequest, DatasetCommandExecutionResult } from "./types.ts";
-import { createRequestSchema, parseCreateRequest } from "./validation.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
+import { assertCreatePolicy } from './policy.ts';
+import { createDatasetCommandRepository, type DatasetCommandRepository } from './repository.ts';
+import type { CreateRequest, DatasetCommandExecutionResult } from './types.ts';
+import { createRequestSchema, parseCreateRequest } from './validation.ts';
 
 export { createRequestSchema };
 
@@ -17,9 +14,7 @@ export function parseCreateCommand(body: unknown) {
 export async function executeCreateCommand(
   request: CreateRequest,
   actor: ActorContext,
-  repository: DatasetCommandRepository = createDatasetCommandRepository(
-    actor.supabase,
-  ),
+  repository: DatasetCommandRepository = createDatasetCommandRepository(actor.supabase),
 ): Promise<DatasetCommandExecutionResult> {
   const policy = assertCreatePolicy(request);
   if (!policy.ok) {
@@ -27,11 +22,11 @@ export async function executeCreateCommand(
   }
 
   const audit = buildCommandAuditPayload({
-    command: "dataset_create",
+    command: 'dataset_create',
     actorUserId: actor.userId,
     targetTable: request.table,
     targetId: request.id,
-    targetVersion: "",
+    targetVersion: '',
     payload: request.modelId ? { modelId: request.modelId } : {},
   });
 
@@ -45,7 +40,7 @@ export async function executeCreateCommand(
     status: 200,
     body: {
       ok: true,
-      command: "dataset_create",
+      command: 'dataset_create',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/dataset/delete.ts
+++ b/supabase/functions/_shared/commands/dataset/delete.ts
@@ -1,12 +1,9 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
-import { assertDeletePolicy } from "./policy.ts";
-import {
-  createDatasetCommandRepository,
-  type DatasetCommandRepository,
-} from "./repository.ts";
-import type { DatasetCommandExecutionResult, DeleteRequest } from "./types.ts";
-import { deleteRequestSchema, parseDeleteRequest } from "./validation.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
+import { assertDeletePolicy } from './policy.ts';
+import { createDatasetCommandRepository, type DatasetCommandRepository } from './repository.ts';
+import type { DatasetCommandExecutionResult, DeleteRequest } from './types.ts';
+import { deleteRequestSchema, parseDeleteRequest } from './validation.ts';
 
 export { deleteRequestSchema };
 
@@ -17,9 +14,7 @@ export function parseDeleteCommand(body: unknown) {
 export async function executeDeleteCommand(
   request: DeleteRequest,
   actor: ActorContext,
-  repository: DatasetCommandRepository = createDatasetCommandRepository(
-    actor.supabase,
-  ),
+  repository: DatasetCommandRepository = createDatasetCommandRepository(actor.supabase),
 ): Promise<DatasetCommandExecutionResult> {
   const policy = assertDeletePolicy(request);
   if (!policy.ok) {
@@ -27,7 +22,7 @@ export async function executeDeleteCommand(
   }
 
   const audit = buildCommandAuditPayload({
-    command: "dataset_delete",
+    command: 'dataset_delete',
     actorUserId: actor.userId,
     targetTable: request.table,
     targetId: request.id,
@@ -45,7 +40,7 @@ export async function executeDeleteCommand(
     status: 200,
     body: {
       ok: true,
-      command: "dataset_delete",
+      command: 'dataset_delete',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/dataset/policy.ts
+++ b/supabase/functions/_shared/commands/dataset/policy.ts
@@ -6,7 +6,7 @@ import type {
   PublishRequest,
   SaveDraftRequest,
   SubmitReviewRequest,
-} from "./types.ts";
+} from './types.ts';
 
 function invalidInput(code: string, message: string): DatasetCommandFailure {
   return {
@@ -20,32 +20,28 @@ function invalidInput(code: string, message: string): DatasetCommandFailure {
 export function assertSaveDraftPolicy(
   request: SaveDraftRequest,
 ): { ok: true } | DatasetCommandFailure {
-  if (request.table !== "processes" && request.modelId) {
+  if (request.table !== 'processes' && request.modelId) {
     return invalidInput(
-      "MODEL_ID_NOT_ALLOWED",
-      "modelId is only allowed for process dataset drafts",
+      'MODEL_ID_NOT_ALLOWED',
+      'modelId is only allowed for process dataset drafts',
     );
   }
 
   return { ok: true };
 }
 
-export function assertCreatePolicy(
-  request: CreateRequest,
-): { ok: true } | DatasetCommandFailure {
-  if (request.table !== "processes" && request.modelId) {
+export function assertCreatePolicy(request: CreateRequest): { ok: true } | DatasetCommandFailure {
+  if (request.table !== 'processes' && request.modelId) {
     return invalidInput(
-      "MODEL_ID_NOT_ALLOWED",
-      "modelId is only allowed for process dataset creates",
+      'MODEL_ID_NOT_ALLOWED',
+      'modelId is only allowed for process dataset creates',
     );
   }
 
   return { ok: true };
 }
 
-export function assertDeletePolicy(
-  _request: DeleteRequest,
-): { ok: true } | DatasetCommandFailure {
+export function assertDeletePolicy(_request: DeleteRequest): { ok: true } | DatasetCommandFailure {
   return { ok: true };
 }
 

--- a/supabase/functions/_shared/commands/dataset/repository.ts
+++ b/supabase/functions/_shared/commands/dataset/repository.ts
@@ -1,6 +1,6 @@
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import type { CommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { CommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   callDatasetAssignTeamRpc,
   callDatasetCreateRpc,
@@ -9,7 +9,7 @@ import {
   callDatasetSaveDraftRpc,
   callDatasetSubmitReviewRpc,
   type DatasetRpcResult,
-} from "../../db_rpc/dataset_commands.ts";
+} from '../../db_rpc/dataset_commands.ts';
 import type {
   AssignTeamRequest,
   CreateRequest,
@@ -17,63 +17,39 @@ import type {
   PublishRequest,
   SaveDraftRequest,
   SubmitReviewRequest,
-} from "./types.ts";
+} from './types.ts';
 
-type RpcClient = Pick<SupabaseClient, "rpc">;
+type RpcClient = Pick<SupabaseClient, 'rpc'>;
 
 export type DatasetCommandRepository = {
-  create: (
-    request: CreateRequest,
-    audit: CommandAuditPayload,
-  ) => Promise<DatasetRpcResult>;
-  delete: (
-    request: DeleteRequest,
-    audit: CommandAuditPayload,
-  ) => Promise<DatasetRpcResult>;
-  saveDraft: (
-    request: SaveDraftRequest,
-    audit: CommandAuditPayload,
-  ) => Promise<DatasetRpcResult>;
-  assignTeam: (
-    request: AssignTeamRequest,
-    audit: CommandAuditPayload,
-  ) => Promise<DatasetRpcResult>;
-  publish: (
-    request: PublishRequest,
-    audit: CommandAuditPayload,
-  ) => Promise<DatasetRpcResult>;
+  create: (request: CreateRequest, audit: CommandAuditPayload) => Promise<DatasetRpcResult>;
+  delete: (request: DeleteRequest, audit: CommandAuditPayload) => Promise<DatasetRpcResult>;
+  saveDraft: (request: SaveDraftRequest, audit: CommandAuditPayload) => Promise<DatasetRpcResult>;
+  assignTeam: (request: AssignTeamRequest, audit: CommandAuditPayload) => Promise<DatasetRpcResult>;
+  publish: (request: PublishRequest, audit: CommandAuditPayload) => Promise<DatasetRpcResult>;
   submitReview: (
     request: SubmitReviewRequest,
     audit: CommandAuditPayload,
   ) => Promise<DatasetRpcResult>;
 };
 
-function requireExplicitClient(
-  supabase: RpcClient | null | undefined,
-): RpcClient {
-  if (!supabase || typeof supabase.rpc !== "function") {
-    throw new Error(
-      "Dataset command repository requires an explicit Supabase client",
-    );
+function requireExplicitClient(supabase: RpcClient | null | undefined): RpcClient {
+  if (!supabase || typeof supabase.rpc !== 'function') {
+    throw new Error('Dataset command repository requires an explicit Supabase client');
   }
 
   return supabase;
 }
 
-export function createDatasetCommandRepository(
-  supabase: RpcClient,
-): DatasetCommandRepository {
+export function createDatasetCommandRepository(supabase: RpcClient): DatasetCommandRepository {
   const client = requireExplicitClient(supabase);
 
   return {
     create: (request, audit) => callDatasetCreateRpc(client, request, audit),
     delete: (request, audit) => callDatasetDeleteRpc(client, request, audit),
-    saveDraft: (request, audit) =>
-      callDatasetSaveDraftRpc(client, request, audit),
-    assignTeam: (request, audit) =>
-      callDatasetAssignTeamRpc(client, request, audit),
+    saveDraft: (request, audit) => callDatasetSaveDraftRpc(client, request, audit),
+    assignTeam: (request, audit) => callDatasetAssignTeamRpc(client, request, audit),
     publish: (request, audit) => callDatasetPublishRpc(client, request, audit),
-    submitReview: (request, audit) =>
-      callDatasetSubmitReviewRpc(client, request, audit),
+    submitReview: (request, audit) => callDatasetSubmitReviewRpc(client, request, audit),
   };
 }

--- a/supabase/functions/_shared/commands/dataset/types.ts
+++ b/supabase/functions/_shared/commands/dataset/types.ts
@@ -1,11 +1,11 @@
 export const DATASET_TABLES = [
-  "contacts",
-  "sources",
-  "unitgroups",
-  "flowproperties",
-  "flows",
-  "processes",
-  "lifecyclemodels",
+  'contacts',
+  'sources',
+  'unitgroups',
+  'flowproperties',
+  'flows',
+  'processes',
+  'lifecyclemodels',
 ] as const;
 
 export type DatasetTable = (typeof DATASET_TABLES)[number];

--- a/supabase/functions/_shared/commands/dataset/validation.ts
+++ b/supabase/functions/_shared/commands/dataset/validation.ts
@@ -1,6 +1,6 @@
-import { z } from "zod";
+import { z } from 'zod';
 
-import type { CommandParseResult } from "../../command_runtime/command.ts";
+import type { CommandParseResult } from '../../command_runtime/command.ts';
 import {
   type AssignTeamRequest,
   type CreateRequest,
@@ -9,16 +9,13 @@ import {
   type PublishRequest,
   type SaveDraftRequest,
   type SubmitReviewRequest,
-} from "./types.ts";
+} from './types.ts';
 
 const versionPattern = /^\d{2}\.\d{2}\.\d{3}$/;
 
 const datasetTableSchema = z.enum(DATASET_TABLES);
 const datasetIdSchema = z.string().uuid();
-const versionSchema = z.string().regex(
-  versionPattern,
-  "version must be in 00.00.000 format",
-);
+const versionSchema = z.string().regex(versionPattern, 'version must be in 00.00.000 format');
 
 const datasetIdTableSchema = z
   .object({
@@ -60,10 +57,7 @@ export const assignTeamRequestSchema = datasetBaseRequestSchema
 export const publishRequestSchema = datasetBaseRequestSchema.strict();
 export const submitReviewRequestSchema = datasetBaseRequestSchema.strict();
 
-function invalidPayload<T>(
-  message: string,
-  error: z.ZodError,
-): CommandParseResult<T> {
+function invalidPayload<T>(message: string, error: z.ZodError): CommandParseResult<T> {
   return {
     ok: false,
     message,
@@ -71,12 +65,10 @@ function invalidPayload<T>(
   };
 }
 
-export function parseSaveDraftRequest(
-  body: unknown,
-): CommandParseResult<SaveDraftRequest> {
+export function parseSaveDraftRequest(body: unknown): CommandParseResult<SaveDraftRequest> {
   const parsed = saveDraftRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid dataset save draft payload", parsed.error);
+    return invalidPayload('Invalid dataset save draft payload', parsed.error);
   }
 
   return {
@@ -85,12 +77,10 @@ export function parseSaveDraftRequest(
   };
 }
 
-export function parseCreateRequest(
-  body: unknown,
-): CommandParseResult<CreateRequest> {
+export function parseCreateRequest(body: unknown): CommandParseResult<CreateRequest> {
   const parsed = createRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid dataset create payload", parsed.error);
+    return invalidPayload('Invalid dataset create payload', parsed.error);
   }
 
   return {
@@ -99,12 +89,10 @@ export function parseCreateRequest(
   };
 }
 
-export function parseDeleteRequest(
-  body: unknown,
-): CommandParseResult<DeleteRequest> {
+export function parseDeleteRequest(body: unknown): CommandParseResult<DeleteRequest> {
   const parsed = deleteRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid dataset delete payload", parsed.error);
+    return invalidPayload('Invalid dataset delete payload', parsed.error);
   }
 
   return {
@@ -113,12 +101,10 @@ export function parseDeleteRequest(
   };
 }
 
-export function parseAssignTeamRequest(
-  body: unknown,
-): CommandParseResult<AssignTeamRequest> {
+export function parseAssignTeamRequest(body: unknown): CommandParseResult<AssignTeamRequest> {
   const parsed = assignTeamRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid dataset assign-team payload", parsed.error);
+    return invalidPayload('Invalid dataset assign-team payload', parsed.error);
   }
 
   return {
@@ -127,12 +113,10 @@ export function parseAssignTeamRequest(
   };
 }
 
-export function parsePublishRequest(
-  body: unknown,
-): CommandParseResult<PublishRequest> {
+export function parsePublishRequest(body: unknown): CommandParseResult<PublishRequest> {
   const parsed = publishRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid dataset publish payload", parsed.error);
+    return invalidPayload('Invalid dataset publish payload', parsed.error);
   }
 
   return {
@@ -141,15 +125,10 @@ export function parsePublishRequest(
   };
 }
 
-export function parseSubmitReviewRequest(
-  body: unknown,
-): CommandParseResult<SubmitReviewRequest> {
+export function parseSubmitReviewRequest(body: unknown): CommandParseResult<SubmitReviewRequest> {
   const parsed = submitReviewRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload(
-      "Invalid dataset submit-review payload",
-      parsed.error,
-    );
+    return invalidPayload('Invalid dataset submit-review payload', parsed.error);
   }
 
   return {

--- a/supabase/functions/_shared/commands/membership/accept_invitation.ts
+++ b/supabase/functions/_shared/commands/membership/accept_invitation.ts
@@ -1,14 +1,11 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   createMembershipCommandRepository,
   type MembershipCommandRepository,
-} from "./repository.ts";
-import type {
-  MembershipCommandExecutionResult,
-  TeamInvitationDecisionRequest,
-} from "./types.ts";
-import { parseTeamInvitationDecisionRequest } from "./validation.ts";
+} from './repository.ts';
+import type { MembershipCommandExecutionResult, TeamInvitationDecisionRequest } from './types.ts';
+import { parseTeamInvitationDecisionRequest } from './validation.ts';
 
 export function parseTeamAcceptInvitationCommand(body: unknown) {
   return parseTeamInvitationDecisionRequest(body);
@@ -17,14 +14,12 @@ export function parseTeamAcceptInvitationCommand(body: unknown) {
 export async function executeTeamAcceptInvitationCommand(
   request: TeamInvitationDecisionRequest,
   actor: ActorContext,
-  repository: MembershipCommandRepository = createMembershipCommandRepository(
-    actor.supabase,
-  ),
+  repository: MembershipCommandRepository = createMembershipCommandRepository(actor.supabase),
 ): Promise<MembershipCommandExecutionResult> {
   const audit = buildCommandAuditPayload({
-    command: "team_accept_invitation",
+    command: 'team_accept_invitation',
     actorUserId: actor.userId,
-    targetTable: "roles",
+    targetTable: 'roles',
     targetId: actor.userId,
     targetVersion: request.teamId,
     payload: {
@@ -42,7 +37,7 @@ export async function executeTeamAcceptInvitationCommand(
     status: 200,
     body: {
       ok: true,
-      command: "team_accept_invitation",
+      command: 'team_accept_invitation',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/membership/change_role.ts
+++ b/supabase/functions/_shared/commands/membership/change_role.ts
@@ -1,46 +1,46 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   createMembershipCommandRepository,
   type MembershipCommandRepository,
-} from "./repository.ts";
+} from './repository.ts';
 import type {
   MembershipCommandExecutionResult,
   ReviewChangeMemberRoleRequest,
   SystemChangeMemberRoleRequest,
   TeamChangeMemberRoleRequest,
-} from "./types.ts";
+} from './types.ts';
 import {
   parseReviewChangeMemberRoleRequest,
   parseSystemChangeMemberRoleRequest,
   parseTeamChangeMemberRoleRequest,
-} from "./validation.ts";
+} from './validation.ts';
 
-type ChangeMemberRoleScope = "team" | "system" | "review";
+type ChangeMemberRoleScope = 'team' | 'system' | 'review';
 
-function normalizeAction(action?: "set" | "remove") {
-  return action ?? "set";
+function normalizeAction(action?: 'set' | 'remove') {
+  return action ?? 'set';
 }
 
 function assertChangeRolePayload(
-  action: "set" | "remove",
+  action: 'set' | 'remove',
   role: string | null | undefined,
 ): MembershipCommandExecutionResult | null {
-  if (action === "set" && (!role || role.trim().length === 0)) {
+  if (action === 'set' && (!role || role.trim().length === 0)) {
     return {
       ok: false,
-      code: "ROLE_REQUIRED",
+      code: 'ROLE_REQUIRED',
       status: 400,
-      message: "role is required when action is set",
+      message: 'role is required when action is set',
     };
   }
 
-  if (action === "remove" && role && role.trim().length > 0) {
+  if (action === 'remove' && role && role.trim().length > 0) {
     return {
       ok: false,
-      code: "ROLE_NOT_ALLOWED",
+      code: 'ROLE_NOT_ALLOWED',
       status: 400,
-      message: "role must be omitted when action is remove",
+      message: 'role must be omitted when action is remove',
     };
   }
 
@@ -62,31 +62,25 @@ export function parseReviewChangeMemberRoleCommand(body: unknown) {
 export async function executeTeamChangeMemberRoleCommand(
   request: TeamChangeMemberRoleRequest,
   actor: ActorContext,
-  repository: MembershipCommandRepository = createMembershipCommandRepository(
-    actor.supabase,
-  ),
+  repository: MembershipCommandRepository = createMembershipCommandRepository(actor.supabase),
 ): Promise<MembershipCommandExecutionResult> {
-  return executeChangeRoleByScope("team", request, actor, repository);
+  return executeChangeRoleByScope('team', request, actor, repository);
 }
 
 export async function executeSystemChangeMemberRoleCommand(
   request: SystemChangeMemberRoleRequest,
   actor: ActorContext,
-  repository: MembershipCommandRepository = createMembershipCommandRepository(
-    actor.supabase,
-  ),
+  repository: MembershipCommandRepository = createMembershipCommandRepository(actor.supabase),
 ): Promise<MembershipCommandExecutionResult> {
-  return executeChangeRoleByScope("system", request, actor, repository);
+  return executeChangeRoleByScope('system', request, actor, repository);
 }
 
 export async function executeReviewChangeMemberRoleCommand(
   request: ReviewChangeMemberRoleRequest,
   actor: ActorContext,
-  repository: MembershipCommandRepository = createMembershipCommandRepository(
-    actor.supabase,
-  ),
+  repository: MembershipCommandRepository = createMembershipCommandRepository(actor.supabase),
 ): Promise<MembershipCommandExecutionResult> {
-  return executeChangeRoleByScope("review", request, actor, repository);
+  return executeChangeRoleByScope('review', request, actor, repository);
 }
 
 async function executeChangeRoleByScope(
@@ -107,30 +101,22 @@ async function executeChangeRoleByScope(
   const audit = buildCommandAuditPayload({
     command: `${scope}_change_member_role`,
     actorUserId: actor.userId,
-    targetTable: "roles",
+    targetTable: 'roles',
     targetId: request.userId,
-    targetVersion: "teamId" in request ? request.teamId : "",
+    targetVersion: 'teamId' in request ? request.teamId : '',
     payload: {
       action,
       role: request.role ?? null,
-      teamId: "teamId" in request ? request.teamId : null,
+      teamId: 'teamId' in request ? request.teamId : null,
     },
   });
 
-  const result = scope === "team"
-    ? await repository.changeTeamMemberRole(
-      request as TeamChangeMemberRoleRequest,
-      audit,
-    )
-    : scope === "system"
-    ? await repository.changeSystemMemberRole(
-      request as SystemChangeMemberRoleRequest,
-      audit,
-    )
-    : await repository.changeReviewMemberRole(
-      request as ReviewChangeMemberRoleRequest,
-      audit,
-    );
+  const result =
+    scope === 'team'
+      ? await repository.changeTeamMemberRole(request as TeamChangeMemberRoleRequest, audit)
+      : scope === 'system'
+        ? await repository.changeSystemMemberRole(request as SystemChangeMemberRoleRequest, audit)
+        : await repository.changeReviewMemberRole(request as ReviewChangeMemberRoleRequest, audit);
 
   if (!result.ok) {
     return result;

--- a/supabase/functions/_shared/commands/membership/reinvite_member.ts
+++ b/supabase/functions/_shared/commands/membership/reinvite_member.ts
@@ -1,14 +1,11 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   createMembershipCommandRepository,
   type MembershipCommandRepository,
-} from "./repository.ts";
-import type {
-  MembershipCommandExecutionResult,
-  TeamReinviteMemberRequest,
-} from "./types.ts";
-import { parseTeamReinviteMemberRequest } from "./validation.ts";
+} from './repository.ts';
+import type { MembershipCommandExecutionResult, TeamReinviteMemberRequest } from './types.ts';
+import { parseTeamReinviteMemberRequest } from './validation.ts';
 
 export function parseTeamReinviteMemberCommand(body: unknown) {
   return parseTeamReinviteMemberRequest(body);
@@ -17,14 +14,12 @@ export function parseTeamReinviteMemberCommand(body: unknown) {
 export async function executeTeamReinviteMemberCommand(
   request: TeamReinviteMemberRequest,
   actor: ActorContext,
-  repository: MembershipCommandRepository = createMembershipCommandRepository(
-    actor.supabase,
-  ),
+  repository: MembershipCommandRepository = createMembershipCommandRepository(actor.supabase),
 ): Promise<MembershipCommandExecutionResult> {
   const audit = buildCommandAuditPayload({
-    command: "team_reinvite_member",
+    command: 'team_reinvite_member',
     actorUserId: actor.userId,
-    targetTable: "roles",
+    targetTable: 'roles',
     targetId: request.userId,
     targetVersion: request.teamId,
     payload: {
@@ -43,7 +38,7 @@ export async function executeTeamReinviteMemberCommand(
     status: 200,
     body: {
       ok: true,
-      command: "team_reinvite_member",
+      command: 'team_reinvite_member',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/membership/reject_invitation.ts
+++ b/supabase/functions/_shared/commands/membership/reject_invitation.ts
@@ -1,14 +1,11 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   createMembershipCommandRepository,
   type MembershipCommandRepository,
-} from "./repository.ts";
-import type {
-  MembershipCommandExecutionResult,
-  TeamInvitationDecisionRequest,
-} from "./types.ts";
-import { parseTeamInvitationDecisionRequest } from "./validation.ts";
+} from './repository.ts';
+import type { MembershipCommandExecutionResult, TeamInvitationDecisionRequest } from './types.ts';
+import { parseTeamInvitationDecisionRequest } from './validation.ts';
 
 export function parseTeamRejectInvitationCommand(body: unknown) {
   return parseTeamInvitationDecisionRequest(body);
@@ -17,14 +14,12 @@ export function parseTeamRejectInvitationCommand(body: unknown) {
 export async function executeTeamRejectInvitationCommand(
   request: TeamInvitationDecisionRequest,
   actor: ActorContext,
-  repository: MembershipCommandRepository = createMembershipCommandRepository(
-    actor.supabase,
-  ),
+  repository: MembershipCommandRepository = createMembershipCommandRepository(actor.supabase),
 ): Promise<MembershipCommandExecutionResult> {
   const audit = buildCommandAuditPayload({
-    command: "team_reject_invitation",
+    command: 'team_reject_invitation',
     actorUserId: actor.userId,
-    targetTable: "roles",
+    targetTable: 'roles',
     targetId: actor.userId,
     targetVersion: request.teamId,
     payload: {
@@ -42,7 +37,7 @@ export async function executeTeamRejectInvitationCommand(
     status: 200,
     body: {
       ok: true,
-      command: "team_reject_invitation",
+      command: 'team_reject_invitation',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/membership/repository.ts
+++ b/supabase/functions/_shared/commands/membership/repository.ts
@@ -1,19 +1,19 @@
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import type { CommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { CommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   callReviewChangeMemberRoleRpc,
   callSystemChangeMemberRoleRpc,
   callTeamAcceptInvitationRpc,
   callTeamChangeMemberRoleRpc,
   callTeamCreateRpc,
-  callTeamRejectInvitationRpc,
   callTeamReinviteMemberRpc,
+  callTeamRejectInvitationRpc,
   callTeamSetRankRpc,
   callTeamUpdateProfileRpc,
   callUserUpdateContactRpc,
   type MembershipRpcResult,
-} from "../../db_rpc/membership_commands.ts";
+} from '../../db_rpc/membership_commands.ts';
 import type {
   ReviewChangeMemberRoleRequest,
   SystemChangeMemberRoleRequest,
@@ -24,9 +24,9 @@ import type {
   TeamSetRankRequest,
   TeamUpdateProfileRequest,
   UserUpdateContactRequest,
-} from "./types.ts";
+} from './types.ts';
 
-type RpcClient = Pick<SupabaseClient, "rpc">;
+type RpcClient = Pick<SupabaseClient, 'rpc'>;
 
 export type MembershipCommandRepository = {
   createTeam: (
@@ -71,13 +71,9 @@ export type MembershipCommandRepository = {
   ) => Promise<MembershipRpcResult>;
 };
 
-function requireExplicitClient(
-  supabase: RpcClient | null | undefined,
-): RpcClient {
-  if (!supabase || typeof supabase.rpc !== "function") {
-    throw new Error(
-      "Membership command repository requires an explicit Supabase client",
-    );
+function requireExplicitClient(supabase: RpcClient | null | undefined): RpcClient {
+  if (!supabase || typeof supabase.rpc !== 'function') {
+    throw new Error('Membership command repository requires an explicit Supabase client');
   }
 
   return supabase;
@@ -90,22 +86,16 @@ export function createMembershipCommandRepository(
 
   return {
     createTeam: (request, audit) => callTeamCreateRpc(client, request, audit),
-    updateTeamProfile: (request, audit) =>
-      callTeamUpdateProfileRpc(client, request, audit),
+    updateTeamProfile: (request, audit) => callTeamUpdateProfileRpc(client, request, audit),
     setTeamRank: (request, audit) => callTeamSetRankRpc(client, request, audit),
-    updateUserContact: (request, audit) =>
-      callUserUpdateContactRpc(client, request, audit),
-    changeTeamMemberRole: (request, audit) =>
-      callTeamChangeMemberRoleRpc(client, request, audit),
+    updateUserContact: (request, audit) => callUserUpdateContactRpc(client, request, audit),
+    changeTeamMemberRole: (request, audit) => callTeamChangeMemberRoleRpc(client, request, audit),
     changeSystemMemberRole: (request, audit) =>
       callSystemChangeMemberRoleRpc(client, request, audit),
     changeReviewMemberRole: (request, audit) =>
       callReviewChangeMemberRoleRpc(client, request, audit),
-    reinviteTeamMember: (request, audit) =>
-      callTeamReinviteMemberRpc(client, request, audit),
-    acceptInvitation: (request, audit) =>
-      callTeamAcceptInvitationRpc(client, request, audit),
-    rejectInvitation: (request, audit) =>
-      callTeamRejectInvitationRpc(client, request, audit),
+    reinviteTeamMember: (request, audit) => callTeamReinviteMemberRpc(client, request, audit),
+    acceptInvitation: (request, audit) => callTeamAcceptInvitationRpc(client, request, audit),
+    rejectInvitation: (request, audit) => callTeamRejectInvitationRpc(client, request, audit),
   };
 }

--- a/supabase/functions/_shared/commands/membership/types.ts
+++ b/supabase/functions/_shared/commands/membership/types.ts
@@ -1,4 +1,4 @@
-export const MEMBER_ROLE_ACTIONS = ["set", "remove"] as const;
+export const MEMBER_ROLE_ACTIONS = ['set', 'remove'] as const;
 
 export type MemberRoleAction = (typeof MEMBER_ROLE_ACTIONS)[number];
 

--- a/supabase/functions/_shared/commands/membership/validation.ts
+++ b/supabase/functions/_shared/commands/membership/validation.ts
@@ -1,6 +1,6 @@
-import { z } from "zod";
+import { z } from 'zod';
 
-import type { CommandParseResult } from "../../command_runtime/command.ts";
+import type { CommandParseResult } from '../../command_runtime/command.ts';
 import {
   MEMBER_ROLE_ACTIONS,
   type ReviewChangeMemberRoleRequest,
@@ -12,7 +12,7 @@ import {
   type TeamSetRankRequest,
   type TeamUpdateProfileRequest,
   type UserUpdateContactRequest,
-} from "./types.ts";
+} from './types.ts';
 
 const uuidSchema = z.string().uuid();
 const nonEmptyStringSchema = z.string().trim().min(1);
@@ -32,11 +32,9 @@ export const teamChangeMemberRoleRequestSchema = baseChangeMemberRoleSchema
   })
   .strict();
 
-export const systemChangeMemberRoleRequestSchema =
-  baseChangeMemberRoleSchema.strict();
+export const systemChangeMemberRoleRequestSchema = baseChangeMemberRoleSchema.strict();
 
-export const reviewChangeMemberRoleRequestSchema =
-  baseChangeMemberRoleSchema.strict();
+export const reviewChangeMemberRoleRequestSchema = baseChangeMemberRoleSchema.strict();
 
 export const teamReinviteMemberRequestSchema = z
   .object({
@@ -82,10 +80,7 @@ export const userUpdateContactRequestSchema = z
   })
   .strict();
 
-function invalidPayload<T>(
-  message: string,
-  error: z.ZodError,
-): CommandParseResult<T> {
+function invalidPayload<T>(message: string, error: z.ZodError): CommandParseResult<T> {
   return {
     ok: false,
     message,
@@ -98,7 +93,7 @@ export function parseTeamChangeMemberRoleRequest(
 ): CommandParseResult<TeamChangeMemberRoleRequest> {
   const parsed = teamChangeMemberRoleRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid team change-member-role payload", parsed.error);
+    return invalidPayload('Invalid team change-member-role payload', parsed.error);
   }
   return { ok: true, value: parsed.data };
 }
@@ -108,10 +103,7 @@ export function parseSystemChangeMemberRoleRequest(
 ): CommandParseResult<SystemChangeMemberRoleRequest> {
   const parsed = systemChangeMemberRoleRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload(
-      "Invalid system change-member-role payload",
-      parsed.error,
-    );
+    return invalidPayload('Invalid system change-member-role payload', parsed.error);
   }
   return { ok: true, value: parsed.data };
 }
@@ -121,10 +113,7 @@ export function parseReviewChangeMemberRoleRequest(
 ): CommandParseResult<ReviewChangeMemberRoleRequest> {
   const parsed = reviewChangeMemberRoleRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload(
-      "Invalid review change-member-role payload",
-      parsed.error,
-    );
+    return invalidPayload('Invalid review change-member-role payload', parsed.error);
   }
   return { ok: true, value: parsed.data };
 }
@@ -134,7 +123,7 @@ export function parseTeamReinviteMemberRequest(
 ): CommandParseResult<TeamReinviteMemberRequest> {
   const parsed = teamReinviteMemberRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid team reinvite-member payload", parsed.error);
+    return invalidPayload('Invalid team reinvite-member payload', parsed.error);
   }
   return { ok: true, value: parsed.data };
 }
@@ -144,17 +133,15 @@ export function parseTeamInvitationDecisionRequest(
 ): CommandParseResult<TeamInvitationDecisionRequest> {
   const parsed = teamInvitationDecisionRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid team invitation payload", parsed.error);
+    return invalidPayload('Invalid team invitation payload', parsed.error);
   }
   return { ok: true, value: parsed.data };
 }
 
-export function parseTeamCreateRequest(
-  body: unknown,
-): CommandParseResult<TeamCreateRequest> {
+export function parseTeamCreateRequest(body: unknown): CommandParseResult<TeamCreateRequest> {
   const parsed = teamCreateRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid team create payload", parsed.error);
+    return invalidPayload('Invalid team create payload', parsed.error);
   }
   return { ok: true, value: parsed.data };
 }
@@ -164,17 +151,15 @@ export function parseTeamUpdateProfileRequest(
 ): CommandParseResult<TeamUpdateProfileRequest> {
   const parsed = teamUpdateProfileRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid team update-profile payload", parsed.error);
+    return invalidPayload('Invalid team update-profile payload', parsed.error);
   }
   return { ok: true, value: parsed.data };
 }
 
-export function parseTeamSetRankRequest(
-  body: unknown,
-): CommandParseResult<TeamSetRankRequest> {
+export function parseTeamSetRankRequest(body: unknown): CommandParseResult<TeamSetRankRequest> {
   const parsed = teamSetRankRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid team set-rank payload", parsed.error);
+    return invalidPayload('Invalid team set-rank payload', parsed.error);
   }
   return { ok: true, value: parsed.data };
 }
@@ -184,7 +169,7 @@ export function parseUserUpdateContactRequest(
 ): CommandParseResult<UserUpdateContactRequest> {
   const parsed = userUpdateContactRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid user update-contact payload", parsed.error);
+    return invalidPayload('Invalid user update-contact payload', parsed.error);
   }
   return { ok: true, value: parsed.data };
 }

--- a/supabase/functions/_shared/commands/notification/repository.ts
+++ b/supabase/functions/_shared/commands/notification/repository.ts
@@ -1,13 +1,13 @@
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import type { CommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { CommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   callNotificationSendValidationIssueRpc,
   type NotificationRpcResult,
-} from "../../db_rpc/notification_commands.ts";
-import type { NotificationSendValidationIssueRequest } from "./types.ts";
+} from '../../db_rpc/notification_commands.ts';
+import type { NotificationSendValidationIssueRequest } from './types.ts';
 
-type RpcClient = Pick<SupabaseClient, "rpc">;
+type RpcClient = Pick<SupabaseClient, 'rpc'>;
 
 export type NotificationCommandRepository = {
   sendValidationIssue: (
@@ -16,13 +16,9 @@ export type NotificationCommandRepository = {
   ) => Promise<NotificationRpcResult>;
 };
 
-function requireExplicitClient(
-  supabase: RpcClient | null | undefined,
-): RpcClient {
-  if (!supabase || typeof supabase.rpc !== "function") {
-    throw new Error(
-      "Notification command repository requires an explicit Supabase client",
-    );
+function requireExplicitClient(supabase: RpcClient | null | undefined): RpcClient {
+  if (!supabase || typeof supabase.rpc !== 'function') {
+    throw new Error('Notification command repository requires an explicit Supabase client');
   }
 
   return supabase;

--- a/supabase/functions/_shared/commands/notification/send_validation_issue.ts
+++ b/supabase/functions/_shared/commands/notification/send_validation_issue.ts
@@ -1,14 +1,14 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   createNotificationCommandRepository,
   type NotificationCommandRepository,
-} from "./repository.ts";
+} from './repository.ts';
 import type {
   NotificationCommandExecutionResult,
   NotificationSendValidationIssueRequest,
-} from "./types.ts";
-import { parseNotificationSendValidationIssueRequest } from "./validation.ts";
+} from './types.ts';
+import { parseNotificationSendValidationIssueRequest } from './validation.ts';
 
 export function parseNotificationSendValidationIssueCommand(body: unknown) {
   return parseNotificationSendValidationIssueRequest(body);
@@ -17,14 +17,12 @@ export function parseNotificationSendValidationIssueCommand(body: unknown) {
 export async function executeNotificationSendValidationIssueCommand(
   request: NotificationSendValidationIssueRequest,
   actor: ActorContext,
-  repository: NotificationCommandRepository = createNotificationCommandRepository(
-    actor.supabase,
-  ),
+  repository: NotificationCommandRepository = createNotificationCommandRepository(actor.supabase),
 ): Promise<NotificationCommandExecutionResult> {
   const audit = buildCommandAuditPayload({
-    command: "notification_send_validation_issue",
+    command: 'notification_send_validation_issue',
     actorUserId: actor.userId,
-    targetTable: "notifications",
+    targetTable: 'notifications',
     targetId: request.datasetId,
     targetVersion: request.datasetVersion,
     payload: {
@@ -47,7 +45,7 @@ export async function executeNotificationSendValidationIssueCommand(
     status: 200,
     body: {
       ok: true,
-      command: "notification_send_validation_issue",
+      command: 'notification_send_validation_issue',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/notification/validation.ts
+++ b/supabase/functions/_shared/commands/notification/validation.ts
@@ -1,7 +1,7 @@
-import { z } from "zod";
+import { z } from 'zod';
 
-import type { CommandParseResult } from "../../command_runtime/command.ts";
-import type { NotificationSendValidationIssueRequest } from "./types.ts";
+import type { CommandParseResult } from '../../command_runtime/command.ts';
+import type { NotificationSendValidationIssueRequest } from './types.ts';
 
 const uuidSchema = z.string().uuid();
 const nonEmptyStringSchema = z.string().trim().min(1);
@@ -22,10 +22,7 @@ export const notificationSendValidationIssueRequestSchema = z
   })
   .strict();
 
-function invalidPayload<T>(
-  message: string,
-  error: z.ZodError,
-): CommandParseResult<T> {
+function invalidPayload<T>(message: string, error: z.ZodError): CommandParseResult<T> {
   return {
     ok: false,
     message,
@@ -38,10 +35,7 @@ export function parseNotificationSendValidationIssueRequest(
 ): CommandParseResult<NotificationSendValidationIssueRequest> {
   const parsed = notificationSendValidationIssueRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload(
-      "Invalid notification send-validation-issue payload",
-      parsed.error,
-    );
+    return invalidPayload('Invalid notification send-validation-issue payload', parsed.error);
   }
 
   return {

--- a/supabase/functions/_shared/commands/profile/update_team_profile.ts
+++ b/supabase/functions/_shared/commands/profile/update_team_profile.ts
@@ -1,18 +1,18 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   createMembershipCommandRepository,
   type MembershipCommandRepository,
-} from "../membership/repository.ts";
+} from '../membership/repository.ts';
 import type {
   MembershipCommandExecutionResult,
   TeamSetRankRequest,
   TeamUpdateProfileRequest,
-} from "../membership/types.ts";
+} from '../membership/types.ts';
 import {
   parseTeamSetRankRequest,
   parseTeamUpdateProfileRequest,
-} from "../membership/validation.ts";
+} from '../membership/validation.ts';
 
 export function parseTeamUpdateProfileCommand(body: unknown) {
   return parseTeamUpdateProfileRequest(body);
@@ -25,16 +25,14 @@ export function parseTeamSetRankCommand(body: unknown) {
 export async function executeTeamUpdateProfileCommand(
   request: TeamUpdateProfileRequest,
   actor: ActorContext,
-  repository: MembershipCommandRepository = createMembershipCommandRepository(
-    actor.supabase,
-  ),
+  repository: MembershipCommandRepository = createMembershipCommandRepository(actor.supabase),
 ): Promise<MembershipCommandExecutionResult> {
   const audit = buildCommandAuditPayload({
-    command: "team_update_profile",
+    command: 'team_update_profile',
     actorUserId: actor.userId,
-    targetTable: "teams",
+    targetTable: 'teams',
     targetId: request.teamId,
-    targetVersion: "",
+    targetVersion: '',
     payload: {
       isPublic: request.isPublic,
     },
@@ -50,7 +48,7 @@ export async function executeTeamUpdateProfileCommand(
     status: 200,
     body: {
       ok: true,
-      command: "team_update_profile",
+      command: 'team_update_profile',
       data: result.data,
     },
   };
@@ -59,16 +57,14 @@ export async function executeTeamUpdateProfileCommand(
 export async function executeTeamSetRankCommand(
   request: TeamSetRankRequest,
   actor: ActorContext,
-  repository: MembershipCommandRepository = createMembershipCommandRepository(
-    actor.supabase,
-  ),
+  repository: MembershipCommandRepository = createMembershipCommandRepository(actor.supabase),
 ): Promise<MembershipCommandExecutionResult> {
   const audit = buildCommandAuditPayload({
-    command: "team_set_rank",
+    command: 'team_set_rank',
     actorUserId: actor.userId,
-    targetTable: "teams",
+    targetTable: 'teams',
     targetId: request.teamId,
-    targetVersion: "",
+    targetVersion: '',
     payload: {
       rank: request.rank,
     },
@@ -84,7 +80,7 @@ export async function executeTeamSetRankCommand(
     status: 200,
     body: {
       ok: true,
-      command: "team_set_rank",
+      command: 'team_set_rank',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/profile/update_user_contact.ts
+++ b/supabase/functions/_shared/commands/profile/update_user_contact.ts
@@ -1,14 +1,14 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   createMembershipCommandRepository,
   type MembershipCommandRepository,
-} from "../membership/repository.ts";
+} from '../membership/repository.ts';
 import type {
   MembershipCommandExecutionResult,
   UserUpdateContactRequest,
-} from "../membership/types.ts";
-import { parseUserUpdateContactRequest } from "../membership/validation.ts";
+} from '../membership/types.ts';
+import { parseUserUpdateContactRequest } from '../membership/validation.ts';
 
 export function parseUserUpdateContactCommand(body: unknown) {
   return parseUserUpdateContactRequest(body);
@@ -17,16 +17,14 @@ export function parseUserUpdateContactCommand(body: unknown) {
 export async function executeUserUpdateContactCommand(
   request: UserUpdateContactRequest,
   actor: ActorContext,
-  repository: MembershipCommandRepository = createMembershipCommandRepository(
-    actor.supabase,
-  ),
+  repository: MembershipCommandRepository = createMembershipCommandRepository(actor.supabase),
 ): Promise<MembershipCommandExecutionResult> {
   const audit = buildCommandAuditPayload({
-    command: "user_update_contact",
+    command: 'user_update_contact',
     actorUserId: actor.userId,
-    targetTable: "users",
+    targetTable: 'users',
     targetId: request.userId,
-    targetVersion: "",
+    targetVersion: '',
     payload: {
       hasContact: true,
     },
@@ -42,7 +40,7 @@ export async function executeUserUpdateContactCommand(
     status: 200,
     body: {
       ok: true,
-      command: "user_update_contact",
+      command: 'user_update_contact',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/review/approve_review.ts
+++ b/supabase/functions/_shared/commands/review/approve_review.ts
@@ -1,15 +1,9 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
-import { assertApproveReviewPolicy } from "./policy.ts";
-import {
-  createReviewCommandRepository,
-  type ReviewCommandRepository,
-} from "./repository.ts";
-import type {
-  ApproveReviewRequest,
-  ReviewCommandExecutionResult,
-} from "./types.ts";
-import { parseApproveReviewRequest } from "./validation.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
+import { assertApproveReviewPolicy } from './policy.ts';
+import { createReviewCommandRepository, type ReviewCommandRepository } from './repository.ts';
+import type { ApproveReviewRequest, ReviewCommandExecutionResult } from './types.ts';
+import { parseApproveReviewRequest } from './validation.ts';
 
 export function parseApproveReviewCommand(body: unknown) {
   return parseApproveReviewRequest(body);
@@ -18,9 +12,7 @@ export function parseApproveReviewCommand(body: unknown) {
 export async function executeApproveReviewCommand(
   request: ApproveReviewRequest,
   actor: ActorContext,
-  repository: ReviewCommandRepository = createReviewCommandRepository(
-    actor.supabase,
-  ),
+  repository: ReviewCommandRepository = createReviewCommandRepository(actor.supabase),
 ): Promise<ReviewCommandExecutionResult> {
   const policy = assertApproveReviewPolicy(request);
   if (!policy.ok) {
@@ -28,11 +20,11 @@ export async function executeApproveReviewCommand(
   }
 
   const audit = buildCommandAuditPayload({
-    command: "review_approve",
+    command: 'review_approve',
     actorUserId: actor.userId,
     targetTable: request.table,
     targetId: request.reviewId,
-    targetVersion: "",
+    targetVersion: '',
     payload: {},
   });
 
@@ -46,7 +38,7 @@ export async function executeApproveReviewCommand(
     status: 200,
     body: {
       ok: true,
-      command: "review_approve",
+      command: 'review_approve',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/review/assign_reviewers.ts
+++ b/supabase/functions/_shared/commands/review/assign_reviewers.ts
@@ -1,15 +1,9 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
-import { assertAssignReviewersPolicy } from "./policy.ts";
-import {
-  createReviewCommandRepository,
-  type ReviewCommandRepository,
-} from "./repository.ts";
-import type {
-  AssignReviewersRequest,
-  ReviewCommandExecutionResult,
-} from "./types.ts";
-import { parseAssignReviewersRequest } from "./validation.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
+import { assertAssignReviewersPolicy } from './policy.ts';
+import { createReviewCommandRepository, type ReviewCommandRepository } from './repository.ts';
+import type { AssignReviewersRequest, ReviewCommandExecutionResult } from './types.ts';
+import { parseAssignReviewersRequest } from './validation.ts';
 
 export function parseAssignReviewersCommand(body: unknown) {
   return parseAssignReviewersRequest(body);
@@ -18,9 +12,7 @@ export function parseAssignReviewersCommand(body: unknown) {
 export async function executeAssignReviewersCommand(
   request: AssignReviewersRequest,
   actor: ActorContext,
-  repository: ReviewCommandRepository = createReviewCommandRepository(
-    actor.supabase,
-  ),
+  repository: ReviewCommandRepository = createReviewCommandRepository(actor.supabase),
 ): Promise<ReviewCommandExecutionResult> {
   const policy = assertAssignReviewersPolicy(request);
   if (!policy.ok) {
@@ -28,11 +20,11 @@ export async function executeAssignReviewersCommand(
   }
 
   const audit = buildCommandAuditPayload({
-    command: "review_assign_reviewers",
+    command: 'review_assign_reviewers',
     actorUserId: actor.userId,
-    targetTable: "reviews",
+    targetTable: 'reviews',
     targetId: request.reviewId,
-    targetVersion: "",
+    targetVersion: '',
     payload: {
       reviewerIds: request.reviewerIds,
       deadline: request.deadline ?? null,
@@ -49,7 +41,7 @@ export async function executeAssignReviewersCommand(
     status: 200,
     body: {
       ok: true,
-      command: "review_assign_reviewers",
+      command: 'review_assign_reviewers',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/review/policy.ts
+++ b/supabase/functions/_shared/commands/review/policy.ts
@@ -7,7 +7,7 @@ import type {
   SaveAssignmentDraftRequest,
   SaveCommentDraftRequest,
   SubmitCommentRequest,
-} from "./types.ts";
+} from './types.ts';
 
 function invalidInput(code: string, message: string): ReviewCommandFailure {
   return {
@@ -50,10 +50,7 @@ export function assertSubmitCommentPolicy(
     request.commentState !== -3 &&
     request.commentState !== 1
   ) {
-    return invalidInput(
-      "INVALID_COMMENT_STATE",
-      "commentState must be 1 or -3",
-    );
+    return invalidInput('INVALID_COMMENT_STATE', 'commentState must be 1 or -3');
   }
 
   return { ok: true };
@@ -69,7 +66,7 @@ export function assertRejectReviewPolicy(
   request: RejectReviewRequest,
 ): { ok: true } | ReviewCommandFailure {
   if (!request.reason.trim()) {
-    return invalidInput("REASON_REQUIRED", "reason is required");
+    return invalidInput('REASON_REQUIRED', 'reason is required');
   }
 
   return { ok: true };

--- a/supabase/functions/_shared/commands/review/reject_review.ts
+++ b/supabase/functions/_shared/commands/review/reject_review.ts
@@ -1,15 +1,9 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
-import { assertRejectReviewPolicy } from "./policy.ts";
-import {
-  createReviewCommandRepository,
-  type ReviewCommandRepository,
-} from "./repository.ts";
-import type {
-  RejectReviewRequest,
-  ReviewCommandExecutionResult,
-} from "./types.ts";
-import { parseRejectReviewRequest } from "./validation.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
+import { assertRejectReviewPolicy } from './policy.ts';
+import { createReviewCommandRepository, type ReviewCommandRepository } from './repository.ts';
+import type { RejectReviewRequest, ReviewCommandExecutionResult } from './types.ts';
+import { parseRejectReviewRequest } from './validation.ts';
 
 export function parseRejectReviewCommand(body: unknown) {
   return parseRejectReviewRequest(body);
@@ -18,9 +12,7 @@ export function parseRejectReviewCommand(body: unknown) {
 export async function executeRejectReviewCommand(
   request: RejectReviewRequest,
   actor: ActorContext,
-  repository: ReviewCommandRepository = createReviewCommandRepository(
-    actor.supabase,
-  ),
+  repository: ReviewCommandRepository = createReviewCommandRepository(actor.supabase),
 ): Promise<ReviewCommandExecutionResult> {
   const policy = assertRejectReviewPolicy(request);
   if (!policy.ok) {
@@ -28,11 +20,11 @@ export async function executeRejectReviewCommand(
   }
 
   const audit = buildCommandAuditPayload({
-    command: "review_reject",
+    command: 'review_reject',
     actorUserId: actor.userId,
     targetTable: request.table,
     targetId: request.reviewId,
-    targetVersion: "",
+    targetVersion: '',
     payload: {
       reason: request.reason,
     },
@@ -48,7 +40,7 @@ export async function executeRejectReviewCommand(
     status: 200,
     body: {
       ok: true,
-      command: "review_reject",
+      command: 'review_reject',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/review/repository.ts
+++ b/supabase/functions/_shared/commands/review/repository.ts
@@ -1,6 +1,6 @@
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import type { CommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { CommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   callReviewApproveRpc,
   callReviewAssignReviewersRpc,
@@ -10,7 +10,7 @@ import {
   callReviewSaveCommentDraftRpc,
   callReviewSubmitCommentRpc,
   type ReviewRpcResult,
-} from "../../db_rpc/review_commands.ts";
+} from '../../db_rpc/review_commands.ts';
 import type {
   ApproveReviewRequest,
   AssignReviewersRequest,
@@ -19,9 +19,9 @@ import type {
   SaveAssignmentDraftRequest,
   SaveCommentDraftRequest,
   SubmitCommentRequest,
-} from "./types.ts";
+} from './types.ts';
 
-type RpcClient = Pick<SupabaseClient, "rpc">;
+type RpcClient = Pick<SupabaseClient, 'rpc'>;
 
 export type ReviewCommandRepository = {
   saveAssignmentDraft: (
@@ -54,37 +54,25 @@ export type ReviewCommandRepository = {
   ) => Promise<ReviewRpcResult>;
 };
 
-function requireExplicitClient(
-  supabase: RpcClient | null | undefined,
-): RpcClient {
-  if (!supabase || typeof supabase.rpc !== "function") {
-    throw new Error(
-      "Review command repository requires an explicit Supabase client",
-    );
+function requireExplicitClient(supabase: RpcClient | null | undefined): RpcClient {
+  if (!supabase || typeof supabase.rpc !== 'function') {
+    throw new Error('Review command repository requires an explicit Supabase client');
   }
 
   return supabase;
 }
 
-export function createReviewCommandRepository(
-  supabase: RpcClient,
-): ReviewCommandRepository {
+export function createReviewCommandRepository(supabase: RpcClient): ReviewCommandRepository {
   const client = requireExplicitClient(supabase);
 
   return {
     saveAssignmentDraft: (request, audit) =>
       callReviewSaveAssignmentDraftRpc(client, request, audit),
-    assignReviewers: (request, audit) =>
-      callReviewAssignReviewersRpc(client, request, audit),
-    revokeReviewer: (request, audit) =>
-      callReviewRevokeReviewerRpc(client, request, audit),
-    saveCommentDraft: (request, audit) =>
-      callReviewSaveCommentDraftRpc(client, request, audit),
-    submitComment: (request, audit) =>
-      callReviewSubmitCommentRpc(client, request, audit),
-    approveReview: (request, audit) =>
-      callReviewApproveRpc(client, request, audit),
-    rejectReview: (request, audit) =>
-      callReviewRejectRpc(client, request, audit),
+    assignReviewers: (request, audit) => callReviewAssignReviewersRpc(client, request, audit),
+    revokeReviewer: (request, audit) => callReviewRevokeReviewerRpc(client, request, audit),
+    saveCommentDraft: (request, audit) => callReviewSaveCommentDraftRpc(client, request, audit),
+    submitComment: (request, audit) => callReviewSubmitCommentRpc(client, request, audit),
+    approveReview: (request, audit) => callReviewApproveRpc(client, request, audit),
+    rejectReview: (request, audit) => callReviewRejectRpc(client, request, audit),
   };
 }

--- a/supabase/functions/_shared/commands/review/revoke_reviewer.ts
+++ b/supabase/functions/_shared/commands/review/revoke_reviewer.ts
@@ -1,15 +1,9 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
-import { assertRevokeReviewerPolicy } from "./policy.ts";
-import {
-  createReviewCommandRepository,
-  type ReviewCommandRepository,
-} from "./repository.ts";
-import type {
-  ReviewCommandExecutionResult,
-  RevokeReviewerRequest,
-} from "./types.ts";
-import { parseRevokeReviewerRequest } from "./validation.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
+import { assertRevokeReviewerPolicy } from './policy.ts';
+import { createReviewCommandRepository, type ReviewCommandRepository } from './repository.ts';
+import type { ReviewCommandExecutionResult, RevokeReviewerRequest } from './types.ts';
+import { parseRevokeReviewerRequest } from './validation.ts';
 
 export function parseRevokeReviewerCommand(body: unknown) {
   return parseRevokeReviewerRequest(body);
@@ -18,9 +12,7 @@ export function parseRevokeReviewerCommand(body: unknown) {
 export async function executeRevokeReviewerCommand(
   request: RevokeReviewerRequest,
   actor: ActorContext,
-  repository: ReviewCommandRepository = createReviewCommandRepository(
-    actor.supabase,
-  ),
+  repository: ReviewCommandRepository = createReviewCommandRepository(actor.supabase),
 ): Promise<ReviewCommandExecutionResult> {
   const policy = assertRevokeReviewerPolicy(request);
   if (!policy.ok) {
@@ -28,11 +20,11 @@ export async function executeRevokeReviewerCommand(
   }
 
   const audit = buildCommandAuditPayload({
-    command: "review_revoke_reviewer",
+    command: 'review_revoke_reviewer',
     actorUserId: actor.userId,
-    targetTable: "reviews",
+    targetTable: 'reviews',
     targetId: request.reviewId,
-    targetVersion: "",
+    targetVersion: '',
     payload: {
       reviewerId: request.reviewerId,
     },
@@ -48,7 +40,7 @@ export async function executeRevokeReviewerCommand(
     status: 200,
     body: {
       ok: true,
-      command: "review_revoke_reviewer",
+      command: 'review_revoke_reviewer',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/review/save_assignment_draft.ts
+++ b/supabase/functions/_shared/commands/review/save_assignment_draft.ts
@@ -1,18 +1,9 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
-import { assertSaveAssignmentDraftPolicy } from "./policy.ts";
-import {
-  createReviewCommandRepository,
-  type ReviewCommandRepository,
-} from "./repository.ts";
-import type {
-  ReviewCommandExecutionResult,
-  SaveAssignmentDraftRequest,
-} from "./types.ts";
-import {
-  parseSaveAssignmentDraftRequest,
-  saveAssignmentDraftRequestSchema,
-} from "./validation.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
+import { assertSaveAssignmentDraftPolicy } from './policy.ts';
+import { createReviewCommandRepository, type ReviewCommandRepository } from './repository.ts';
+import type { ReviewCommandExecutionResult, SaveAssignmentDraftRequest } from './types.ts';
+import { parseSaveAssignmentDraftRequest, saveAssignmentDraftRequestSchema } from './validation.ts';
 
 export { saveAssignmentDraftRequestSchema };
 
@@ -23,9 +14,7 @@ export function parseSaveAssignmentDraftCommand(body: unknown) {
 export async function executeSaveAssignmentDraftCommand(
   request: SaveAssignmentDraftRequest,
   actor: ActorContext,
-  repository: ReviewCommandRepository = createReviewCommandRepository(
-    actor.supabase,
-  ),
+  repository: ReviewCommandRepository = createReviewCommandRepository(actor.supabase),
 ): Promise<ReviewCommandExecutionResult> {
   const policy = assertSaveAssignmentDraftPolicy(request);
   if (!policy.ok) {
@@ -33,11 +22,11 @@ export async function executeSaveAssignmentDraftCommand(
   }
 
   const audit = buildCommandAuditPayload({
-    command: "review_save_assignment_draft",
+    command: 'review_save_assignment_draft',
     actorUserId: actor.userId,
-    targetTable: "reviews",
+    targetTable: 'reviews',
     targetId: request.reviewId,
-    targetVersion: "",
+    targetVersion: '',
     payload: {
       reviewerIds: request.reviewerIds,
     },
@@ -53,7 +42,7 @@ export async function executeSaveAssignmentDraftCommand(
     status: 200,
     body: {
       ok: true,
-      command: "review_save_assignment_draft",
+      command: 'review_save_assignment_draft',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/review/save_comment_draft.ts
+++ b/supabase/functions/_shared/commands/review/save_comment_draft.ts
@@ -1,15 +1,9 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
-import { assertSaveCommentDraftPolicy } from "./policy.ts";
-import {
-  createReviewCommandRepository,
-  type ReviewCommandRepository,
-} from "./repository.ts";
-import type {
-  ReviewCommandExecutionResult,
-  SaveCommentDraftRequest,
-} from "./types.ts";
-import { parseSaveCommentDraftRequest } from "./validation.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
+import { assertSaveCommentDraftPolicy } from './policy.ts';
+import { createReviewCommandRepository, type ReviewCommandRepository } from './repository.ts';
+import type { ReviewCommandExecutionResult, SaveCommentDraftRequest } from './types.ts';
+import { parseSaveCommentDraftRequest } from './validation.ts';
 
 export function parseSaveCommentDraftCommand(body: unknown) {
   return parseSaveCommentDraftRequest(body);
@@ -18,9 +12,7 @@ export function parseSaveCommentDraftCommand(body: unknown) {
 export async function executeSaveCommentDraftCommand(
   request: SaveCommentDraftRequest,
   actor: ActorContext,
-  repository: ReviewCommandRepository = createReviewCommandRepository(
-    actor.supabase,
-  ),
+  repository: ReviewCommandRepository = createReviewCommandRepository(actor.supabase),
 ): Promise<ReviewCommandExecutionResult> {
   const policy = assertSaveCommentDraftPolicy(request);
   if (!policy.ok) {
@@ -28,11 +20,11 @@ export async function executeSaveCommentDraftCommand(
   }
 
   const audit = buildCommandAuditPayload({
-    command: "review_save_comment_draft",
+    command: 'review_save_comment_draft',
     actorUserId: actor.userId,
-    targetTable: "reviews",
+    targetTable: 'reviews',
     targetId: request.reviewId,
-    targetVersion: "",
+    targetVersion: '',
     payload: {
       hasJson: request.json !== undefined,
     },
@@ -48,7 +40,7 @@ export async function executeSaveCommentDraftCommand(
     status: 200,
     body: {
       ok: true,
-      command: "review_save_comment_draft",
+      command: 'review_save_comment_draft',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/review/submit_comment.ts
+++ b/supabase/functions/_shared/commands/review/submit_comment.ts
@@ -1,18 +1,9 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
-import { assertSubmitCommentPolicy } from "./policy.ts";
-import {
-  createReviewCommandRepository,
-  type ReviewCommandRepository,
-} from "./repository.ts";
-import type {
-  ReviewCommandExecutionResult,
-  SubmitCommentRequest,
-} from "./types.ts";
-import {
-  parseSubmitCommentRequest,
-  submitCommentRequestSchema,
-} from "./validation.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
+import { assertSubmitCommentPolicy } from './policy.ts';
+import { createReviewCommandRepository, type ReviewCommandRepository } from './repository.ts';
+import type { ReviewCommandExecutionResult, SubmitCommentRequest } from './types.ts';
+import { parseSubmitCommentRequest, submitCommentRequestSchema } from './validation.ts';
 
 export { submitCommentRequestSchema };
 
@@ -23,9 +14,7 @@ export function parseSubmitCommentCommand(body: unknown) {
 export async function executeSubmitCommentCommand(
   request: SubmitCommentRequest,
   actor: ActorContext,
-  repository: ReviewCommandRepository = createReviewCommandRepository(
-    actor.supabase,
-  ),
+  repository: ReviewCommandRepository = createReviewCommandRepository(actor.supabase),
 ): Promise<ReviewCommandExecutionResult> {
   const policy = assertSubmitCommentPolicy(request);
   if (!policy.ok) {
@@ -33,11 +22,11 @@ export async function executeSubmitCommentCommand(
   }
 
   const audit = buildCommandAuditPayload({
-    command: "review_submit_comment",
+    command: 'review_submit_comment',
     actorUserId: actor.userId,
-    targetTable: "reviews",
+    targetTable: 'reviews',
     targetId: request.reviewId,
-    targetVersion: "",
+    targetVersion: '',
     payload: {
       hasJson: request.json !== undefined,
       commentState: request.commentState ?? 1,
@@ -54,7 +43,7 @@ export async function executeSubmitCommentCommand(
     status: 200,
     body: {
       ok: true,
-      command: "review_submit_comment",
+      command: 'review_submit_comment',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/commands/review/types.ts
+++ b/supabase/functions/_shared/commands/review/types.ts
@@ -1,4 +1,4 @@
-export const REVIEW_DECISION_TABLES = ["processes", "lifecyclemodels"] as const;
+export const REVIEW_DECISION_TABLES = ['processes', 'lifecyclemodels'] as const;
 
 export type ReviewDecisionTable = (typeof REVIEW_DECISION_TABLES)[number];
 

--- a/supabase/functions/_shared/commands/review/validation.ts
+++ b/supabase/functions/_shared/commands/review/validation.ts
@@ -1,6 +1,6 @@
-import { z } from "zod";
+import { z } from 'zod';
 
-import type { CommandParseResult } from "../../command_runtime/command.ts";
+import type { CommandParseResult } from '../../command_runtime/command.ts';
 import {
   type ApproveReviewRequest,
   type AssignReviewersRequest,
@@ -10,17 +10,14 @@ import {
   type SaveAssignmentDraftRequest,
   type SaveCommentDraftRequest,
   type SubmitCommentRequest,
-} from "./types.ts";
+} from './types.ts';
 
 const uuidSchema = z.string().uuid();
 const reviewerIdsSchema = z.array(uuidSchema);
 const commentStateSchema = z.union([z.literal(-3), z.literal(1)]);
 const isoDateTimeSchema = z
   .string()
-  .refine(
-    (value) => !Number.isNaN(Date.parse(value)),
-    "deadline must be an ISO datetime string",
-  );
+  .refine((value) => !Number.isNaN(Date.parse(value)), 'deadline must be an ISO datetime string');
 
 const reviewBaseSchema = z
   .object({
@@ -71,14 +68,11 @@ export const approveReviewRequestSchema = decisionBaseSchema.strict();
 
 export const rejectReviewRequestSchema = decisionBaseSchema
   .extend({
-    reason: z.string().trim().min(1, "reason is required"),
+    reason: z.string().trim().min(1, 'reason is required'),
   })
   .strict();
 
-function invalidPayload<T>(
-  message: string,
-  error: z.ZodError,
-): CommandParseResult<T> {
+function invalidPayload<T>(message: string, error: z.ZodError): CommandParseResult<T> {
   return {
     ok: false,
     message,
@@ -91,10 +85,7 @@ export function parseSaveAssignmentDraftRequest(
 ): CommandParseResult<SaveAssignmentDraftRequest> {
   const parsed = saveAssignmentDraftRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload(
-      "Invalid review save-assignment-draft payload",
-      parsed.error,
-    );
+    return invalidPayload('Invalid review save-assignment-draft payload', parsed.error);
   }
 
   return { ok: true, value: parsed.data };
@@ -105,10 +96,7 @@ export function parseAssignReviewersRequest(
 ): CommandParseResult<AssignReviewersRequest> {
   const parsed = assignReviewersRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload(
-      "Invalid review assign-reviewers payload",
-      parsed.error,
-    );
+    return invalidPayload('Invalid review assign-reviewers payload', parsed.error);
   }
 
   return { ok: true, value: parsed.data };
@@ -119,10 +107,7 @@ export function parseRevokeReviewerRequest(
 ): CommandParseResult<RevokeReviewerRequest> {
   const parsed = revokeReviewerRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload(
-      "Invalid review revoke-reviewer payload",
-      parsed.error,
-    );
+    return invalidPayload('Invalid review revoke-reviewer payload', parsed.error);
   }
 
   return { ok: true, value: parsed.data };
@@ -133,46 +118,34 @@ export function parseSaveCommentDraftRequest(
 ): CommandParseResult<SaveCommentDraftRequest> {
   const parsed = saveCommentDraftRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload(
-      "Invalid review save-comment-draft payload",
-      parsed.error,
-    );
+    return invalidPayload('Invalid review save-comment-draft payload', parsed.error);
   }
 
   return { ok: true, value: parsed.data };
 }
 
-export function parseSubmitCommentRequest(
-  body: unknown,
-): CommandParseResult<SubmitCommentRequest> {
+export function parseSubmitCommentRequest(body: unknown): CommandParseResult<SubmitCommentRequest> {
   const parsed = submitCommentRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload(
-      "Invalid review submit-comment payload",
-      parsed.error,
-    );
+    return invalidPayload('Invalid review submit-comment payload', parsed.error);
   }
 
   return { ok: true, value: parsed.data };
 }
 
-export function parseApproveReviewRequest(
-  body: unknown,
-): CommandParseResult<ApproveReviewRequest> {
+export function parseApproveReviewRequest(body: unknown): CommandParseResult<ApproveReviewRequest> {
   const parsed = approveReviewRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid review approve payload", parsed.error);
+    return invalidPayload('Invalid review approve payload', parsed.error);
   }
 
   return { ok: true, value: parsed.data };
 }
 
-export function parseRejectReviewRequest(
-  body: unknown,
-): CommandParseResult<RejectReviewRequest> {
+export function parseRejectReviewRequest(body: unknown): CommandParseResult<RejectReviewRequest> {
   const parsed = rejectReviewRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return invalidPayload("Invalid review reject payload", parsed.error);
+    return invalidPayload('Invalid review reject payload', parsed.error);
   }
 
   return { ok: true, value: parsed.data };

--- a/supabase/functions/_shared/commands/team/create_team.ts
+++ b/supabase/functions/_shared/commands/team/create_team.ts
@@ -1,14 +1,11 @@
-import type { ActorContext } from "../../command_runtime/actor_context.ts";
-import { buildCommandAuditPayload } from "../../command_runtime/audit_log.ts";
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   createMembershipCommandRepository,
   type MembershipCommandRepository,
-} from "../membership/repository.ts";
-import type {
-  MembershipCommandExecutionResult,
-  TeamCreateRequest,
-} from "../membership/types.ts";
-import { parseTeamCreateRequest } from "../membership/validation.ts";
+} from '../membership/repository.ts';
+import type { MembershipCommandExecutionResult, TeamCreateRequest } from '../membership/types.ts';
+import { parseTeamCreateRequest } from '../membership/validation.ts';
 
 export function parseTeamCreateCommand(body: unknown) {
   return parseTeamCreateRequest(body);
@@ -17,16 +14,14 @@ export function parseTeamCreateCommand(body: unknown) {
 export async function executeTeamCreateCommand(
   request: TeamCreateRequest,
   actor: ActorContext,
-  repository: MembershipCommandRepository = createMembershipCommandRepository(
-    actor.supabase,
-  ),
+  repository: MembershipCommandRepository = createMembershipCommandRepository(actor.supabase),
 ): Promise<MembershipCommandExecutionResult> {
   const audit = buildCommandAuditPayload({
-    command: "team_create",
+    command: 'team_create',
     actorUserId: actor.userId,
-    targetTable: "teams",
+    targetTable: 'teams',
     targetId: request.teamId,
-    targetVersion: "",
+    targetVersion: '',
     payload: {
       rank: request.rank,
       isPublic: request.isPublic,
@@ -43,7 +38,7 @@ export async function executeTeamCreateCommand(
     status: 200,
     body: {
       ok: true,
-      command: "team_create",
+      command: 'team_create',
       data: result.data,
     },
   };

--- a/supabase/functions/_shared/db_rpc/dataset_commands.ts
+++ b/supabase/functions/_shared/db_rpc/dataset_commands.ts
@@ -1,6 +1,6 @@
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import type { CommandAuditPayload } from "../command_runtime/audit_log.ts";
+import type { CommandAuditPayload } from '../command_runtime/audit_log.ts';
 import type {
   AssignTeamRequest,
   CreateRequest,
@@ -9,46 +9,37 @@ import type {
   PublishRequest,
   SaveDraftRequest,
   SubmitReviewRequest,
-} from "../commands/dataset/types.ts";
+} from '../commands/dataset/types.ts';
 
-type RpcClient = Pick<SupabaseClient, "rpc">;
+type RpcClient = Pick<SupabaseClient, 'rpc'>;
 
-export type DatasetRpcResult =
-  | { ok: true; data: unknown }
-  | DatasetCommandFailure;
+export type DatasetRpcResult = { ok: true; data: unknown } | DatasetCommandFailure;
 
-function mapRpcError(
-  error: { code?: string; message?: string; details?: unknown },
-) {
-  const code = error.code ?? "RPC_ERROR";
-  const status = code === "42501"
-    ? 403
-    : code === "PGRST116"
-    ? 404
-    : code === "AUTH_REQUIRED"
-    ? 401
-    : 400;
+function mapRpcError(error: { code?: string; message?: string; details?: unknown }) {
+  const code = error.code ?? 'RPC_ERROR';
+  const status =
+    code === '42501' ? 403 : code === 'PGRST116' ? 404 : code === 'AUTH_REQUIRED' ? 401 : 400;
 
   return {
     ok: false as const,
     code,
     status,
-    message: error.message ?? "Dataset command RPC failed",
+    message: error.message ?? 'Dataset command RPC failed',
     details: error.details ?? null,
   };
 }
 
 function isDatasetCommandFailure(data: unknown): data is DatasetCommandFailure {
-  if (!data || typeof data !== "object") {
+  if (!data || typeof data !== 'object') {
     return false;
   }
 
   const candidate = data as Partial<DatasetCommandFailure> & { ok?: unknown };
   return (
     candidate.ok === false &&
-    typeof candidate.code === "string" &&
-    typeof candidate.message === "string" &&
-    typeof candidate.status === "number"
+    typeof candidate.code === 'string' &&
+    typeof candidate.message === 'string' &&
+    typeof candidate.status === 'number'
   );
 }
 
@@ -68,10 +59,10 @@ async function callDatasetRpc(
 
   if (
     data &&
-    typeof data === "object" &&
+    typeof data === 'object' &&
     !Array.isArray(data) &&
     (data as { ok?: unknown }).ok === true &&
-    "data" in (data as Record<string, unknown>)
+    'data' in (data as Record<string, unknown>)
   ) {
     return {
       ok: true,
@@ -170,7 +161,7 @@ export function callDatasetSaveDraftRpc(
 ) {
   return callDatasetRpc(
     supabase,
-    "cmd_dataset_save_draft",
+    'cmd_dataset_save_draft',
     buildDatasetSaveDraftRpcArgs(request, audit),
   );
 }
@@ -180,11 +171,7 @@ export function callDatasetCreateRpc(
   request: CreateRequest,
   audit: CommandAuditPayload,
 ) {
-  return callDatasetRpc(
-    supabase,
-    "cmd_dataset_create",
-    buildDatasetCreateRpcArgs(request, audit),
-  );
+  return callDatasetRpc(supabase, 'cmd_dataset_create', buildDatasetCreateRpcArgs(request, audit));
 }
 
 export function callDatasetDeleteRpc(
@@ -192,11 +179,7 @@ export function callDatasetDeleteRpc(
   request: DeleteRequest,
   audit: CommandAuditPayload,
 ) {
-  return callDatasetRpc(
-    supabase,
-    "cmd_dataset_delete",
-    buildDatasetDeleteRpcArgs(request, audit),
-  );
+  return callDatasetRpc(supabase, 'cmd_dataset_delete', buildDatasetDeleteRpcArgs(request, audit));
 }
 
 export function callDatasetAssignTeamRpc(
@@ -206,7 +189,7 @@ export function callDatasetAssignTeamRpc(
 ) {
   return callDatasetRpc(
     supabase,
-    "cmd_dataset_assign_team",
+    'cmd_dataset_assign_team',
     buildDatasetAssignTeamRpcArgs(request, audit),
   );
 }
@@ -218,7 +201,7 @@ export function callDatasetPublishRpc(
 ) {
   return callDatasetRpc(
     supabase,
-    "cmd_dataset_publish",
+    'cmd_dataset_publish',
     buildDatasetPublishRpcArgs(request, audit),
   );
 }
@@ -230,7 +213,7 @@ export function callDatasetSubmitReviewRpc(
 ) {
   return callDatasetRpc(
     supabase,
-    "cmd_review_submit",
+    'cmd_review_submit',
     buildDatasetSubmitReviewRpcArgs(request, audit),
   );
 }

--- a/supabase/functions/_shared/db_rpc/membership_commands.ts
+++ b/supabase/functions/_shared/db_rpc/membership_commands.ts
@@ -1,6 +1,6 @@
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import type { CommandAuditPayload } from "../command_runtime/audit_log.ts";
+import type { CommandAuditPayload } from '../command_runtime/audit_log.ts';
 import type {
   MembershipCommandFailure,
   ReviewChangeMemberRoleRequest,
@@ -12,39 +12,28 @@ import type {
   TeamSetRankRequest,
   TeamUpdateProfileRequest,
   UserUpdateContactRequest,
-} from "../commands/membership/types.ts";
+} from '../commands/membership/types.ts';
 
-type RpcClient = Pick<SupabaseClient, "rpc">;
+type RpcClient = Pick<SupabaseClient, 'rpc'>;
 
-export type MembershipRpcResult =
-  | { ok: true; data: unknown }
-  | MembershipCommandFailure;
+export type MembershipRpcResult = { ok: true; data: unknown } | MembershipCommandFailure;
 
-function mapRpcError(
-  error: { code?: string; message?: string; details?: unknown },
-) {
-  const code = error.code ?? "RPC_ERROR";
-  const status = code === "42501"
-    ? 403
-    : code === "PGRST116"
-    ? 404
-    : code === "AUTH_REQUIRED"
-    ? 401
-    : 400;
+function mapRpcError(error: { code?: string; message?: string; details?: unknown }) {
+  const code = error.code ?? 'RPC_ERROR';
+  const status =
+    code === '42501' ? 403 : code === 'PGRST116' ? 404 : code === 'AUTH_REQUIRED' ? 401 : 400;
 
   return {
     ok: false as const,
     code,
     status,
-    message: error.message ?? "Membership command RPC failed",
+    message: error.message ?? 'Membership command RPC failed',
     details: error.details ?? null,
   };
 }
 
-function isMembershipCommandFailure(
-  data: unknown,
-): data is MembershipCommandFailure {
-  if (!data || typeof data !== "object") {
+function isMembershipCommandFailure(data: unknown): data is MembershipCommandFailure {
+  if (!data || typeof data !== 'object') {
     return false;
   }
 
@@ -53,9 +42,9 @@ function isMembershipCommandFailure(
   };
   return (
     candidate.ok === false &&
-    typeof candidate.code === "string" &&
-    typeof candidate.message === "string" &&
-    typeof candidate.status === "number"
+    typeof candidate.code === 'string' &&
+    typeof candidate.message === 'string' &&
+    typeof candidate.status === 'number'
   );
 }
 
@@ -75,10 +64,10 @@ async function callMembershipRpc(
 
   if (
     data &&
-    typeof data === "object" &&
+    typeof data === 'object' &&
     !Array.isArray(data) &&
     (data as { ok?: unknown }).ok === true &&
-    "data" in (data as Record<string, unknown>)
+    'data' in (data as Record<string, unknown>)
   ) {
     return {
       ok: true,
@@ -147,7 +136,7 @@ export function buildTeamChangeMemberRoleRpcArgs(
     p_team_id: request.teamId,
     p_user_id: request.userId,
     p_role: request.role ?? null,
-    p_action: request.action ?? "set",
+    p_action: request.action ?? 'set',
     p_audit: audit,
   };
 }
@@ -159,7 +148,7 @@ export function buildSystemChangeMemberRoleRpcArgs(
   return {
     p_user_id: request.userId,
     p_role: request.role ?? null,
-    p_action: request.action ?? "set",
+    p_action: request.action ?? 'set',
     p_audit: audit,
   };
 }
@@ -171,7 +160,7 @@ export function buildReviewChangeMemberRoleRpcArgs(
   return {
     p_user_id: request.userId,
     p_role: request.role ?? null,
-    p_action: request.action ?? "set",
+    p_action: request.action ?? 'set',
     p_audit: audit,
   };
 }
@@ -202,11 +191,7 @@ export function callTeamCreateRpc(
   request: TeamCreateRequest,
   audit: CommandAuditPayload,
 ) {
-  return callMembershipRpc(
-    supabase,
-    "cmd_team_create",
-    buildTeamCreateRpcArgs(request, audit),
-  );
+  return callMembershipRpc(supabase, 'cmd_team_create', buildTeamCreateRpcArgs(request, audit));
 }
 
 export function callTeamUpdateProfileRpc(
@@ -216,7 +201,7 @@ export function callTeamUpdateProfileRpc(
 ) {
   return callMembershipRpc(
     supabase,
-    "cmd_team_update_profile",
+    'cmd_team_update_profile',
     buildTeamUpdateProfileRpcArgs(request, audit),
   );
 }
@@ -226,11 +211,7 @@ export function callTeamSetRankRpc(
   request: TeamSetRankRequest,
   audit: CommandAuditPayload,
 ) {
-  return callMembershipRpc(
-    supabase,
-    "cmd_team_set_rank",
-    buildTeamSetRankRpcArgs(request, audit),
-  );
+  return callMembershipRpc(supabase, 'cmd_team_set_rank', buildTeamSetRankRpcArgs(request, audit));
 }
 
 export function callUserUpdateContactRpc(
@@ -240,7 +221,7 @@ export function callUserUpdateContactRpc(
 ) {
   return callMembershipRpc(
     supabase,
-    "cmd_user_update_contact",
+    'cmd_user_update_contact',
     buildUserUpdateContactRpcArgs(request, audit),
   );
 }
@@ -252,7 +233,7 @@ export function callTeamChangeMemberRoleRpc(
 ) {
   return callMembershipRpc(
     supabase,
-    "cmd_team_change_member_role",
+    'cmd_team_change_member_role',
     buildTeamChangeMemberRoleRpcArgs(request, audit),
   );
 }
@@ -264,7 +245,7 @@ export function callSystemChangeMemberRoleRpc(
 ) {
   return callMembershipRpc(
     supabase,
-    "cmd_system_change_member_role",
+    'cmd_system_change_member_role',
     buildSystemChangeMemberRoleRpcArgs(request, audit),
   );
 }
@@ -276,7 +257,7 @@ export function callReviewChangeMemberRoleRpc(
 ) {
   return callMembershipRpc(
     supabase,
-    "cmd_review_change_member_role",
+    'cmd_review_change_member_role',
     buildReviewChangeMemberRoleRpcArgs(request, audit),
   );
 }
@@ -288,7 +269,7 @@ export function callTeamReinviteMemberRpc(
 ) {
   return callMembershipRpc(
     supabase,
-    "cmd_team_reinvite_member",
+    'cmd_team_reinvite_member',
     buildTeamReinviteMemberRpcArgs(request, audit),
   );
 }
@@ -300,7 +281,7 @@ export function callTeamAcceptInvitationRpc(
 ) {
   return callMembershipRpc(
     supabase,
-    "cmd_team_accept_invitation",
+    'cmd_team_accept_invitation',
     buildTeamInvitationDecisionRpcArgs(request, audit),
   );
 }
@@ -312,7 +293,7 @@ export function callTeamRejectInvitationRpc(
 ) {
   return callMembershipRpc(
     supabase,
-    "cmd_team_reject_invitation",
+    'cmd_team_reject_invitation',
     buildTeamInvitationDecisionRpcArgs(request, audit),
   );
 }

--- a/supabase/functions/_shared/db_rpc/notification_commands.ts
+++ b/supabase/functions/_shared/db_rpc/notification_commands.ts
@@ -1,42 +1,31 @@
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import type { CommandAuditPayload } from "../command_runtime/audit_log.ts";
+import type { CommandAuditPayload } from '../command_runtime/audit_log.ts';
 import type {
   NotificationCommandFailure,
   NotificationSendValidationIssueRequest,
-} from "../commands/notification/types.ts";
+} from '../commands/notification/types.ts';
 
-type RpcClient = Pick<SupabaseClient, "rpc">;
+type RpcClient = Pick<SupabaseClient, 'rpc'>;
 
-export type NotificationRpcResult =
-  | { ok: true; data: unknown }
-  | NotificationCommandFailure;
+export type NotificationRpcResult = { ok: true; data: unknown } | NotificationCommandFailure;
 
-function mapRpcError(
-  error: { code?: string; message?: string; details?: unknown },
-) {
-  const code = error.code ?? "RPC_ERROR";
-  const status = code === "42501"
-    ? 403
-    : code === "PGRST116"
-    ? 404
-    : code === "AUTH_REQUIRED"
-    ? 401
-    : 400;
+function mapRpcError(error: { code?: string; message?: string; details?: unknown }) {
+  const code = error.code ?? 'RPC_ERROR';
+  const status =
+    code === '42501' ? 403 : code === 'PGRST116' ? 404 : code === 'AUTH_REQUIRED' ? 401 : 400;
 
   return {
     ok: false as const,
     code,
     status,
-    message: error.message ?? "Notification command RPC failed",
+    message: error.message ?? 'Notification command RPC failed',
     details: error.details ?? null,
   };
 }
 
-function isNotificationCommandFailure(
-  data: unknown,
-): data is NotificationCommandFailure {
-  if (!data || typeof data !== "object") {
+function isNotificationCommandFailure(data: unknown): data is NotificationCommandFailure {
+  if (!data || typeof data !== 'object') {
     return false;
   }
 
@@ -45,9 +34,9 @@ function isNotificationCommandFailure(
   };
   return (
     candidate.ok === false &&
-    typeof candidate.code === "string" &&
-    typeof candidate.message === "string" &&
-    typeof candidate.status === "number"
+    typeof candidate.code === 'string' &&
+    typeof candidate.message === 'string' &&
+    typeof candidate.status === 'number'
   );
 }
 
@@ -67,10 +56,10 @@ async function callNotificationRpc(
 
   if (
     data &&
-    typeof data === "object" &&
+    typeof data === 'object' &&
     !Array.isArray(data) &&
     (data as { ok?: unknown }).ok === true &&
-    "data" in (data as Record<string, unknown>)
+    'data' in (data as Record<string, unknown>)
   ) {
     return {
       ok: true,
@@ -111,7 +100,7 @@ export function callNotificationSendValidationIssueRpc(
 ) {
   return callNotificationRpc(
     supabase,
-    "cmd_notification_send_validation_issue",
+    'cmd_notification_send_validation_issue',
     buildNotificationSendValidationIssueRpcArgs(request, audit),
   );
 }

--- a/supabase/functions/_shared/db_rpc/review_commands.ts
+++ b/supabase/functions/_shared/db_rpc/review_commands.ts
@@ -1,6 +1,6 @@
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import type { CommandAuditPayload } from "../command_runtime/audit_log.ts";
+import type { CommandAuditPayload } from '../command_runtime/audit_log.ts';
 import type {
   ApproveReviewRequest,
   AssignReviewersRequest,
@@ -10,46 +10,37 @@ import type {
   SaveAssignmentDraftRequest,
   SaveCommentDraftRequest,
   SubmitCommentRequest,
-} from "../commands/review/types.ts";
+} from '../commands/review/types.ts';
 
-type RpcClient = Pick<SupabaseClient, "rpc">;
+type RpcClient = Pick<SupabaseClient, 'rpc'>;
 
-export type ReviewRpcResult =
-  | { ok: true; data: unknown }
-  | ReviewCommandFailure;
+export type ReviewRpcResult = { ok: true; data: unknown } | ReviewCommandFailure;
 
-function mapRpcError(
-  error: { code?: string; message?: string; details?: unknown },
-) {
-  const code = error.code ?? "RPC_ERROR";
-  const status = code === "42501"
-    ? 403
-    : code === "PGRST116"
-    ? 404
-    : code === "AUTH_REQUIRED"
-    ? 401
-    : 400;
+function mapRpcError(error: { code?: string; message?: string; details?: unknown }) {
+  const code = error.code ?? 'RPC_ERROR';
+  const status =
+    code === '42501' ? 403 : code === 'PGRST116' ? 404 : code === 'AUTH_REQUIRED' ? 401 : 400;
 
   return {
     ok: false as const,
     code,
     status,
-    message: error.message ?? "Review command RPC failed",
+    message: error.message ?? 'Review command RPC failed',
     details: error.details ?? null,
   };
 }
 
 function isReviewCommandFailure(data: unknown): data is ReviewCommandFailure {
-  if (!data || typeof data !== "object") {
+  if (!data || typeof data !== 'object') {
     return false;
   }
 
   const candidate = data as Partial<ReviewCommandFailure> & { ok?: unknown };
   return (
     candidate.ok === false &&
-    typeof candidate.code === "string" &&
-    typeof candidate.message === "string" &&
-    typeof candidate.status === "number"
+    typeof candidate.code === 'string' &&
+    typeof candidate.message === 'string' &&
+    typeof candidate.status === 'number'
   );
 }
 
@@ -69,10 +60,10 @@ async function callReviewRpc(
 
   if (
     data &&
-    typeof data === "object" &&
+    typeof data === 'object' &&
     !Array.isArray(data) &&
     (data as { ok?: unknown }).ok === true &&
-    "data" in (data as Record<string, unknown>)
+    'data' in (data as Record<string, unknown>)
   ) {
     return {
       ok: true,
@@ -173,7 +164,7 @@ export function callReviewSaveAssignmentDraftRpc(
 ) {
   return callReviewRpc(
     supabase,
-    "cmd_review_save_assignment_draft",
+    'cmd_review_save_assignment_draft',
     buildReviewSaveAssignmentDraftRpcArgs(request, audit),
   );
 }
@@ -185,7 +176,7 @@ export function callReviewAssignReviewersRpc(
 ) {
   return callReviewRpc(
     supabase,
-    "cmd_review_assign_reviewers",
+    'cmd_review_assign_reviewers',
     buildReviewAssignReviewersRpcArgs(request, audit),
   );
 }
@@ -197,7 +188,7 @@ export function callReviewRevokeReviewerRpc(
 ) {
   return callReviewRpc(
     supabase,
-    "cmd_review_revoke_reviewer",
+    'cmd_review_revoke_reviewer',
     buildReviewRevokeReviewerRpcArgs(request, audit),
   );
 }
@@ -209,7 +200,7 @@ export function callReviewSaveCommentDraftRpc(
 ) {
   return callReviewRpc(
     supabase,
-    "cmd_review_save_comment_draft",
+    'cmd_review_save_comment_draft',
     buildReviewSaveCommentDraftRpcArgs(request, audit),
   );
 }
@@ -221,7 +212,7 @@ export function callReviewSubmitCommentRpc(
 ) {
   return callReviewRpc(
     supabase,
-    "cmd_review_submit_comment",
+    'cmd_review_submit_comment',
     buildReviewSubmitCommentRpcArgs(request, audit),
   );
 }
@@ -231,11 +222,7 @@ export function callReviewApproveRpc(
   request: ApproveReviewRequest,
   audit: CommandAuditPayload,
 ) {
-  return callReviewRpc(
-    supabase,
-    "cmd_review_approve",
-    buildReviewApproveRpcArgs(request, audit),
-  );
+  return callReviewRpc(supabase, 'cmd_review_approve', buildReviewApproveRpcArgs(request, audit));
 }
 
 export function callReviewRejectRpc(
@@ -243,9 +230,5 @@ export function callReviewRejectRpc(
   request: RejectReviewRequest,
   audit: CommandAuditPayload,
 ) {
-  return callReviewRpc(
-    supabase,
-    "cmd_review_reject",
-    buildReviewRejectRpcArgs(request, audit),
-  );
+  return callReviewRpc(supabase, 'cmd_review_reject', buildReviewRejectRpcArgs(request, audit));
 }

--- a/supabase/functions/_shared/legacy_endpoint_removed.ts
+++ b/supabase/functions/_shared/legacy_endpoint_removed.ts
@@ -1,21 +1,21 @@
-import { corsHeaders } from "./cors.ts";
+import { corsHeaders } from './cors.ts';
 
 export const LEGACY_ENDPOINT_REMOVED_RESPONSE = {
   ok: false,
-  code: "LEGACY_ENDPOINT_REMOVED",
-  message: "Use explicit command endpoints instead",
+  code: 'LEGACY_ENDPOINT_REMOVED',
+  message: 'Use explicit command endpoints instead',
 } as const;
 
 export function createLegacyEndpointRemovedHandler() {
   return (req: Request) => {
-    if (req.method === "OPTIONS") {
-      return new Response("ok", { headers: corsHeaders });
+    if (req.method === 'OPTIONS') {
+      return new Response('ok', { headers: corsHeaders });
     }
 
     return new Response(JSON.stringify(LEGACY_ENDPOINT_REMOVED_RESPONSE), {
       status: 410,
       headers: {
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
         ...corsHeaders,
       },
     });

--- a/supabase/functions/update_comment/index.ts
+++ b/supabase/functions/update_comment/index.ts
@@ -1,6 +1,6 @@
-import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
-import { createLegacyEndpointRemovedHandler } from "../_shared/legacy_endpoint_removed.ts";
+import { createLegacyEndpointRemovedHandler } from '../_shared/legacy_endpoint_removed.ts';
 
 export const handleUpdateComment = createLegacyEndpointRemovedHandler();
 

--- a/supabase/functions/update_data/index.ts
+++ b/supabase/functions/update_data/index.ts
@@ -1,6 +1,6 @@
-import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
-import { createLegacyEndpointRemovedHandler } from "../_shared/legacy_endpoint_removed.ts";
+import { createLegacyEndpointRemovedHandler } from '../_shared/legacy_endpoint_removed.ts';
 
 export const handleUpdateData = createLegacyEndpointRemovedHandler();
 

--- a/supabase/functions/update_review/index.ts
+++ b/supabase/functions/update_review/index.ts
@@ -1,6 +1,6 @@
-import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
-import { createLegacyEndpointRemovedHandler } from "../_shared/legacy_endpoint_removed.ts";
+import { createLegacyEndpointRemovedHandler } from '../_shared/legacy_endpoint_removed.ts';
 
 export const handleUpdateReview = createLegacyEndpointRemovedHandler();
 

--- a/supabase/functions/update_role/index.ts
+++ b/supabase/functions/update_role/index.ts
@@ -1,6 +1,6 @@
-import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
-import { createLegacyEndpointRemovedHandler } from "../_shared/legacy_endpoint_removed.ts";
+import { createLegacyEndpointRemovedHandler } from '../_shared/legacy_endpoint_removed.ts';
 
 export const handleUpdateRole = createLegacyEndpointRemovedHandler();
 

--- a/supabase/functions/update_team/index.ts
+++ b/supabase/functions/update_team/index.ts
@@ -1,6 +1,6 @@
-import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
-import { createLegacyEndpointRemovedHandler } from "../_shared/legacy_endpoint_removed.ts";
+import { createLegacyEndpointRemovedHandler } from '../_shared/legacy_endpoint_removed.ts';
 
 export const handleUpdateTeam = createLegacyEndpointRemovedHandler();
 

--- a/supabase/functions/update_user/index.ts
+++ b/supabase/functions/update_user/index.ts
@@ -1,6 +1,6 @@
-import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 
-import { createLegacyEndpointRemovedHandler } from "../_shared/legacy_endpoint_removed.ts";
+import { createLegacyEndpointRemovedHandler } from '../_shared/legacy_endpoint_removed.ts';
 
 export const handleUpdateUser = createLegacyEndpointRemovedHandler();
 

--- a/test/admin_review_assignment_test.ts
+++ b/test/admin_review_assignment_test.ts
@@ -1,14 +1,14 @@
-import { assertEquals } from "jsr:@std/assert";
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import { executeAssignReviewersCommand } from "../supabase/functions/_shared/commands/review/assign_reviewers.ts";
-import { executeRevokeReviewerCommand } from "../supabase/functions/_shared/commands/review/revoke_reviewer.ts";
-import { executeSaveAssignmentDraftCommand } from "../supabase/functions/_shared/commands/review/save_assignment_draft.ts";
+import { executeAssignReviewersCommand } from '../supabase/functions/_shared/commands/review/assign_reviewers.ts';
+import { executeRevokeReviewerCommand } from '../supabase/functions/_shared/commands/review/revoke_reviewer.ts';
+import { executeSaveAssignmentDraftCommand } from '../supabase/functions/_shared/commands/review/save_assignment_draft.ts';
 
-const TEST_USER_ID = "11111111-1111-4111-8111-111111111111";
-const TEST_REVIEW_ID = "22222222-2222-4222-8222-222222222222";
-const TEST_REVIEWER_A = "33333333-3333-4333-8333-333333333333";
-const TEST_REVIEWER_B = "44444444-4444-4444-8444-444444444444";
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_REVIEW_ID = '22222222-2222-4222-8222-222222222222';
+const TEST_REVIEWER_A = '33333333-3333-4333-8333-333333333333';
+const TEST_REVIEWER_B = '44444444-4444-4444-8444-444444444444';
 
 class FakeRpcSupabase {
   rpcCalls: Array<{ fn: string; args: unknown }> = [];
@@ -31,13 +31,13 @@ class FakeRpcSupabase {
 function buildActor(supabase: FakeRpcSupabase) {
   return {
     userId: TEST_USER_ID,
-    accessToken: "access-token",
+    accessToken: 'access-token',
     supabase: supabase as unknown as SupabaseClient,
   };
 }
 
 Deno.test(
-  "executeSaveAssignmentDraftCommand forwards review assignment draft to cmd_review_save_assignment_draft",
+  'executeSaveAssignmentDraftCommand forwards review assignment draft to cmd_review_save_assignment_draft',
   async () => {
     const supabase = new FakeRpcSupabase();
     const result = await executeSaveAssignmentDraftCommand(
@@ -51,16 +51,16 @@ Deno.test(
     assertEquals(result.ok, true);
     assertEquals(supabase.rpcCalls, [
       {
-        fn: "cmd_review_save_assignment_draft",
+        fn: 'cmd_review_save_assignment_draft',
         args: {
           p_review_id: TEST_REVIEW_ID,
           p_reviewer_ids: [TEST_REVIEWER_A, TEST_REVIEWER_B],
           p_audit: {
-            command: "review_save_assignment_draft",
+            command: 'review_save_assignment_draft',
             actorUserId: TEST_USER_ID,
-            targetTable: "reviews",
+            targetTable: 'reviews',
             targetId: TEST_REVIEW_ID,
-            targetVersion: "",
+            targetVersion: '',
             payload: {
               reviewerIds: [TEST_REVIEWER_A, TEST_REVIEWER_B],
             },
@@ -72,14 +72,14 @@ Deno.test(
 );
 
 Deno.test(
-  "executeAssignReviewersCommand forwards review assignment to cmd_review_assign_reviewers",
+  'executeAssignReviewersCommand forwards review assignment to cmd_review_assign_reviewers',
   async () => {
     const supabase = new FakeRpcSupabase();
     const result = await executeAssignReviewersCommand(
       {
         reviewId: TEST_REVIEW_ID,
         reviewerIds: [TEST_REVIEWER_A],
-        deadline: "2026-04-10T12:00:00.000Z",
+        deadline: '2026-04-10T12:00:00.000Z',
       },
       buildActor(supabase),
     );
@@ -87,20 +87,20 @@ Deno.test(
     assertEquals(result.ok, true);
     assertEquals(supabase.rpcCalls, [
       {
-        fn: "cmd_review_assign_reviewers",
+        fn: 'cmd_review_assign_reviewers',
         args: {
           p_review_id: TEST_REVIEW_ID,
           p_reviewer_ids: [TEST_REVIEWER_A],
-          p_deadline: "2026-04-10T12:00:00.000Z",
+          p_deadline: '2026-04-10T12:00:00.000Z',
           p_audit: {
-            command: "review_assign_reviewers",
+            command: 'review_assign_reviewers',
             actorUserId: TEST_USER_ID,
-            targetTable: "reviews",
+            targetTable: 'reviews',
             targetId: TEST_REVIEW_ID,
-            targetVersion: "",
+            targetVersion: '',
             payload: {
               reviewerIds: [TEST_REVIEWER_A],
-              deadline: "2026-04-10T12:00:00.000Z",
+              deadline: '2026-04-10T12:00:00.000Z',
             },
           },
         },
@@ -110,7 +110,7 @@ Deno.test(
 );
 
 Deno.test(
-  "executeRevokeReviewerCommand forwards review revocation to cmd_review_revoke_reviewer",
+  'executeRevokeReviewerCommand forwards review revocation to cmd_review_revoke_reviewer',
   async () => {
     const supabase = new FakeRpcSupabase();
     const result = await executeRevokeReviewerCommand(
@@ -124,16 +124,16 @@ Deno.test(
     assertEquals(result.ok, true);
     assertEquals(supabase.rpcCalls, [
       {
-        fn: "cmd_review_revoke_reviewer",
+        fn: 'cmd_review_revoke_reviewer',
         args: {
           p_review_id: TEST_REVIEW_ID,
           p_reviewer_id: TEST_REVIEWER_B,
           p_audit: {
-            command: "review_revoke_reviewer",
+            command: 'review_revoke_reviewer',
             actorUserId: TEST_USER_ID,
-            targetTable: "reviews",
+            targetTable: 'reviews',
             targetId: TEST_REVIEW_ID,
-            targetVersion: "",
+            targetVersion: '',
             payload: {
               reviewerId: TEST_REVIEWER_B,
             },

--- a/test/admin_review_decision_test.ts
+++ b/test/admin_review_decision_test.ts
@@ -1,11 +1,11 @@
-import { assertEquals } from "jsr:@std/assert";
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import { executeApproveReviewCommand } from "../supabase/functions/_shared/commands/review/approve_review.ts";
-import { executeRejectReviewCommand } from "../supabase/functions/_shared/commands/review/reject_review.ts";
+import { executeApproveReviewCommand } from '../supabase/functions/_shared/commands/review/approve_review.ts';
+import { executeRejectReviewCommand } from '../supabase/functions/_shared/commands/review/reject_review.ts';
 
-const TEST_USER_ID = "11111111-1111-4111-8111-111111111111";
-const TEST_REVIEW_ID = "22222222-2222-4222-8222-222222222222";
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_REVIEW_ID = '22222222-2222-4222-8222-222222222222';
 
 class FakeRpcSupabase {
   rpcCalls: Array<{ fn: string; args: unknown }> = [];
@@ -28,16 +28,16 @@ class FakeRpcSupabase {
 function buildActor(supabase: FakeRpcSupabase) {
   return {
     userId: TEST_USER_ID,
-    accessToken: "access-token",
+    accessToken: 'access-token',
     supabase: supabase as unknown as SupabaseClient,
   };
 }
 
-Deno.test("executeApproveReviewCommand forwards approvals to cmd_review_approve", async () => {
+Deno.test('executeApproveReviewCommand forwards approvals to cmd_review_approve', async () => {
   const supabase = new FakeRpcSupabase();
   const result = await executeApproveReviewCommand(
     {
-      table: "processes",
+      table: 'processes',
       reviewId: TEST_REVIEW_ID,
     },
     buildActor(supabase),
@@ -46,16 +46,16 @@ Deno.test("executeApproveReviewCommand forwards approvals to cmd_review_approve"
   assertEquals(result.ok, true);
   assertEquals(supabase.rpcCalls, [
     {
-      fn: "cmd_review_approve",
+      fn: 'cmd_review_approve',
       args: {
-        p_table: "processes",
+        p_table: 'processes',
         p_review_id: TEST_REVIEW_ID,
         p_audit: {
-          command: "review_approve",
+          command: 'review_approve',
           actorUserId: TEST_USER_ID,
-          targetTable: "processes",
+          targetTable: 'processes',
           targetId: TEST_REVIEW_ID,
-          targetVersion: "",
+          targetVersion: '',
           payload: {},
         },
       },
@@ -63,13 +63,13 @@ Deno.test("executeApproveReviewCommand forwards approvals to cmd_review_approve"
   ]);
 });
 
-Deno.test("executeRejectReviewCommand forwards rejections to cmd_review_reject", async () => {
+Deno.test('executeRejectReviewCommand forwards rejections to cmd_review_reject', async () => {
   const supabase = new FakeRpcSupabase();
   const result = await executeRejectReviewCommand(
     {
-      table: "lifecyclemodels",
+      table: 'lifecyclemodels',
       reviewId: TEST_REVIEW_ID,
-      reason: "Data quality issue",
+      reason: 'Data quality issue',
     },
     buildActor(supabase),
   );
@@ -77,19 +77,19 @@ Deno.test("executeRejectReviewCommand forwards rejections to cmd_review_reject",
   assertEquals(result.ok, true);
   assertEquals(supabase.rpcCalls, [
     {
-      fn: "cmd_review_reject",
+      fn: 'cmd_review_reject',
       args: {
-        p_table: "lifecyclemodels",
+        p_table: 'lifecyclemodels',
         p_review_id: TEST_REVIEW_ID,
-        p_reason: "Data quality issue",
+        p_reason: 'Data quality issue',
         p_audit: {
-          command: "review_reject",
+          command: 'review_reject',
           actorUserId: TEST_USER_ID,
-          targetTable: "lifecyclemodels",
+          targetTable: 'lifecyclemodels',
           targetId: TEST_REVIEW_ID,
-          targetVersion: "",
+          targetVersion: '',
           payload: {
-            reason: "Data quality issue",
+            reason: 'Data quality issue',
           },
         },
       },
@@ -97,20 +97,20 @@ Deno.test("executeRejectReviewCommand forwards rejections to cmd_review_reject",
   ]);
 });
 
-Deno.test("executeRejectReviewCommand rejects blank reason before RPC call", async () => {
+Deno.test('executeRejectReviewCommand rejects blank reason before RPC call', async () => {
   const supabase = new FakeRpcSupabase();
   const result = await executeRejectReviewCommand(
     {
-      table: "processes",
+      table: 'processes',
       reviewId: TEST_REVIEW_ID,
-      reason: "   ",
+      reason: '   ',
     },
     buildActor(supabase),
   );
 
   assertEquals(result.ok, false);
   if (!result.ok) {
-    assertEquals(result.code, "REASON_REQUIRED");
+    assertEquals(result.code, 'REASON_REQUIRED');
     assertEquals(result.status, 400);
   }
   assertEquals(supabase.rpcCalls.length, 0);

--- a/test/app_dataset_create_test.ts
+++ b/test/app_dataset_create_test.ts
@@ -1,14 +1,14 @@
-import { assertEquals } from "jsr:@std/assert";
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
 import {
   executeCreateCommand,
   parseCreateCommand,
-} from "../supabase/functions/_shared/commands/dataset/create.ts";
+} from '../supabase/functions/_shared/commands/dataset/create.ts';
 
-const TEST_USER_ID = "11111111-1111-4111-8111-111111111111";
-const TEST_DATASET_ID = "22222222-2222-4222-8222-222222222222";
-const TEST_MODEL_ID = "33333333-3333-4333-8333-333333333333";
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_DATASET_ID = '22222222-2222-4222-8222-222222222222';
+const TEST_MODEL_ID = '33333333-3333-4333-8333-333333333333';
 
 class FakeRpcSupabase {
   rpcCalls: Array<{ fn: string; args: unknown }> = [];
@@ -18,7 +18,7 @@ class FakeRpcSupabase {
     response: { data: unknown; error: unknown } = {
       data: {
         id: TEST_DATASET_ID,
-        version: "01.00.000",
+        version: '01.00.000',
       },
       error: null,
     },
@@ -39,18 +39,18 @@ class FakeRpcSupabase {
 function buildActor(supabase: FakeRpcSupabase) {
   return {
     userId: TEST_USER_ID,
-    accessToken: "access-token",
+    accessToken: 'access-token',
     supabase: supabase as unknown as SupabaseClient,
   };
 }
 
-Deno.test("executeCreateCommand forwards dataset creation to cmd_dataset_create", async () => {
+Deno.test('executeCreateCommand forwards dataset creation to cmd_dataset_create', async () => {
   const supabase = new FakeRpcSupabase();
   const result = await executeCreateCommand(
     {
-      table: "processes",
+      table: 'processes',
       id: TEST_DATASET_ID,
-      jsonOrdered: { foo: "bar" },
+      jsonOrdered: { foo: 'bar' },
       modelId: TEST_MODEL_ID,
       ruleVerification: false,
     },
@@ -60,19 +60,19 @@ Deno.test("executeCreateCommand forwards dataset creation to cmd_dataset_create"
   assertEquals(result.ok, true);
   assertEquals(supabase.rpcCalls, [
     {
-      fn: "cmd_dataset_create",
+      fn: 'cmd_dataset_create',
       args: {
-        p_table: "processes",
+        p_table: 'processes',
         p_id: TEST_DATASET_ID,
-        p_json_ordered: { foo: "bar" },
+        p_json_ordered: { foo: 'bar' },
         p_model_id: TEST_MODEL_ID,
         p_rule_verification: false,
         p_audit: {
-          command: "dataset_create",
+          command: 'dataset_create',
           actorUserId: TEST_USER_ID,
-          targetTable: "processes",
+          targetTable: 'processes',
           targetId: TEST_DATASET_ID,
-          targetVersion: "",
+          targetVersion: '',
           payload: {
             modelId: TEST_MODEL_ID,
           },
@@ -82,13 +82,13 @@ Deno.test("executeCreateCommand forwards dataset creation to cmd_dataset_create"
   ]);
 });
 
-Deno.test("executeCreateCommand allows process creates without modelId", async () => {
+Deno.test('executeCreateCommand allows process creates without modelId', async () => {
   const supabase = new FakeRpcSupabase();
   const result = await executeCreateCommand(
     {
-      table: "processes",
+      table: 'processes',
       id: TEST_DATASET_ID,
-      jsonOrdered: { foo: "bar" },
+      jsonOrdered: { foo: 'bar' },
     },
     buildActor(supabase),
   );
@@ -96,19 +96,19 @@ Deno.test("executeCreateCommand allows process creates without modelId", async (
   assertEquals(result.ok, true);
   assertEquals(supabase.rpcCalls, [
     {
-      fn: "cmd_dataset_create",
+      fn: 'cmd_dataset_create',
       args: {
-        p_table: "processes",
+        p_table: 'processes',
         p_id: TEST_DATASET_ID,
-        p_json_ordered: { foo: "bar" },
+        p_json_ordered: { foo: 'bar' },
         p_model_id: null,
         p_rule_verification: null,
         p_audit: {
-          command: "dataset_create",
+          command: 'dataset_create',
           actorUserId: TEST_USER_ID,
-          targetTable: "processes",
+          targetTable: 'processes',
           targetId: TEST_DATASET_ID,
-          targetVersion: "",
+          targetVersion: '',
           payload: {},
         },
       },
@@ -116,23 +116,23 @@ Deno.test("executeCreateCommand allows process creates without modelId", async (
   ]);
 });
 
-Deno.test("parseCreateCommand rejects invalid dataset create payloads", () => {
+Deno.test('parseCreateCommand rejects invalid dataset create payloads', () => {
   const result = parseCreateCommand({
-    table: "unknown",
-    id: "not-a-uuid",
-    jsonOrdered: { foo: "bar" },
+    table: 'unknown',
+    id: 'not-a-uuid',
+    jsonOrdered: { foo: 'bar' },
   });
 
   assertEquals(result.ok, false);
 });
 
-Deno.test("executeCreateCommand rejects modelId for non-process datasets", async () => {
+Deno.test('executeCreateCommand rejects modelId for non-process datasets', async () => {
   const supabase = new FakeRpcSupabase();
   const result = await executeCreateCommand(
     {
-      table: "flows",
+      table: 'flows',
       id: TEST_DATASET_ID,
-      jsonOrdered: { foo: "bar" },
+      jsonOrdered: { foo: 'bar' },
       modelId: TEST_MODEL_ID,
     },
     buildActor(supabase),
@@ -140,8 +140,8 @@ Deno.test("executeCreateCommand rejects modelId for non-process datasets", async
 
   assertEquals(result, {
     ok: false,
-    code: "MODEL_ID_NOT_ALLOWED",
-    message: "modelId is only allowed for process dataset creates",
+    code: 'MODEL_ID_NOT_ALLOWED',
+    message: 'modelId is only allowed for process dataset creates',
     status: 400,
   });
   assertEquals(supabase.rpcCalls, []);

--- a/test/app_dataset_delete_test.ts
+++ b/test/app_dataset_delete_test.ts
@@ -1,13 +1,13 @@
-import { assertEquals } from "jsr:@std/assert";
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
 import {
   executeDeleteCommand,
   parseDeleteCommand,
-} from "../supabase/functions/_shared/commands/dataset/delete.ts";
+} from '../supabase/functions/_shared/commands/dataset/delete.ts';
 
-const TEST_USER_ID = "11111111-1111-4111-8111-111111111111";
-const TEST_DATASET_ID = "22222222-2222-4222-8222-222222222222";
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_DATASET_ID = '22222222-2222-4222-8222-222222222222';
 
 class FakeRpcSupabase {
   rpcCalls: Array<{ fn: string; args: unknown }> = [];
@@ -38,18 +38,18 @@ class FakeRpcSupabase {
 function buildActor(supabase: FakeRpcSupabase) {
   return {
     userId: TEST_USER_ID,
-    accessToken: "access-token",
+    accessToken: 'access-token',
     supabase: supabase as unknown as SupabaseClient,
   };
 }
 
-Deno.test("executeDeleteCommand forwards dataset deletion to cmd_dataset_delete", async () => {
+Deno.test('executeDeleteCommand forwards dataset deletion to cmd_dataset_delete', async () => {
   const supabase = new FakeRpcSupabase();
   const result = await executeDeleteCommand(
     {
-      table: "flows",
+      table: 'flows',
       id: TEST_DATASET_ID,
-      version: "01.00.000",
+      version: '01.00.000',
     },
     buildActor(supabase),
   );
@@ -57,17 +57,17 @@ Deno.test("executeDeleteCommand forwards dataset deletion to cmd_dataset_delete"
   assertEquals(result.ok, true);
   assertEquals(supabase.rpcCalls, [
     {
-      fn: "cmd_dataset_delete",
+      fn: 'cmd_dataset_delete',
       args: {
-        p_table: "flows",
+        p_table: 'flows',
         p_id: TEST_DATASET_ID,
-        p_version: "01.00.000",
+        p_version: '01.00.000',
         p_audit: {
-          command: "dataset_delete",
+          command: 'dataset_delete',
           actorUserId: TEST_USER_ID,
-          targetTable: "flows",
+          targetTable: 'flows',
           targetId: TEST_DATASET_ID,
-          targetVersion: "01.00.000",
+          targetVersion: '01.00.000',
           payload: {},
         },
       },
@@ -75,39 +75,39 @@ Deno.test("executeDeleteCommand forwards dataset deletion to cmd_dataset_delete"
   ]);
 });
 
-Deno.test("parseDeleteCommand rejects invalid dataset delete payloads", () => {
+Deno.test('parseDeleteCommand rejects invalid dataset delete payloads', () => {
   const result = parseDeleteCommand({
-    table: "unknown",
-    id: "not-a-uuid",
-    version: "1",
+    table: 'unknown',
+    id: 'not-a-uuid',
+    version: '1',
   });
 
   assertEquals(result.ok, false);
 });
 
-Deno.test("executeDeleteCommand maps RPC permission errors to 403", async () => {
+Deno.test('executeDeleteCommand maps RPC permission errors to 403', async () => {
   const supabase = new FakeRpcSupabase({
     data: null,
     error: {
-      code: "42501",
-      message: "permission denied",
-      details: "actor lacks permission",
+      code: '42501',
+      message: 'permission denied',
+      details: 'actor lacks permission',
     },
   });
   const result = await executeDeleteCommand(
     {
-      table: "flows",
+      table: 'flows',
       id: TEST_DATASET_ID,
-      version: "01.00.000",
+      version: '01.00.000',
     },
     buildActor(supabase),
   );
 
   assertEquals(result, {
     ok: false,
-    code: "42501",
+    code: '42501',
     status: 403,
-    message: "permission denied",
-    details: "actor lacks permission",
+    message: 'permission denied',
+    details: 'actor lacks permission',
   });
 });

--- a/test/app_dataset_save_draft_test.ts
+++ b/test/app_dataset_save_draft_test.ts
@@ -1,11 +1,11 @@
-import { assertEquals } from "jsr:@std/assert";
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import { executeSaveDraftCommand } from "../supabase/functions/_shared/commands/dataset/save_draft.ts";
+import { executeSaveDraftCommand } from '../supabase/functions/_shared/commands/dataset/save_draft.ts';
 
-const TEST_USER_ID = "11111111-1111-4111-8111-111111111111";
-const TEST_DATASET_ID = "22222222-2222-4222-8222-222222222222";
-const TEST_MODEL_ID = "33333333-3333-4333-8333-333333333333";
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_DATASET_ID = '22222222-2222-4222-8222-222222222222';
+const TEST_MODEL_ID = '33333333-3333-4333-8333-333333333333';
 
 class FakeRpcSupabase {
   rpcCalls: Array<{ fn: string; args: unknown }> = [];
@@ -19,7 +19,7 @@ class FakeRpcSupabase {
     return Promise.resolve({
       data: {
         id: TEST_DATASET_ID,
-        version: "01.00.000",
+        version: '01.00.000',
       },
       error: null,
     });
@@ -29,21 +29,21 @@ class FakeRpcSupabase {
 function buildActor(supabase: FakeRpcSupabase) {
   return {
     userId: TEST_USER_ID,
-    accessToken: "access-token",
+    accessToken: 'access-token',
     supabase: supabase as unknown as SupabaseClient,
   };
 }
 
 Deno.test(
-  "executeSaveDraftCommand forwards draft mutations to cmd_dataset_save_draft",
+  'executeSaveDraftCommand forwards draft mutations to cmd_dataset_save_draft',
   async () => {
     const supabase = new FakeRpcSupabase();
     const result = await executeSaveDraftCommand(
       {
-        table: "processes",
+        table: 'processes',
         id: TEST_DATASET_ID,
-        version: "01.00.000",
-        jsonOrdered: { foo: "bar" },
+        version: '01.00.000',
+        jsonOrdered: { foo: 'bar' },
         modelId: TEST_MODEL_ID,
         ruleVerification: false,
       },
@@ -53,20 +53,20 @@ Deno.test(
     assertEquals(result.ok, true);
     assertEquals(supabase.rpcCalls, [
       {
-        fn: "cmd_dataset_save_draft",
+        fn: 'cmd_dataset_save_draft',
         args: {
-          p_table: "processes",
+          p_table: 'processes',
           p_id: TEST_DATASET_ID,
-          p_version: "01.00.000",
-          p_json_ordered: { foo: "bar" },
+          p_version: '01.00.000',
+          p_json_ordered: { foo: 'bar' },
           p_model_id: TEST_MODEL_ID,
           p_rule_verification: false,
           p_audit: {
-            command: "dataset_save_draft",
+            command: 'dataset_save_draft',
             actorUserId: TEST_USER_ID,
-            targetTable: "processes",
+            targetTable: 'processes',
             targetId: TEST_DATASET_ID,
-            targetVersion: "01.00.000",
+            targetVersion: '01.00.000',
             payload: {
               modelId: TEST_MODEL_ID,
             },
@@ -77,14 +77,14 @@ Deno.test(
   },
 );
 
-Deno.test("executeSaveDraftCommand allows process drafts without modelId", async () => {
+Deno.test('executeSaveDraftCommand allows process drafts without modelId', async () => {
   const supabase = new FakeRpcSupabase();
   const result = await executeSaveDraftCommand(
     {
-      table: "processes",
+      table: 'processes',
       id: TEST_DATASET_ID,
-      version: "01.00.000",
-      jsonOrdered: { foo: "bar" },
+      version: '01.00.000',
+      jsonOrdered: { foo: 'bar' },
     },
     buildActor(supabase),
   );
@@ -92,20 +92,20 @@ Deno.test("executeSaveDraftCommand allows process drafts without modelId", async
   assertEquals(result.ok, true);
   assertEquals(supabase.rpcCalls, [
     {
-      fn: "cmd_dataset_save_draft",
+      fn: 'cmd_dataset_save_draft',
       args: {
-        p_table: "processes",
+        p_table: 'processes',
         p_id: TEST_DATASET_ID,
-        p_version: "01.00.000",
-        p_json_ordered: { foo: "bar" },
+        p_version: '01.00.000',
+        p_json_ordered: { foo: 'bar' },
         p_model_id: null,
         p_rule_verification: null,
         p_audit: {
-          command: "dataset_save_draft",
+          command: 'dataset_save_draft',
           actorUserId: TEST_USER_ID,
-          targetTable: "processes",
+          targetTable: 'processes',
           targetId: TEST_DATASET_ID,
-          targetVersion: "01.00.000",
+          targetVersion: '01.00.000',
           payload: {},
         },
       },

--- a/test/app_review_comment_test.ts
+++ b/test/app_review_comment_test.ts
@@ -1,11 +1,11 @@
-import { assertEquals } from "jsr:@std/assert";
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import { executeSaveCommentDraftCommand } from "../supabase/functions/_shared/commands/review/save_comment_draft.ts";
-import { executeSubmitCommentCommand } from "../supabase/functions/_shared/commands/review/submit_comment.ts";
+import { executeSaveCommentDraftCommand } from '../supabase/functions/_shared/commands/review/save_comment_draft.ts';
+import { executeSubmitCommentCommand } from '../supabase/functions/_shared/commands/review/submit_comment.ts';
 
-const TEST_USER_ID = "11111111-1111-4111-8111-111111111111";
-const TEST_REVIEW_ID = "22222222-2222-4222-8222-222222222222";
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_REVIEW_ID = '22222222-2222-4222-8222-222222222222';
 
 class FakeRpcSupabase {
   rpcCalls: Array<{ fn: string; args: unknown }> = [];
@@ -28,16 +28,16 @@ class FakeRpcSupabase {
 function buildActor(supabase: FakeRpcSupabase) {
   return {
     userId: TEST_USER_ID,
-    accessToken: "access-token",
+    accessToken: 'access-token',
     supabase: supabase as unknown as SupabaseClient,
   };
 }
 
 Deno.test(
-  "executeSaveCommentDraftCommand forwards comment draft save to cmd_review_save_comment_draft",
+  'executeSaveCommentDraftCommand forwards comment draft save to cmd_review_save_comment_draft',
   async () => {
     const supabase = new FakeRpcSupabase();
-    const json = { blocks: [{ type: "paragraph", text: "Needs adjustments" }] };
+    const json = { blocks: [{ type: 'paragraph', text: 'Needs adjustments' }] };
     const result = await executeSaveCommentDraftCommand(
       {
         reviewId: TEST_REVIEW_ID,
@@ -49,16 +49,16 @@ Deno.test(
     assertEquals(result.ok, true);
     assertEquals(supabase.rpcCalls, [
       {
-        fn: "cmd_review_save_comment_draft",
+        fn: 'cmd_review_save_comment_draft',
         args: {
           p_review_id: TEST_REVIEW_ID,
           p_json: json,
           p_audit: {
-            command: "review_save_comment_draft",
+            command: 'review_save_comment_draft',
             actorUserId: TEST_USER_ID,
-            targetTable: "reviews",
+            targetTable: 'reviews',
             targetId: TEST_REVIEW_ID,
-            targetVersion: "",
+            targetVersion: '',
             payload: {
               hasJson: true,
             },
@@ -70,10 +70,10 @@ Deno.test(
 );
 
 Deno.test(
-  "executeSubmitCommentCommand forwards comment submission to cmd_review_submit_comment",
+  'executeSubmitCommentCommand forwards comment submission to cmd_review_submit_comment',
   async () => {
     const supabase = new FakeRpcSupabase();
-    const json = { summary: "Approved with comments" };
+    const json = { summary: 'Approved with comments' };
     const result = await executeSubmitCommentCommand(
       {
         reviewId: TEST_REVIEW_ID,
@@ -85,17 +85,17 @@ Deno.test(
     assertEquals(result.ok, true);
     assertEquals(supabase.rpcCalls, [
       {
-        fn: "cmd_review_submit_comment",
+        fn: 'cmd_review_submit_comment',
         args: {
           p_review_id: TEST_REVIEW_ID,
           p_json: json,
           p_comment_state: 1,
           p_audit: {
-            command: "review_submit_comment",
+            command: 'review_submit_comment',
             actorUserId: TEST_USER_ID,
-            targetTable: "reviews",
+            targetTable: 'reviews',
             targetId: TEST_REVIEW_ID,
-            targetVersion: "",
+            targetVersion: '',
             payload: {
               hasJson: true,
               commentState: 1,
@@ -108,10 +108,10 @@ Deno.test(
 );
 
 Deno.test(
-  "executeSubmitCommentCommand forwards reviewer rejection through cmd_review_submit_comment",
+  'executeSubmitCommentCommand forwards reviewer rejection through cmd_review_submit_comment',
   async () => {
     const supabase = new FakeRpcSupabase();
-    const json = { summary: "Rejected by reviewer" };
+    const json = { summary: 'Rejected by reviewer' };
     const result = await executeSubmitCommentCommand(
       {
         reviewId: TEST_REVIEW_ID,
@@ -124,17 +124,17 @@ Deno.test(
     assertEquals(result.ok, true);
     assertEquals(supabase.rpcCalls, [
       {
-        fn: "cmd_review_submit_comment",
+        fn: 'cmd_review_submit_comment',
         args: {
           p_review_id: TEST_REVIEW_ID,
           p_json: json,
           p_comment_state: -3,
           p_audit: {
-            command: "review_submit_comment",
+            command: 'review_submit_comment',
             actorUserId: TEST_USER_ID,
-            targetTable: "reviews",
+            targetTable: 'reviews',
             targetId: TEST_REVIEW_ID,
-            targetVersion: "",
+            targetVersion: '',
             payload: {
               hasJson: true,
               commentState: -3,
@@ -146,24 +146,21 @@ Deno.test(
   },
 );
 
-Deno.test(
-  "executeSubmitCommentCommand rejects invalid commentState before RPC call",
-  async () => {
-    const supabase = new FakeRpcSupabase();
-    const result = await executeSubmitCommentCommand(
-      {
-        reviewId: TEST_REVIEW_ID,
-        json: { summary: "Invalid state" },
-        commentState: 0 as never,
-      },
-      buildActor(supabase),
-    );
+Deno.test('executeSubmitCommentCommand rejects invalid commentState before RPC call', async () => {
+  const supabase = new FakeRpcSupabase();
+  const result = await executeSubmitCommentCommand(
+    {
+      reviewId: TEST_REVIEW_ID,
+      json: { summary: 'Invalid state' },
+      commentState: 0 as never,
+    },
+    buildActor(supabase),
+  );
 
-    assertEquals(result.ok, false);
-    if (!result.ok) {
-      assertEquals(result.code, "INVALID_COMMENT_STATE");
-      assertEquals(result.status, 400);
-    }
-    assertEquals(supabase.rpcCalls.length, 0);
-  },
-);
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.code, 'INVALID_COMMENT_STATE');
+    assertEquals(result.status, 400);
+  }
+  assertEquals(supabase.rpcCalls.length, 0);
+});

--- a/test/dataset_command_rpc_contract_test.ts
+++ b/test/dataset_command_rpc_contract_test.ts
@@ -1,24 +1,24 @@
-import { assertEquals, assertThrows } from "jsr:@std/assert";
+import { assertEquals, assertThrows } from 'jsr:@std/assert';
 
-import { buildCommandAuditPayload } from "../supabase/functions/_shared/command_runtime/audit_log.ts";
-import { createRequestSchema } from "../supabase/functions/_shared/commands/dataset/create.ts";
-import { deleteRequestSchema } from "../supabase/functions/_shared/commands/dataset/delete.ts";
-import { createDatasetCommandRepository } from "../supabase/functions/_shared/commands/dataset/repository.ts";
-import { saveDraftRequestSchema } from "../supabase/functions/_shared/commands/dataset/save_draft.ts";
-import { submitReviewRequestSchema } from "../supabase/functions/_shared/commands/dataset/submit_review.ts";
+import { buildCommandAuditPayload } from '../supabase/functions/_shared/command_runtime/audit_log.ts';
+import { createRequestSchema } from '../supabase/functions/_shared/commands/dataset/create.ts';
+import { deleteRequestSchema } from '../supabase/functions/_shared/commands/dataset/delete.ts';
+import { createDatasetCommandRepository } from '../supabase/functions/_shared/commands/dataset/repository.ts';
+import { saveDraftRequestSchema } from '../supabase/functions/_shared/commands/dataset/save_draft.ts';
+import { submitReviewRequestSchema } from '../supabase/functions/_shared/commands/dataset/submit_review.ts';
 import {
   callDatasetCreateRpc,
   callDatasetDeleteRpc,
   callDatasetSaveDraftRpc,
   callDatasetSubmitReviewRpc,
   type DatasetRpcResult,
-} from "../supabase/functions/_shared/db_rpc/dataset_commands.ts";
+} from '../supabase/functions/_shared/db_rpc/dataset_commands.ts';
 
-Deno.test("saveDraftRequestSchema accepts optional ruleVerification metadata", () => {
+Deno.test('saveDraftRequestSchema accepts optional ruleVerification metadata', () => {
   const parsed = saveDraftRequestSchema.safeParse({
-    table: "flows",
-    id: "11111111-1111-4111-8111-111111111111",
-    version: "01.00.000",
+    table: 'flows',
+    id: '11111111-1111-4111-8111-111111111111',
+    version: '01.00.000',
     jsonOrdered: {},
     ruleVerification: false,
   });
@@ -26,32 +26,32 @@ Deno.test("saveDraftRequestSchema accepts optional ruleVerification metadata", (
   assertEquals(parsed.success, true);
 });
 
-Deno.test("submitReviewRequestSchema rejects unexpected payload fields", () => {
+Deno.test('submitReviewRequestSchema rejects unexpected payload fields', () => {
   const parsed = submitReviewRequestSchema.safeParse({
-    table: "processes",
-    id: "11111111-1111-4111-8111-111111111111",
-    version: "01.00.000",
-    reviewId: "33333333-3333-4333-8333-333333333333",
+    table: 'processes',
+    id: '11111111-1111-4111-8111-111111111111',
+    version: '01.00.000',
+    reviewId: '33333333-3333-4333-8333-333333333333',
   });
 
   assertEquals(parsed.success, false);
 });
 
-Deno.test("createRequestSchema rejects create payloads with version fields", () => {
+Deno.test('createRequestSchema rejects create payloads with version fields', () => {
   const parsed = createRequestSchema.safeParse({
-    table: "flows",
-    id: "11111111-1111-4111-8111-111111111111",
-    version: "01.00.000",
+    table: 'flows',
+    id: '11111111-1111-4111-8111-111111111111',
+    version: '01.00.000',
     jsonOrdered: {},
   });
 
   assertEquals(parsed.success, false);
 });
 
-Deno.test("createRequestSchema accepts optional ruleVerification", () => {
+Deno.test('createRequestSchema accepts optional ruleVerification', () => {
   const parsed = createRequestSchema.safeParse({
-    table: "flows",
-    id: "11111111-1111-4111-8111-111111111111",
+    table: 'flows',
+    id: '11111111-1111-4111-8111-111111111111',
     jsonOrdered: {},
     ruleVerification: false,
   });
@@ -59,22 +59,22 @@ Deno.test("createRequestSchema accepts optional ruleVerification", () => {
   assertEquals(parsed.success, true);
 });
 
-Deno.test("deleteRequestSchema rejects unexpected payload fields", () => {
+Deno.test('deleteRequestSchema rejects unexpected payload fields', () => {
   const parsed = deleteRequestSchema.safeParse({
-    table: "flows",
-    id: "11111111-1111-4111-8111-111111111111",
-    version: "01.00.000",
+    table: 'flows',
+    id: '11111111-1111-4111-8111-111111111111',
+    version: '01.00.000',
     jsonOrdered: {},
   });
 
   assertEquals(parsed.success, false);
 });
 
-Deno.test("createDatasetCommandRepository requires an explicit Supabase client", () => {
+Deno.test('createDatasetCommandRepository requires an explicit Supabase client', () => {
   assertThrows(
     () => createDatasetCommandRepository(undefined as never),
     Error,
-    "Dataset command repository requires an explicit Supabase client",
+    'Dataset command repository requires an explicit Supabase client',
   );
 });
 
@@ -87,42 +87,42 @@ class FakeRpcSupabase {
 }
 
 const draftRequest = {
-  table: "flows" as const,
-  id: "11111111-1111-4111-8111-111111111111",
-  version: "01.00.000",
-  jsonOrdered: { foo: "bar" },
+  table: 'flows' as const,
+  id: '11111111-1111-4111-8111-111111111111',
+  version: '01.00.000',
+  jsonOrdered: { foo: 'bar' },
 };
 
 const createRequest = {
-  table: "processes" as const,
-  id: "11111111-1111-4111-8111-111111111111",
-  jsonOrdered: { foo: "bar" },
-  modelId: "33333333-3333-4333-8333-333333333333",
+  table: 'processes' as const,
+  id: '11111111-1111-4111-8111-111111111111',
+  jsonOrdered: { foo: 'bar' },
+  modelId: '33333333-3333-4333-8333-333333333333',
 };
 
 const deleteRequest = {
-  table: "flows" as const,
-  id: "11111111-1111-4111-8111-111111111111",
-  version: "01.00.000",
+  table: 'flows' as const,
+  id: '11111111-1111-4111-8111-111111111111',
+  version: '01.00.000',
 };
 
 const submitReviewRequest = {
-  table: "processes" as const,
-  id: "11111111-1111-4111-8111-111111111111",
-  version: "01.00.000",
+  table: 'processes' as const,
+  id: '11111111-1111-4111-8111-111111111111',
+  version: '01.00.000',
 };
 
 const auditPayload = buildCommandAuditPayload({
-  command: "dataset_save_draft",
-  actorUserId: "22222222-2222-4222-8222-222222222222",
-  targetTable: "flows",
-  targetId: "11111111-1111-4111-8111-111111111111",
-  targetVersion: "01.00.000",
+  command: 'dataset_save_draft',
+  actorUserId: '22222222-2222-4222-8222-222222222222',
+  targetTable: 'flows',
+  targetId: '11111111-1111-4111-8111-111111111111',
+  targetVersion: '01.00.000',
   payload: {},
 });
 
 Deno.test(
-  "callDatasetCreateRpc unwraps success envelopes returned by cmd_dataset_create",
+  'callDatasetCreateRpc unwraps success envelopes returned by cmd_dataset_create',
   async () => {
     const result = (await callDatasetCreateRpc(
       new FakeRpcSupabase({
@@ -130,7 +130,7 @@ Deno.test(
           ok: true,
           data: {
             id: createRequest.id,
-            version: "01.00.000",
+            version: '01.00.000',
           },
         },
         error: null,
@@ -143,41 +143,38 @@ Deno.test(
       ok: true,
       data: {
         id: createRequest.id,
-        version: "01.00.000",
+        version: '01.00.000',
       },
     });
   },
 );
 
-Deno.test(
-  "callDatasetDeleteRpc treats command failure envelopes as command failures",
-  async () => {
-    const result = (await callDatasetDeleteRpc(
-      new FakeRpcSupabase({
-        data: {
-          ok: false,
-          code: "DATASET_NOT_FOUND",
-          status: 404,
-          message: "Dataset not found",
-        },
-        error: null,
-      }) as never,
-      deleteRequest,
-      auditPayload,
-    )) as DatasetRpcResult;
+Deno.test('callDatasetDeleteRpc treats command failure envelopes as command failures', async () => {
+  const result = (await callDatasetDeleteRpc(
+    new FakeRpcSupabase({
+      data: {
+        ok: false,
+        code: 'DATASET_NOT_FOUND',
+        status: 404,
+        message: 'Dataset not found',
+      },
+      error: null,
+    }) as never,
+    deleteRequest,
+    auditPayload,
+  )) as DatasetRpcResult;
 
-    assertEquals(result.ok, false);
-    if (!result.ok) {
-      assertEquals(result.code, "DATASET_NOT_FOUND");
-      assertEquals(result.status, 404);
-      assertEquals(result.message, "Dataset not found");
-      assertEquals(result.details, undefined);
-    }
-  },
-);
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.code, 'DATASET_NOT_FOUND');
+    assertEquals(result.status, 404);
+    assertEquals(result.message, 'Dataset not found');
+    assertEquals(result.details, undefined);
+  }
+});
 
 Deno.test(
-  "callDatasetSaveDraftRpc unwraps success envelopes returned by cmd_dataset_* RPCs",
+  'callDatasetSaveDraftRpc unwraps success envelopes returned by cmd_dataset_* RPCs',
   async () => {
     const result = (await callDatasetSaveDraftRpc(
       new FakeRpcSupabase({
@@ -205,15 +202,15 @@ Deno.test(
 );
 
 Deno.test(
-  "callDatasetSaveDraftRpc treats command failure envelopes as command failures",
+  'callDatasetSaveDraftRpc treats command failure envelopes as command failures',
   async () => {
     const result = (await callDatasetSaveDraftRpc(
       new FakeRpcSupabase({
         data: {
           ok: false,
-          code: "DATA_UNDER_REVIEW",
+          code: 'DATA_UNDER_REVIEW',
           status: 403,
-          message: "Data is under review and cannot be modified",
+          message: 'Data is under review and cannot be modified',
           details: {
             state_code: 20,
             review_state_code: 20,
@@ -227,9 +224,9 @@ Deno.test(
 
     assertEquals(result, {
       ok: false,
-      code: "DATA_UNDER_REVIEW",
+      code: 'DATA_UNDER_REVIEW',
       status: 403,
-      message: "Data is under review and cannot be modified",
+      message: 'Data is under review and cannot be modified',
       details: {
         state_code: 20,
         review_state_code: 20,
@@ -239,7 +236,7 @@ Deno.test(
 );
 
 Deno.test(
-  "callDatasetSubmitReviewRpc unwraps success envelopes returned by cmd_review_submit",
+  'callDatasetSubmitReviewRpc unwraps success envelopes returned by cmd_review_submit',
   async () => {
     const result = (await callDatasetSubmitReviewRpc(
       new FakeRpcSupabase({
@@ -247,7 +244,7 @@ Deno.test(
           ok: true,
           data: {
             review: {
-              id: "33333333-3333-4333-8333-333333333333",
+              id: '33333333-3333-4333-8333-333333333333',
             },
           },
         },
@@ -261,7 +258,7 @@ Deno.test(
       ok: true,
       data: {
         review: {
-          id: "33333333-3333-4333-8333-333333333333",
+          id: '33333333-3333-4333-8333-333333333333',
         },
       },
     });
@@ -269,19 +266,19 @@ Deno.test(
 );
 
 Deno.test(
-  "callDatasetSubmitReviewRpc treats command failure envelopes as command failures",
+  'callDatasetSubmitReviewRpc treats command failure envelopes as command failures',
   async () => {
     const result = (await callDatasetSubmitReviewRpc(
       new FakeRpcSupabase({
         data: {
           ok: false,
-          code: "REFERENCED_DATA_UNDER_REVIEW",
+          code: 'REFERENCED_DATA_UNDER_REVIEW',
           status: 409,
-          message: "Referenced data is already under review",
+          message: 'Referenced data is already under review',
           details: {
-            table: "flows",
-            id: "44444444-4444-4444-8444-444444444444",
-            version: "01.00.000",
+            table: 'flows',
+            id: '44444444-4444-4444-8444-444444444444',
+            version: '01.00.000',
           },
         },
         error: null,
@@ -292,13 +289,13 @@ Deno.test(
 
     assertEquals(result, {
       ok: false,
-      code: "REFERENCED_DATA_UNDER_REVIEW",
+      code: 'REFERENCED_DATA_UNDER_REVIEW',
       status: 409,
-      message: "Referenced data is already under review",
+      message: 'Referenced data is already under review',
       details: {
-        table: "flows",
-        id: "44444444-4444-4444-8444-444444444444",
-        version: "01.00.000",
+        table: 'flows',
+        id: '44444444-4444-4444-8444-444444444444',
+        version: '01.00.000',
       },
     });
   },

--- a/test/legacy_update_endpoint_deprecation_test.ts
+++ b/test/legacy_update_endpoint_deprecation_test.ts
@@ -1,33 +1,33 @@
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from 'jsr:@std/assert';
 
-import { LEGACY_ENDPOINT_REMOVED_RESPONSE } from "../supabase/functions/_shared/legacy_endpoint_removed.ts";
-import { handleUpdateComment } from "../supabase/functions/update_comment/index.ts";
-import { handleUpdateData } from "../supabase/functions/update_data/index.ts";
-import { handleUpdateReview } from "../supabase/functions/update_review/index.ts";
-import { handleUpdateRole } from "../supabase/functions/update_role/index.ts";
-import { handleUpdateTeam } from "../supabase/functions/update_team/index.ts";
-import { handleUpdateUser } from "../supabase/functions/update_user/index.ts";
+import { LEGACY_ENDPOINT_REMOVED_RESPONSE } from '../supabase/functions/_shared/legacy_endpoint_removed.ts';
+import { handleUpdateComment } from '../supabase/functions/update_comment/index.ts';
+import { handleUpdateData } from '../supabase/functions/update_data/index.ts';
+import { handleUpdateReview } from '../supabase/functions/update_review/index.ts';
+import { handleUpdateRole } from '../supabase/functions/update_role/index.ts';
+import { handleUpdateTeam } from '../supabase/functions/update_team/index.ts';
+import { handleUpdateUser } from '../supabase/functions/update_user/index.ts';
 
 const legacyHandlers = [
-  ["update_data", handleUpdateData],
-  ["update_user", handleUpdateUser],
-  ["update_team", handleUpdateTeam],
-  ["update_role", handleUpdateRole],
-  ["update_comment", handleUpdateComment],
-  ["update_review", handleUpdateReview],
+  ['update_data', handleUpdateData],
+  ['update_user', handleUpdateUser],
+  ['update_team', handleUpdateTeam],
+  ['update_role', handleUpdateRole],
+  ['update_comment', handleUpdateComment],
+  ['update_review', handleUpdateReview],
 ] as const;
 
 for (const [name, handler] of legacyHandlers) {
-  for (const method of ["GET", "POST", "PUT"] as const) {
+  for (const method of ['GET', 'POST', 'PUT'] as const) {
     Deno.test(`${name} returns 410 Gone for legacy ${method} callers`, async () => {
       const response = await handler(
         new Request(`http://localhost/functions/v1/${name}`, {
           method,
           headers: {
-            Authorization: "Bearer legacy-token",
-            "Content-Type": "application/json",
+            Authorization: 'Bearer legacy-token',
+            'Content-Type': 'application/json',
           },
-          body: method === "GET" ? undefined : JSON.stringify({}),
+          body: method === 'GET' ? undefined : JSON.stringify({}),
         }),
       );
 
@@ -39,11 +39,11 @@ for (const [name, handler] of legacyHandlers) {
   Deno.test(`${name} still responds to OPTIONS preflight`, async () => {
     const response = await handler(
       new Request(`http://localhost/functions/v1/${name}`, {
-        method: "OPTIONS",
+        method: 'OPTIONS',
       }),
     );
 
     assertEquals(response.status, 200);
-    assertEquals(await response.text(), "ok");
+    assertEquals(await response.text(), 'ok');
   });
 }

--- a/test/membership_command_test.ts
+++ b/test/membership_command_test.ts
@@ -1,32 +1,20 @@
-import { assertEquals, assertThrows } from "jsr:@std/assert";
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import { assertEquals, assertThrows } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import {
-  parseTeamAcceptInvitationCommand,
-} from "../supabase/functions/_shared/commands/membership/accept_invitation.ts";
-import {
-  executeTeamChangeMemberRoleCommand,
-} from "../supabase/functions/_shared/commands/membership/change_role.ts";
-import {
-  createMembershipCommandRepository,
-} from "../supabase/functions/_shared/commands/membership/repository.ts";
-import {
-  parseTeamRejectInvitationCommand,
-} from "../supabase/functions/_shared/commands/membership/reject_invitation.ts";
-import {
-  executeTeamCreateCommand,
-} from "../supabase/functions/_shared/commands/team/create_team.ts";
+import { parseTeamAcceptInvitationCommand } from '../supabase/functions/_shared/commands/membership/accept_invitation.ts';
+import { executeTeamChangeMemberRoleCommand } from '../supabase/functions/_shared/commands/membership/change_role.ts';
+import { parseTeamRejectInvitationCommand } from '../supabase/functions/_shared/commands/membership/reject_invitation.ts';
+import { createMembershipCommandRepository } from '../supabase/functions/_shared/commands/membership/repository.ts';
 import {
   executeTeamSetRankCommand,
   executeTeamUpdateProfileCommand,
-} from "../supabase/functions/_shared/commands/profile/update_team_profile.ts";
-import {
-  executeUserUpdateContactCommand,
-} from "../supabase/functions/_shared/commands/profile/update_user_contact.ts";
+} from '../supabase/functions/_shared/commands/profile/update_team_profile.ts';
+import { executeUserUpdateContactCommand } from '../supabase/functions/_shared/commands/profile/update_user_contact.ts';
+import { executeTeamCreateCommand } from '../supabase/functions/_shared/commands/team/create_team.ts';
 
-const TEST_ACTOR_ID = "11111111-1111-4111-8111-111111111111";
-const TEST_TEAM_ID = "22222222-2222-4222-8222-222222222222";
-const TEST_USER_ID = "33333333-3333-4333-8333-333333333333";
+const TEST_ACTOR_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_TEAM_ID = '22222222-2222-4222-8222-222222222222';
+const TEST_USER_ID = '33333333-3333-4333-8333-333333333333';
 
 class FakeRpcSupabase {
   rpcCalls: Array<{ fn: string; args: unknown }> = [];
@@ -52,21 +40,21 @@ class FakeRpcSupabase {
 function buildActor(supabase: FakeRpcSupabase) {
   return {
     userId: TEST_ACTOR_ID,
-    accessToken: "access-token",
+    accessToken: 'access-token',
     supabase: supabase as unknown as SupabaseClient,
   };
 }
 
-Deno.test("accept invitation payload parser is strict", () => {
+Deno.test('accept invitation payload parser is strict', () => {
   const parsed = parseTeamAcceptInvitationCommand({
     teamId: TEST_TEAM_ID,
-    extra: "nope",
+    extra: 'nope',
   });
 
   assertEquals(parsed.ok, false);
 });
 
-Deno.test("reject invitation payload parser is strict", () => {
+Deno.test('reject invitation payload parser is strict', () => {
   const parsed = parseTeamRejectInvitationCommand({
     teamId: TEST_TEAM_ID,
     unexpected: true,
@@ -75,23 +63,23 @@ Deno.test("reject invitation payload parser is strict", () => {
   assertEquals(parsed.ok, false);
 });
 
-Deno.test("createMembershipCommandRepository requires an explicit Supabase client", () => {
+Deno.test('createMembershipCommandRepository requires an explicit Supabase client', () => {
   assertThrows(
     () => createMembershipCommandRepository(undefined as never),
     Error,
-    "Membership command repository requires an explicit Supabase client",
+    'Membership command repository requires an explicit Supabase client',
   );
 });
 
 Deno.test(
-  "executeTeamChangeMemberRoleCommand supports remove action and forwards cmd_team_change_member_role args",
+  'executeTeamChangeMemberRoleCommand supports remove action and forwards cmd_team_change_member_role args',
   async () => {
     const supabase = new FakeRpcSupabase();
     const result = await executeTeamChangeMemberRoleCommand(
       {
         teamId: TEST_TEAM_ID,
         userId: TEST_USER_ID,
-        action: "remove",
+        action: 'remove',
       },
       buildActor(supabase),
     );
@@ -99,20 +87,20 @@ Deno.test(
     assertEquals(result.ok, true);
     assertEquals(supabase.rpcCalls, [
       {
-        fn: "cmd_team_change_member_role",
+        fn: 'cmd_team_change_member_role',
         args: {
           p_team_id: TEST_TEAM_ID,
           p_user_id: TEST_USER_ID,
           p_role: null,
-          p_action: "remove",
+          p_action: 'remove',
           p_audit: {
-            command: "team_change_member_role",
+            command: 'team_change_member_role',
             actorUserId: TEST_ACTOR_ID,
-            targetTable: "roles",
+            targetTable: 'roles',
             targetId: TEST_USER_ID,
             targetVersion: TEST_TEAM_ID,
             payload: {
-              action: "remove",
+              action: 'remove',
               role: null,
               teamId: TEST_TEAM_ID,
             },
@@ -123,136 +111,130 @@ Deno.test(
   },
 );
 
-Deno.test(
-  "executeTeamCreateCommand forwards cmd_team_create args with audit payload",
-  async () => {
-    const supabase = new FakeRpcSupabase();
-    const teamJson = { title: [{ "@xml:lang": "en", "#text": "Team A" }] };
+Deno.test('executeTeamCreateCommand forwards cmd_team_create args with audit payload', async () => {
+  const supabase = new FakeRpcSupabase();
+  const teamJson = { title: [{ '@xml:lang': 'en', '#text': 'Team A' }] };
 
-    const result = await executeTeamCreateCommand(
-      {
-        teamId: TEST_TEAM_ID,
-        json: teamJson,
-        rank: 1,
-        isPublic: false,
-      },
-      buildActor(supabase),
-    );
+  const result = await executeTeamCreateCommand(
+    {
+      teamId: TEST_TEAM_ID,
+      json: teamJson,
+      rank: 1,
+      isPublic: false,
+    },
+    buildActor(supabase),
+  );
 
-    assertEquals(result.ok, true);
-    assertEquals(supabase.rpcCalls, [
-      {
-        fn: "cmd_team_create",
-        args: {
-          p_team_id: TEST_TEAM_ID,
-          p_json: teamJson,
-          p_rank: 1,
-          p_is_public: false,
-          p_audit: {
-            command: "team_create",
-            actorUserId: TEST_ACTOR_ID,
-            targetTable: "teams",
-            targetId: TEST_TEAM_ID,
-            targetVersion: "",
-            payload: {
-              rank: 1,
-              isPublic: false,
-            },
+  assertEquals(result.ok, true);
+  assertEquals(supabase.rpcCalls, [
+    {
+      fn: 'cmd_team_create',
+      args: {
+        p_team_id: TEST_TEAM_ID,
+        p_json: teamJson,
+        p_rank: 1,
+        p_is_public: false,
+        p_audit: {
+          command: 'team_create',
+          actorUserId: TEST_ACTOR_ID,
+          targetTable: 'teams',
+          targetId: TEST_TEAM_ID,
+          targetVersion: '',
+          payload: {
+            rank: 1,
+            isPublic: false,
           },
         },
       },
-    ]);
-  },
-);
+    },
+  ]);
+});
 
-Deno.test(
-  "profile and user commands forward exact RPC names and args",
-  async () => {
-    const supabase = new FakeRpcSupabase();
-    const actor = buildActor(supabase);
+Deno.test('profile and user commands forward exact RPC names and args', async () => {
+  const supabase = new FakeRpcSupabase();
+  const actor = buildActor(supabase);
 
-    await executeTeamUpdateProfileCommand(
-      {
-        teamId: TEST_TEAM_ID,
-        json: { description: [{ "@xml:lang": "en", "#text": "Updated" }] },
-        isPublic: true,
+  await executeTeamUpdateProfileCommand(
+    {
+      teamId: TEST_TEAM_ID,
+      json: { description: [{ '@xml:lang': 'en', '#text': 'Updated' }] },
+      isPublic: true,
+    },
+    actor,
+  );
+
+  await executeTeamSetRankCommand(
+    {
+      teamId: TEST_TEAM_ID,
+      rank: 5,
+    },
+    actor,
+  );
+
+  await executeUserUpdateContactCommand(
+    {
+      userId: TEST_USER_ID,
+      contact: {
+        '@refObjectId': '44444444-4444-4444-8444-444444444444',
       },
-      actor,
-    );
+    },
+    actor,
+  );
 
-    await executeTeamSetRankCommand(
-      {
-        teamId: TEST_TEAM_ID,
-        rank: 5,
-      },
-      actor,
-    );
-
-    await executeUserUpdateContactCommand(
-      {
-        userId: TEST_USER_ID,
-        contact: {
-          "@refObjectId": "44444444-4444-4444-8444-444444444444",
-        },
-      },
-      actor,
-    );
-
-    assertEquals(supabase.rpcCalls, [
-      {
-        fn: "cmd_team_update_profile",
-        args: {
-          p_team_id: TEST_TEAM_ID,
-          p_json: { description: [{ "@xml:lang": "en", "#text": "Updated" }] },
-          p_is_public: true,
-          p_audit: {
-            command: "team_update_profile",
-            actorUserId: TEST_ACTOR_ID,
-            targetTable: "teams",
-            targetId: TEST_TEAM_ID,
-            targetVersion: "",
-            payload: {
-              isPublic: true,
-            },
+  assertEquals(supabase.rpcCalls, [
+    {
+      fn: 'cmd_team_update_profile',
+      args: {
+        p_team_id: TEST_TEAM_ID,
+        p_json: { description: [{ '@xml:lang': 'en', '#text': 'Updated' }] },
+        p_is_public: true,
+        p_audit: {
+          command: 'team_update_profile',
+          actorUserId: TEST_ACTOR_ID,
+          targetTable: 'teams',
+          targetId: TEST_TEAM_ID,
+          targetVersion: '',
+          payload: {
+            isPublic: true,
           },
         },
       },
-      {
-        fn: "cmd_team_set_rank",
-        args: {
-          p_team_id: TEST_TEAM_ID,
-          p_rank: 5,
-          p_audit: {
-            command: "team_set_rank",
-            actorUserId: TEST_ACTOR_ID,
-            targetTable: "teams",
-            targetId: TEST_TEAM_ID,
-            targetVersion: "",
-            payload: {
-              rank: 5,
-            },
+    },
+    {
+      fn: 'cmd_team_set_rank',
+      args: {
+        p_team_id: TEST_TEAM_ID,
+        p_rank: 5,
+        p_audit: {
+          command: 'team_set_rank',
+          actorUserId: TEST_ACTOR_ID,
+          targetTable: 'teams',
+          targetId: TEST_TEAM_ID,
+          targetVersion: '',
+          payload: {
+            rank: 5,
           },
         },
       },
-      {
-        fn: "cmd_user_update_contact",
-        args: {
-          p_user_id: TEST_USER_ID,
-          p_contact: {
-            "@refObjectId": "44444444-4444-4444-8444-444444444444",
-          },
-          p_audit: {
-            command: "user_update_contact",
-            actorUserId: TEST_ACTOR_ID,
-            targetTable: "users",
-            targetId: TEST_USER_ID,
-            targetVersion: "",
-            payload: {
-              hasContact: true,
-            },
+    },
+    {
+      fn: 'cmd_user_update_contact',
+      args: {
+        p_user_id: TEST_USER_ID,
+        p_contact: {
+          '@refObjectId': '44444444-4444-4444-8444-444444444444',
+        },
+        p_audit: {
+          command: 'user_update_contact',
+          actorUserId: TEST_ACTOR_ID,
+          targetTable: 'users',
+          targetId: TEST_USER_ID,
+          targetVersion: '',
+          payload: {
+            hasContact: true,
           },
         },
       },
-    ]);
-  },
-);
+    },
+  ]);
+});

--- a/test/notification_command_test.ts
+++ b/test/notification_command_test.ts
@@ -1,18 +1,16 @@
-import { assertEquals, assertThrows } from "jsr:@std/assert";
-import type { SupabaseClient } from "jsr:@supabase/supabase-js@2.98.0";
+import { assertEquals, assertThrows } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
+import { createNotificationCommandRepository } from '../supabase/functions/_shared/commands/notification/repository.ts';
 import {
   executeNotificationSendValidationIssueCommand,
   parseNotificationSendValidationIssueCommand,
-} from "../supabase/functions/_shared/commands/notification/send_validation_issue.ts";
-import {
-  createNotificationCommandRepository,
-} from "../supabase/functions/_shared/commands/notification/repository.ts";
+} from '../supabase/functions/_shared/commands/notification/send_validation_issue.ts';
 
-const TEST_ACTOR_ID = "11111111-1111-4111-8111-111111111111";
-const TEST_RECIPIENT_ID = "22222222-2222-4222-8222-222222222222";
-const TEST_SOURCE_DATASET_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
-const TEST_DATASET_ID = "33333333-3333-4333-8333-333333333333";
+const TEST_ACTOR_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_RECIPIENT_ID = '22222222-2222-4222-8222-222222222222';
+const TEST_SOURCE_DATASET_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const TEST_DATASET_ID = '33333333-3333-4333-8333-333333333333';
 
 class FakeRpcSupabase {
   rpcCalls: Array<{ fn: string; args: unknown }> = [];
@@ -27,7 +25,7 @@ class FakeRpcSupabase {
       data: {
         ok: true,
         data: {
-          id: "44444444-4444-4444-8444-444444444444",
+          id: '44444444-4444-4444-8444-444444444444',
         },
       },
       error: null,
@@ -38,52 +36,52 @@ class FakeRpcSupabase {
 function buildActor(supabase: FakeRpcSupabase) {
   return {
     userId: TEST_ACTOR_ID,
-    accessToken: "access-token",
+    accessToken: 'access-token',
     supabase: supabase as unknown as SupabaseClient,
   };
 }
 
-Deno.test("notification validation-issue payload parser is strict", () => {
+Deno.test('notification validation-issue payload parser is strict', () => {
   const parsed = parseNotificationSendValidationIssueCommand({
     recipientUserId: TEST_RECIPIENT_ID,
-    sourceDatasetType: "process data set",
+    sourceDatasetType: 'process data set',
     sourceDatasetId: TEST_SOURCE_DATASET_ID,
-    sourceDatasetVersion: "01.00.000",
-    datasetType: "process data set",
+    sourceDatasetVersion: '01.00.000',
+    datasetType: 'process data set',
     datasetId: TEST_DATASET_ID,
-    datasetVersion: "01.00.000",
-    issueCodes: ["ruleVerificationFailed"],
-    extra: "nope",
+    datasetVersion: '01.00.000',
+    issueCodes: ['ruleVerificationFailed'],
+    extra: 'nope',
   });
 
   assertEquals(parsed.ok, false);
 });
 
-Deno.test("createNotificationCommandRepository requires an explicit Supabase client", () => {
+Deno.test('createNotificationCommandRepository requires an explicit Supabase client', () => {
   assertThrows(
     () => createNotificationCommandRepository(undefined as never),
     Error,
-    "Notification command repository requires an explicit Supabase client",
+    'Notification command repository requires an explicit Supabase client',
   );
 });
 
 Deno.test(
-  "executeNotificationSendValidationIssueCommand forwards cmd_notification_send_validation_issue args",
+  'executeNotificationSendValidationIssueCommand forwards cmd_notification_send_validation_issue args',
   async () => {
     const supabase = new FakeRpcSupabase();
 
     const result = await executeNotificationSendValidationIssueCommand(
       {
         recipientUserId: TEST_RECIPIENT_ID,
-        sourceDatasetType: "process data set",
+        sourceDatasetType: 'process data set',
         sourceDatasetId: TEST_SOURCE_DATASET_ID,
-        sourceDatasetVersion: "01.00.000",
-        datasetType: "process data set",
+        sourceDatasetVersion: '01.00.000',
+        datasetType: 'process data set',
         datasetId: TEST_DATASET_ID,
-        datasetVersion: "01.00.000",
-        link: "https://example.com/issues/1",
-        issueCodes: ["ruleVerificationFailed", "sdkInvalid"],
-        tabNames: ["processInformation", "modellingAndValidation"],
+        datasetVersion: '01.00.000',
+        link: 'https://example.com/issues/1',
+        issueCodes: ['ruleVerificationFailed', 'sdkInvalid'],
+        tabNames: ['processInformation', 'modellingAndValidation'],
         issueCount: 2,
       },
       buildActor(supabase),
@@ -92,31 +90,31 @@ Deno.test(
     assertEquals(result.ok, true);
     assertEquals(supabase.rpcCalls, [
       {
-        fn: "cmd_notification_send_validation_issue",
+        fn: 'cmd_notification_send_validation_issue',
         args: {
           p_recipient_user_id: TEST_RECIPIENT_ID,
-          p_source_dataset_type: "process data set",
+          p_source_dataset_type: 'process data set',
           p_source_dataset_id: TEST_SOURCE_DATASET_ID,
-          p_source_dataset_version: "01.00.000",
-          p_dataset_type: "process data set",
+          p_source_dataset_version: '01.00.000',
+          p_dataset_type: 'process data set',
           p_dataset_id: TEST_DATASET_ID,
-          p_dataset_version: "01.00.000",
-          p_link: "https://example.com/issues/1",
-          p_issue_codes: ["ruleVerificationFailed", "sdkInvalid"],
-          p_tab_names: ["processInformation", "modellingAndValidation"],
+          p_dataset_version: '01.00.000',
+          p_link: 'https://example.com/issues/1',
+          p_issue_codes: ['ruleVerificationFailed', 'sdkInvalid'],
+          p_tab_names: ['processInformation', 'modellingAndValidation'],
           p_issue_count: 2,
           p_audit: {
-            command: "notification_send_validation_issue",
+            command: 'notification_send_validation_issue',
             actorUserId: TEST_ACTOR_ID,
-            targetTable: "notifications",
+            targetTable: 'notifications',
             targetId: TEST_DATASET_ID,
-            targetVersion: "01.00.000",
+            targetVersion: '01.00.000',
             payload: {
               recipientUserId: TEST_RECIPIENT_ID,
-              sourceDatasetType: "process data set",
+              sourceDatasetType: 'process data set',
               sourceDatasetId: TEST_SOURCE_DATASET_ID,
-              sourceDatasetVersion: "01.00.000",
-              datasetType: "process data set",
+              sourceDatasetVersion: '01.00.000',
+              datasetType: 'process data set',
               issueCount: 2,
             },
           },

--- a/test/review_command_rpc_contract_test.ts
+++ b/test/review_command_rpc_contract_test.ts
@@ -1,12 +1,12 @@
-import { assertEquals, assertThrows } from "jsr:@std/assert";
+import { assertEquals, assertThrows } from 'jsr:@std/assert';
 
-import { buildCommandAuditPayload } from "../supabase/functions/_shared/command_runtime/audit_log.ts";
-import { createReviewCommandRepository } from "../supabase/functions/_shared/commands/review/repository.ts";
+import { buildCommandAuditPayload } from '../supabase/functions/_shared/command_runtime/audit_log.ts';
+import { createReviewCommandRepository } from '../supabase/functions/_shared/commands/review/repository.ts';
 import {
   rejectReviewRequestSchema,
   saveAssignmentDraftRequestSchema,
   submitCommentRequestSchema,
-} from "../supabase/functions/_shared/commands/review/validation.ts";
+} from '../supabase/functions/_shared/commands/review/validation.ts';
 import {
   buildReviewApproveRpcArgs,
   buildReviewRejectRpcArgs,
@@ -16,31 +16,31 @@ import {
   callReviewRejectRpc,
   callReviewSaveAssignmentDraftRpc,
   type ReviewRpcResult,
-} from "../supabase/functions/_shared/db_rpc/review_commands.ts";
+} from '../supabase/functions/_shared/db_rpc/review_commands.ts';
 
-Deno.test("saveAssignmentDraftRequestSchema rejects unexpected fields", () => {
+Deno.test('saveAssignmentDraftRequestSchema rejects unexpected fields', () => {
   const parsed = saveAssignmentDraftRequestSchema.safeParse({
-    reviewId: "11111111-1111-4111-8111-111111111111",
-    reviewerIds: ["22222222-2222-4222-8222-222222222222"],
-    deadline: "2026-04-10T12:00:00.000Z",
+    reviewId: '11111111-1111-4111-8111-111111111111',
+    reviewerIds: ['22222222-2222-4222-8222-222222222222'],
+    deadline: '2026-04-10T12:00:00.000Z',
   });
 
   assertEquals(parsed.success, false);
 });
 
-Deno.test("submitCommentRequestSchema rejects server-owned fields", () => {
+Deno.test('submitCommentRequestSchema rejects server-owned fields', () => {
   const parsed = submitCommentRequestSchema.safeParse({
-    reviewId: "11111111-1111-4111-8111-111111111111",
+    reviewId: '11111111-1111-4111-8111-111111111111',
     json: {},
-    submittedAt: "2026-04-10T12:00:00.000Z",
+    submittedAt: '2026-04-10T12:00:00.000Z',
   });
 
   assertEquals(parsed.success, false);
 });
 
-Deno.test("submitCommentRequestSchema rejects invalid commentState values", () => {
+Deno.test('submitCommentRequestSchema rejects invalid commentState values', () => {
   const parsed = submitCommentRequestSchema.safeParse({
-    reviewId: "11111111-1111-4111-8111-111111111111",
+    reviewId: '11111111-1111-4111-8111-111111111111',
     json: {},
     commentState: 0,
   });
@@ -48,21 +48,21 @@ Deno.test("submitCommentRequestSchema rejects invalid commentState values", () =
   assertEquals(parsed.success, false);
 });
 
-Deno.test("rejectReviewRequestSchema requires non-empty reason", () => {
+Deno.test('rejectReviewRequestSchema requires non-empty reason', () => {
   const parsed = rejectReviewRequestSchema.safeParse({
-    table: "processes",
-    reviewId: "11111111-1111-4111-8111-111111111111",
-    reason: "   ",
+    table: 'processes',
+    reviewId: '11111111-1111-4111-8111-111111111111',
+    reason: '   ',
   });
 
   assertEquals(parsed.success, false);
 });
 
-Deno.test("createReviewCommandRepository requires an explicit Supabase client", () => {
+Deno.test('createReviewCommandRepository requires an explicit Supabase client', () => {
   assertThrows(
     () => createReviewCommandRepository(undefined as never),
     Error,
-    "Review command repository requires an explicit Supabase client",
+    'Review command repository requires an explicit Supabase client',
   );
 });
 
@@ -75,43 +75,43 @@ class FakeRpcSupabase {
 }
 
 const saveAssignmentDraftRequest = {
-  reviewId: "11111111-1111-4111-8111-111111111111",
-  reviewerIds: ["22222222-2222-4222-8222-222222222222"],
+  reviewId: '11111111-1111-4111-8111-111111111111',
+  reviewerIds: ['22222222-2222-4222-8222-222222222222'],
 };
 
 const approveRequest = {
-  table: "processes" as const,
-  reviewId: "11111111-1111-4111-8111-111111111111",
+  table: 'processes' as const,
+  reviewId: '11111111-1111-4111-8111-111111111111',
 };
 
 const saveCommentDraftRequest = {
-  reviewId: "11111111-1111-4111-8111-111111111111",
+  reviewId: '11111111-1111-4111-8111-111111111111',
   json: { blocks: [] },
 };
 
 const submitCommentRequest = {
-  reviewId: "11111111-1111-4111-8111-111111111111",
-  json: { summary: "looks good" },
+  reviewId: '11111111-1111-4111-8111-111111111111',
+  json: { summary: 'looks good' },
   commentState: -3 as const,
 };
 
 const rejectRequest = {
-  table: "lifecyclemodels" as const,
-  reviewId: "11111111-1111-4111-8111-111111111111",
-  reason: "Insufficient evidence",
+  table: 'lifecyclemodels' as const,
+  reviewId: '11111111-1111-4111-8111-111111111111',
+  reason: 'Insufficient evidence',
 };
 
 const auditPayload = buildCommandAuditPayload({
-  command: "review_save_assignment_draft",
-  actorUserId: "33333333-3333-4333-8333-333333333333",
-  targetTable: "reviews",
-  targetId: "11111111-1111-4111-8111-111111111111",
-  targetVersion: "",
+  command: 'review_save_assignment_draft',
+  actorUserId: '33333333-3333-4333-8333-333333333333',
+  targetTable: 'reviews',
+  targetId: '11111111-1111-4111-8111-111111111111',
+  targetVersion: '',
   payload: {},
 });
 
 Deno.test(
-  "callReviewSaveAssignmentDraftRpc unwraps success envelopes returned by cmd_review_* RPCs",
+  'callReviewSaveAssignmentDraftRpc unwraps success envelopes returned by cmd_review_* RPCs',
   async () => {
     const result = (await callReviewSaveAssignmentDraftRpc(
       new FakeRpcSupabase({
@@ -139,15 +139,15 @@ Deno.test(
 );
 
 Deno.test(
-  "callReviewSaveAssignmentDraftRpc treats failure envelopes as command failures",
+  'callReviewSaveAssignmentDraftRpc treats failure envelopes as command failures',
   async () => {
     const result = (await callReviewSaveAssignmentDraftRpc(
       new FakeRpcSupabase({
         data: {
           ok: false,
-          code: "REVIEW_NOT_FOUND",
+          code: 'REVIEW_NOT_FOUND',
           status: 404,
-          message: "Review not found",
+          message: 'Review not found',
           details: {
             review_id: saveAssignmentDraftRequest.reviewId,
           },
@@ -160,9 +160,9 @@ Deno.test(
 
     assertEquals(result, {
       ok: false,
-      code: "REVIEW_NOT_FOUND",
+      code: 'REVIEW_NOT_FOUND',
       status: 404,
-      message: "Review not found",
+      message: 'Review not found',
       details: {
         review_id: saveAssignmentDraftRequest.reviewId,
       },
@@ -170,39 +170,42 @@ Deno.test(
   },
 );
 
-Deno.test("callReviewApproveRpc unwraps success envelopes returned by cmd_review_approve", async () => {
-  const result = (await callReviewApproveRpc(
-    new FakeRpcSupabase({
-      data: {
-        ok: true,
+Deno.test(
+  'callReviewApproveRpc unwraps success envelopes returned by cmd_review_approve',
+  async () => {
+    const result = (await callReviewApproveRpc(
+      new FakeRpcSupabase({
         data: {
-          review_id: approveRequest.reviewId,
-          approved: true,
+          ok: true,
+          data: {
+            review_id: approveRequest.reviewId,
+            approved: true,
+          },
         },
+        error: null,
+      }) as never,
+      approveRequest,
+      auditPayload,
+    )) as ReviewRpcResult;
+
+    assertEquals(result, {
+      ok: true,
+      data: {
+        review_id: approveRequest.reviewId,
+        approved: true,
       },
-      error: null,
-    }) as never,
-    approveRequest,
-    auditPayload,
-  )) as ReviewRpcResult;
+    });
+  },
+);
 
-  assertEquals(result, {
-    ok: true,
-    data: {
-      review_id: approveRequest.reviewId,
-      approved: true,
-    },
-  });
-});
-
-Deno.test("callReviewRejectRpc treats failure envelopes as command failures", async () => {
+Deno.test('callReviewRejectRpc treats failure envelopes as command failures', async () => {
   const result = (await callReviewRejectRpc(
     new FakeRpcSupabase({
       data: {
         ok: false,
-        code: "INVALID_STATE",
+        code: 'INVALID_STATE',
         status: 409,
-        message: "Review is not in an approvable state",
+        message: 'Review is not in an approvable state',
         details: {
           review_id: rejectRequest.reviewId,
           state_code: 10,
@@ -216,9 +219,9 @@ Deno.test("callReviewRejectRpc treats failure envelopes as command failures", as
 
   assertEquals(result, {
     ok: false,
-    code: "INVALID_STATE",
+    code: 'INVALID_STATE',
     status: 409,
-    message: "Review is not in an approvable state",
+    message: 'Review is not in an approvable state',
     details: {
       review_id: rejectRequest.reviewId,
       state_code: 10,
@@ -226,28 +229,22 @@ Deno.test("callReviewRejectRpc treats failure envelopes as command failures", as
   });
 });
 
-Deno.test("review comment RPC arg builders use the DB contract field names", () => {
-  assertEquals(
-    buildReviewSaveCommentDraftRpcArgs(saveCommentDraftRequest, auditPayload),
-    {
-      p_review_id: saveCommentDraftRequest.reviewId,
-      p_json: saveCommentDraftRequest.json,
-      p_audit: auditPayload,
-    },
-  );
+Deno.test('review comment RPC arg builders use the DB contract field names', () => {
+  assertEquals(buildReviewSaveCommentDraftRpcArgs(saveCommentDraftRequest, auditPayload), {
+    p_review_id: saveCommentDraftRequest.reviewId,
+    p_json: saveCommentDraftRequest.json,
+    p_audit: auditPayload,
+  });
 
-  assertEquals(
-    buildReviewSubmitCommentRpcArgs(submitCommentRequest, auditPayload),
-    {
-      p_review_id: submitCommentRequest.reviewId,
-      p_json: submitCommentRequest.json,
-      p_comment_state: -3,
-      p_audit: auditPayload,
-    },
-  );
+  assertEquals(buildReviewSubmitCommentRpcArgs(submitCommentRequest, auditPayload), {
+    p_review_id: submitCommentRequest.reviewId,
+    p_json: submitCommentRequest.json,
+    p_comment_state: -3,
+    p_audit: auditPayload,
+  });
 });
 
-Deno.test("review decision RPC arg builders forward table and reason fields", () => {
+Deno.test('review decision RPC arg builders forward table and reason fields', () => {
   assertEquals(buildReviewApproveRpcArgs(approveRequest, auditPayload), {
     p_table: approveRequest.table,
     p_review_id: approveRequest.reviewId,


### PR DESCRIPTION
Closes linancn/tiangong-lca-edge-functions#78

## Summary
- Commit the current repo-wide prettier output for shared command modules, legacy wrappers, and related tests.
- Remove repeated local diff churn after npm run lint by aligning the checked-in formatting baseline with the configured prettier rules.

## Key Decisions
- Keep this PR formatting-only and separate from auth or behavioral fixes.

## Validation
- npm install
- npm run lint
- npm run check

## Risks / Rollback
- Large formatting-only diffs can make future cherry-picks noisier, but they reduce repeated lint churn afterward.

## Follow-ups
- After merge, future behavior PRs should no longer need to carry this same prettier residue.

## Workspace Integration
- Requires a later lca-workspace submodule pointer bump after merge.