### PR TITLE
docs: point Supabase ownership to database-engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - 远端环境映射：
   - Git `main` / 远端 `main` project ref：`qgzvkongdjqiiamzbbts`
   - Git `dev` / 持久化远端 `dev` branch project ref：`fotofiyqnuyvgtotswie`
+- 数据库 schema / migration / branch config 真相源位于 `tiangong-lca/database-engine`；本仓只负责 Edge Function 运行时代码与部署，不负责数据库真相源治理。
 - 本地启动：
   - `npm install`
   - `npm start`（等价于 `supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt`）

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,9 +1,10 @@
-# Git / Supabase branch contract for this repo:
+# Runtime / deploy config for this repo:
 # - GitHub default branch remains `main` as a platform exception.
 # - Daily trunk is Git `dev`; `dev -> main` is the promote path.
-# - Root config below is the `main` / production baseline that preview branches inherit.
-# - Persistent Git `dev` maps to the remote branch project `fotofiyqnuyvgtotswie` via `[remotes.dev]`.
-# - The production / `main` project ref used by deploy scripts is `qgzvkongdjqiiamzbbts`.
+# - This file is for Edge Function local serve and deploy configuration, not the database schema source of truth.
+# - Database schema / migration / branch config ownership lives in `tiangong-lca/database-engine`.
+# - Persistent Git `dev` deploy target maps to the remote project `fotofiyqnuyvgtotswie` via `[remotes.dev]`.
+# - The production / `main` deploy target used by scripts is `qgzvkongdjqiiamzbbts`.
 #
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.


### PR DESCRIPTION
## Summary
- update agent guidance so database schema, migration, and branch-config truth ownership points at `tiangong-lca/database-engine`
- clarify that this repo only owns Edge Function runtime code and deploy-time env handling
- narrow the local `supabase/config.toml` comments to the runtime/deploy role

## Validation
- docs-only change

## Notes
- Refs tiangong-lca/workspace#67
- This PR is part of the broader database ownership migration and does not complete the Supabase cutover by itself.
