### PR TITLE
refactor: remove source dataset fields from notification validation issue command

### DIFF
--- a/supabase/functions/_shared/commands/notification/send_validation_issue.ts
+++ b/supabase/functions/_shared/commands/notification/send_validation_issue.ts
@@ -27,9 +27,6 @@ export async function executeNotificationSendValidationIssueCommand(
     targetVersion: request.datasetVersion,
     payload: {
       recipientUserId: request.recipientUserId,
-      sourceDatasetType: request.sourceDatasetType,
-      sourceDatasetId: request.sourceDatasetId,
-      sourceDatasetVersion: request.sourceDatasetVersion,
       datasetType: request.datasetType,
       issueCount: request.issueCount ?? 0,
     },

--- a/supabase/functions/_shared/commands/notification/types.ts
+++ b/supabase/functions/_shared/commands/notification/types.ts
@@ -1,8 +1,5 @@
 export type NotificationSendValidationIssueRequest = {
   recipientUserId: string;
-  sourceDatasetType: string;
-  sourceDatasetId: string;
-  sourceDatasetVersion: string;
   datasetType: string;
   datasetId: string;
   datasetVersion: string;

--- a/supabase/functions/_shared/commands/notification/validation.ts
+++ b/supabase/functions/_shared/commands/notification/validation.ts
@@ -9,9 +9,6 @@ const nonEmptyStringSchema = z.string().trim().min(1);
 export const notificationSendValidationIssueRequestSchema = z
   .object({
     recipientUserId: uuidSchema,
-    sourceDatasetType: nonEmptyStringSchema,
-    sourceDatasetId: uuidSchema,
-    sourceDatasetVersion: nonEmptyStringSchema,
     datasetType: nonEmptyStringSchema,
     datasetId: uuidSchema,
     datasetVersion: nonEmptyStringSchema,

--- a/supabase/functions/_shared/db_rpc/notification_commands.ts
+++ b/supabase/functions/_shared/db_rpc/notification_commands.ts
@@ -79,9 +79,6 @@ export function buildNotificationSendValidationIssueRpcArgs(
 ): Record<string, unknown> {
   return {
     p_recipient_user_id: request.recipientUserId,
-    p_source_dataset_type: request.sourceDatasetType,
-    p_source_dataset_id: request.sourceDatasetId,
-    p_source_dataset_version: request.sourceDatasetVersion,
     p_dataset_type: request.datasetType,
     p_dataset_id: request.datasetId,
     p_dataset_version: request.datasetVersion,

--- a/test/notification_command_test.ts
+++ b/test/notification_command_test.ts
@@ -9,7 +9,6 @@ import {
 
 const TEST_ACTOR_ID = '11111111-1111-4111-8111-111111111111';
 const TEST_RECIPIENT_ID = '22222222-2222-4222-8222-222222222222';
-const TEST_SOURCE_DATASET_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const TEST_DATASET_ID = '33333333-3333-4333-8333-333333333333';
 
 class FakeRpcSupabase {
@@ -41,17 +40,14 @@ function buildActor(supabase: FakeRpcSupabase) {
   };
 }
 
-Deno.test('notification validation-issue payload parser is strict', () => {
+Deno.test('notification validation-issue payload parser rejects removed source dataset fields', () => {
   const parsed = parseNotificationSendValidationIssueCommand({
     recipientUserId: TEST_RECIPIENT_ID,
-    sourceDatasetType: 'process data set',
-    sourceDatasetId: TEST_SOURCE_DATASET_ID,
-    sourceDatasetVersion: '01.00.000',
     datasetType: 'process data set',
     datasetId: TEST_DATASET_ID,
     datasetVersion: '01.00.000',
     issueCodes: ['ruleVerificationFailed'],
-    extra: 'nope',
+    sourceDatasetType: 'process data set',
   });
 
   assertEquals(parsed.ok, false);
@@ -73,9 +69,6 @@ Deno.test(
     const result = await executeNotificationSendValidationIssueCommand(
       {
         recipientUserId: TEST_RECIPIENT_ID,
-        sourceDatasetType: 'process data set',
-        sourceDatasetId: TEST_SOURCE_DATASET_ID,
-        sourceDatasetVersion: '01.00.000',
         datasetType: 'process data set',
         datasetId: TEST_DATASET_ID,
         datasetVersion: '01.00.000',
@@ -93,9 +86,6 @@ Deno.test(
         fn: 'cmd_notification_send_validation_issue',
         args: {
           p_recipient_user_id: TEST_RECIPIENT_ID,
-          p_source_dataset_type: 'process data set',
-          p_source_dataset_id: TEST_SOURCE_DATASET_ID,
-          p_source_dataset_version: '01.00.000',
           p_dataset_type: 'process data set',
           p_dataset_id: TEST_DATASET_ID,
           p_dataset_version: '01.00.000',
@@ -111,9 +101,6 @@ Deno.test(
             targetVersion: '01.00.000',
             payload: {
               recipientUserId: TEST_RECIPIENT_ID,
-              sourceDatasetType: 'process data set',
-              sourceDatasetId: TEST_SOURCE_DATASET_ID,
-              sourceDatasetVersion: '01.00.000',
               datasetType: 'process data set',
               issueCount: 2,
             },


### PR DESCRIPTION
## Branch Contract

- Base branch: `dev`
- Validated environment: local static checks only
- Remote deploy expected?: `No`
- Back-merge required after merge?: `No`
- Root workspace integration expected?: `No`

- [x] This PR targets `dev`.
- [x] I confirm this repos GitHub default branch may still appear as `main`, but routine feature and fix PRs must target `dev`.
- [ ] If remote deployment is part of this change, I used the repo-standard `--no-verify-jwt` deploy contract and documented which environment was deployed.
- [x] New or changed functions do not assume gateway-level JWT verification and still enforce runtime authentication / authorization.

## Linked Issue

N/A

## Functions Changed

- `supabase/functions/_shared/commands/notification/send_validation_issue.ts`
- `supabase/functions/_shared/commands/notification/types.ts`
- `supabase/functions/_shared/commands/notification/validation.ts`
- `supabase/functions/_shared/db_rpc/notification_commands.ts`
- `test/notification_command_test.ts`

## Validation

- `npm run lint`
- `npm run check` could not complete in the local shell because `deno` is not installed globally in this environment.
- `npm exec --yes --package deno@2.7.11 -- node ./scripts/deno-check-all.cjs` reached `test/tidas_package_api_test.ts` and failed on a pre-existing `TS2345` type error at line 245 (`crypto.subtle.digest(..., bytes)`).
- `npm exec --yes --package deno@2.7.11 -- deno check --config supabase/functions/deno.json supabase/functions/app_notification_send_validation_issue/index.ts test/notification_command_test.ts`

## Risks / Follow-up

- Full repository `deno check` is currently blocked by the existing type error in `test/tidas_package_api_test.ts:245`.
- No remote deployment is included in this PR.