### PR TITLE
chore: align edge-functions dev project ref

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - 依赖锁定：`supabase/functions/deno.json` 的 `imports` 使用精确版本（exact pin），避免无版本映射。
 - 远端环境映射：
   - Git `main` / 远端 `main` project ref：`qgzvkongdjqiiamzbbts`
-  - Git `dev` / 持久化远端 `dev` branch project ref：`culgbbvzltdodcpykupc`
+  - Git `dev` / 持久化远端 `dev` branch project ref：`fotofiyqnuyvgtotswie`
 - 本地启动：
   - `npm install`
   - `npm start`（等价于 `supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt`）

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Supabase Edge Functions for LCA search, embedding, and solving workflows.
 - GitHub default branch 继续保持 `main`，这是平台层例外，不代表日常 trunk 改回 `main`。
 - 远端环境映射：
   - `main` project ref：`qgzvkongdjqiiamzbbts`
-  - `dev` project ref：`culgbbvzltdodcpykupc`
+  - `dev` project ref：`fotofiyqnuyvgtotswie`
 - 远端 `main` 与 `dev` 的函数部署都统一使用 `--no-verify-jwt`。这是正式仓库规则，不是临时口头 workaround。
 - 安全边界在函数运行时：gateway 不做 JWT 校验，不等于函数可以匿名执行。新函数不得假设 gateway `verify_jwt=true` 已经帮你兜底，必须继续显式做认证与授权。
 
@@ -415,7 +415,7 @@ Optional envs:
 
 ```bash
 # Dangerous: make sure you are targeting the correct project before overwriting secrets.
-npx --yes supabase@2.85.0 secrets set --env-file ./supabase/.env.local --project-ref culgbbvzltdodcpykupc
+npx --yes supabase@2.85.0 secrets set --env-file ./supabase/.env.local --project-ref fotofiyqnuyvgtotswie
 npx --yes supabase@2.85.0 secrets set --env-file ./supabase/.env.local --project-ref qgzvkongdjqiiamzbbts
 ```
 
@@ -437,7 +437,7 @@ for fn in $(find supabase/functions -mindepth 1 -maxdepth 1 -type d \
   -exec basename {} \; | sort); do
   echo "==> deploy $fn"
   supabase functions deploy "$fn" \
-    --project-ref culgbbvzltdodcpykupc \
+    --project-ref fotofiyqnuyvgtotswie \
     --no-verify-jwt \
     --use-api \
     --import-map supabase/functions/deno.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "supabaseCliVersion": "2.85.0",
-    "supabaseProjectRefDev": "culgbbvzltdodcpykupc",
+    "supabaseProjectRefDev": "fotofiyqnuyvgtotswie",
     "supabaseProjectRefMain": "qgzvkongdjqiiamzbbts"
   },
   "scripts": {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,7 +2,7 @@
 # - GitHub default branch remains `main` as a platform exception.
 # - Daily trunk is Git `dev`; `dev -> main` is the promote path.
 # - Root config below is the `main` / production baseline that preview branches inherit.
-# - Persistent Git `dev` maps to the remote branch project `culgbbvzltdodcpykupc` via `[remotes.dev]`.
+# - Persistent Git `dev` maps to the remote branch project `fotofiyqnuyvgtotswie` via `[remotes.dev]`.
 # - The production / `main` project ref used by deploy scripts is `qgzvkongdjqiiamzbbts`.
 #
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
@@ -159,7 +159,7 @@ skip_nonce_check = false
 
 [remotes.dev]
 # Persistent Supabase branch project used by Git `dev`.
-project_id = "culgbbvzltdodcpykupc"
+project_id = "fotofiyqnuyvgtotswie"
 
 [analytics]
 enabled = false


### PR DESCRIPTION
Refs #48

## Summary
- update the documented and scripted Supabase dev project ref to the new persistent dev branch project
- keep repo docs, package config, and `supabase/config.toml` aligned on the same dev project ref

## Validation
- `npm run lint`
- `npm run check`

## Notes
- this PR targets `dev` because `tiangong-lca-edge-functions` follows the M2 branch model with `dev` as the daily trunk
