### PR TITLE
docs: add repo-local ai-doc-lint gate for issue #88

### DIFF
--- a/.github/scripts/ai-doc-lint.mjs
+++ b/.github/scripts/ai-doc-lint.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MARKDOWN_METADATA_KEYS = [
+  'docType',
+  'scope',
+  'status',
+  'authoritative',
+  'owner',
+  'language',
+  'whenToUse',
+  'whenToUpdate',
+  'checkPaths',
+  'lastReviewedAt',
+  'lastReviewedCommit',
+];
+
+const YAML_METADATA_KEYS = ['lastReviewedAt', 'lastReviewedCommit'];
+
+export function normalizePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let output = '^';
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        output += '.*';
+        index += 1;
+      } else {
+        output += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      output += '[^/]';
+      continue;
+    }
+
+    output += escapeRegex(char);
+  }
+
+  output += '$';
+  return new RegExp(output);
+}
+
+export function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizePath(filePath));
+}
+
+export function parseJsonCompatibleYaml(text, sourceLabel) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${sourceLabel} is not valid JSON-compatible YAML. Phase 1 contract files must use JSON-compatible YAML syntax. ${error.message}`,
+    );
+  }
+}
+
+export function loadJsonCompatibleYaml(absPath, sourceLabel = absPath) {
+  return parseJsonCompatibleYaml(readFileSync(absPath, 'utf8'), sourceLabel);
+}
+
+export function parseFrontmatterKeys(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return new Set();
+  }
+
+  return new Set(
+    Array.from(match[1].matchAll(/^([A-Za-z][A-Za-z0-9]*)\s*:/gm), (result) => result[1]),
+  );
+}
+
+export function missingMarkdownMetadata(text) {
+  const keys = parseFrontmatterKeys(text);
+  return MARKDOWN_METADATA_KEYS.filter((key) => !keys.has(key));
+}
+
+export function missingYamlMetadata(text, sourceLabel) {
+  const parsed = parseJsonCompatibleYaml(text, sourceLabel);
+  return YAML_METADATA_KEYS.filter((key) => !(key in parsed));
+}
+
+export function isKeyMarkdownDoc(relPath) {
+  const normalized = normalizePath(relPath);
+  return (
+    path.posix.basename(normalized) === 'AGENTS.md' ||
+    ((normalized.startsWith('ai/') || normalized.includes('/ai/')) && normalized.endsWith('.md'))
+  );
+}
+
+export function isKeyYamlContract(relPath) {
+  const normalized = normalizePath(relPath);
+  return normalized.endsWith('.yaml') && (normalized.startsWith('ai/') || normalized.includes('/ai/'));
+}
+
+export function detectImpactLayout(rootDir) {
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact-map.yaml'))) {
+    return 'workspace';
+  }
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact.yaml'))) {
+    return 'repo';
+  }
+  return 'none';
+}
+
+export function listImpactFiles(rootDir) {
+  const layout = detectImpactLayout(rootDir);
+
+  if (layout === 'repo') {
+    return [
+      {
+        absPath: path.join(rootDir, 'ai', 'doc-impact.yaml'),
+        relPath: 'ai/doc-impact.yaml',
+        baseDir: '',
+      },
+    ];
+  }
+
+  if (layout !== 'workspace') {
+    return [];
+  }
+
+  const rootImpact = path.join(rootDir, 'ai', 'doc-impact-map.yaml');
+  const results = [
+    {
+      absPath: rootImpact,
+      relPath: 'ai/doc-impact-map.yaml',
+      baseDir: '',
+    },
+  ];
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const repoImpact = path.join(rootDir, entry.name, 'ai', 'doc-impact.yaml');
+    if (!existsSync(repoImpact)) {
+      continue;
+    }
+
+    results.push({
+      absPath: repoImpact,
+      relPath: normalizePath(path.join(entry.name, 'ai', 'doc-impact.yaml')),
+      baseDir: entry.name,
+    });
+  }
+
+  return results;
+}
+
+export function loadImpactFiles(rootDir) {
+  return listImpactFiles(rootDir).flatMap(({ absPath, relPath, baseDir }) => {
+    const parsed = loadJsonCompatibleYaml(absPath, relPath);
+    const rules = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+    return rules.map((rule) => ({
+      source: relPath,
+      baseDir,
+      rule,
+    }));
+  });
+}
+
+export function resolveRulePath(baseDir, relPattern) {
+  if (!baseDir) {
+    return normalizePath(relPattern);
+  }
+  return normalizePath(path.posix.join(baseDir, relPattern));
+}
+
+export function matchRules(changedPaths, loadedRules) {
+  const matches = [];
+
+  for (const changedPath of changedPaths) {
+    for (const loaded of loadedRules) {
+      const triggers = Array.isArray(loaded.rule.triggers) ? loaded.rule.triggers : [];
+      if (
+        triggers.some((trigger) =>
+          matchesPattern(changedPath, resolveRulePath(loaded.baseDir, trigger.path)),
+        )
+      ) {
+        matches.push({
+          changedPath,
+          source: loaded.source,
+          rule: loaded.rule,
+          baseDir: loaded.baseDir,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+export function collectExpectedDocs(matches) {
+  const expected = new Map();
+
+  for (const match of matches) {
+    const requiredDocs = Array.isArray(match.rule.requiredDocs) ? match.rule.requiredDocs : [];
+    for (const doc of requiredDocs) {
+      const fullPath = resolveRulePath(match.baseDir, doc.path);
+      if (!expected.has(fullPath)) {
+        expected.set(fullPath, {
+          path: fullPath,
+          rules: new Set(),
+          changedPaths: new Set(),
+          modes: new Set(),
+        });
+      }
+
+      const entry = expected.get(fullPath);
+      entry.rules.add(match.rule.id);
+      entry.changedPaths.add(match.changedPath);
+      entry.modes.add(doc.mode);
+    }
+  }
+
+  return expected;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    rootDir: process.cwd(),
+    mode: 'warn',
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      options.rootDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--mode') {
+      options.mode = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--files') {
+      options.files = argv[index + 1]
+        .split(',')
+        .map((value) => normalizePath(value.trim()))
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getChangedPaths({ rootDir, base, head, files }) {
+  if (files.length > 0) {
+    return [...new Set(files)];
+  }
+
+  if (!base || !head) {
+    throw new Error('Pass either --files or both --base and --head.');
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  return [...new Set(output.split(/\r?\n/).map((value) => normalizePath(value.trim())).filter(Boolean))];
+}
+
+export function buildDocProblems({ rootDir, changedPaths }) {
+  const problems = [];
+
+  for (const relPath of changedPaths) {
+    const absPath = path.join(rootDir, relPath);
+    if (!existsSync(absPath)) {
+      continue;
+    }
+
+    if (isKeyMarkdownDoc(relPath)) {
+      const missing = missingMarkdownMetadata(readFileSync(absPath, 'utf8'));
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing Markdown metadata keys: ${missing.join(', ')}`,
+        });
+      }
+      continue;
+    }
+
+    if (isKeyYamlContract(relPath)) {
+      const missing = missingYamlMetadata(readFileSync(absPath, 'utf8'), relPath);
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing YAML metadata keys: ${missing.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
+export function buildMissingDocProblems({ changedPaths, expectedDocs }) {
+  const changed = new Set(changedPaths);
+  const problems = [];
+
+  for (const entry of expectedDocs.values()) {
+    if (changed.has(entry.path)) {
+      continue;
+    }
+
+    problems.push({
+      type: 'missing-review',
+      path: entry.path,
+      message: `Expected reviewed doc was not touched. Triggered by ${Array.from(entry.changedPaths).join(', ')} via rule(s): ${Array.from(entry.rules).join(', ')}`,
+    });
+  }
+
+  return problems;
+}
+
+export function formatProblem(problem) {
+  return `- [${problem.type}] ${problem.path}: ${problem.message}`;
+}
+
+export function emitProblems(problems, mode) {
+  if (problems.length === 0) {
+    console.log('AI doc lint: no problems found.');
+    return;
+  }
+
+  const heading =
+    mode === 'enforce' ? 'AI doc lint found blocking problems:' : 'AI doc lint found warnings:';
+  const annotationLevel = mode === 'enforce' ? 'error' : 'warning';
+  console.log(heading);
+  for (const problem of problems) {
+    console.log(formatProblem(problem));
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::${annotationLevel} file=${problem.path}::${problem.message}`);
+    }
+  }
+}
+
+export function run(options) {
+  const changedPaths = getChangedPaths(options);
+  if (changedPaths.length === 0) {
+    console.log('AI doc lint: no changed paths to inspect.');
+    return { problems: [], changedPaths, matchedRules: [] };
+  }
+
+  const loadedRules = loadImpactFiles(options.rootDir);
+  const matchedRules = matchRules(changedPaths, loadedRules);
+  const expectedDocs = collectExpectedDocs(matchedRules);
+  const problems = [
+    ...buildMissingDocProblems({ changedPaths, expectedDocs }),
+    ...buildDocProblems({ rootDir: options.rootDir, changedPaths }),
+  ];
+
+  emitProblems(problems, options.mode);
+
+  if (options.mode === 'enforce' && problems.length > 0) {
+    process.exitCode = 1;
+  }
+
+  return { problems, changedPaths, matchedRules };
+}
+
+function printHelp() {
+  console.log(`Usage: node .github/scripts/ai-doc-lint.mjs [--mode warn|enforce] [--base <sha> --head <sha> | --files <csv>] [--root <dir>]`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    run(options);
+  } catch (error) {
+    console.error(`AI doc lint error: ${error.message}`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/ai-doc-lint.test.mjs
+++ b/.github/scripts/ai-doc-lint.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectExpectedDocs,
+  detectImpactLayout,
+  globToRegExp,
+  isKeyMarkdownDoc,
+  loadImpactFiles,
+  matchRules,
+  missingMarkdownMetadata,
+  missingYamlMetadata,
+  normalizePath,
+} from './ai-doc-lint.mjs';
+
+test('normalizePath and globToRegExp support repo-relative matching', () => {
+  assert.equal(normalizePath('.\\tiangong-lca-next\\config\\routes.ts'), 'tiangong-lca-next/config/routes.ts');
+  assert.equal(globToRegExp('tiangong-lca-next/**').test('tiangong-lca-next/config/routes.ts'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/quality-rubric.md'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/nested/file.md'), false);
+});
+
+test('detectImpactLayout distinguishes workspace and repo roots', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-layout-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  assert.equal(detectImpactLayout(tempDir), 'none');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'repo');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact-map.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'workspace');
+});
+
+test('isKeyMarkdownDoc excludes YAML contract files', () => {
+  assert.equal(isKeyMarkdownDoc('ai/quality-rubric.md'), true);
+  assert.equal(isKeyMarkdownDoc('AGENTS.md'), true);
+  assert.equal(isKeyMarkdownDoc('ai/workspace.yaml'), false);
+});
+
+test('missingMarkdownMetadata detects absent frontmatter keys', () => {
+  const text = `---
+title: Example
+docType: contract
+scope: workspace
+status: draft
+authoritative: false
+owner: lca-workspace
+language: en
+whenToUse:
+  - x
+whenToUpdate:
+  - y
+checkPaths:
+  - ai/**
+lastReviewedAt: 2026-04-18
+---
+
+# Example
+`;
+
+  assert.deepEqual(missingMarkdownMetadata(text), ['lastReviewedCommit']);
+});
+
+test('missingYamlMetadata detects absent top-level review fields', () => {
+  const text = JSON.stringify({ version: 1, lastReviewedAt: '2026-04-18' });
+  assert.deepEqual(missingYamlMetadata(text, 'ai/example.yaml'), ['lastReviewedCommit']);
+});
+
+test('loadImpactFiles, matchRules, and collectExpectedDocs resolve repo-local paths', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+  mkdirSync(path.join(tempDir, 'subrepo', 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact-map.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'root-rule',
+            scope: 'workspace',
+            repo: 'lca-workspace',
+            triggers: [{ path: 'AGENTS.md', kind: 'doc-contract' }],
+            requiredDocs: [{ path: 'ai/workspace.yaml', mode: 'review_or_update' }],
+            reason: 'root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    path.join(tempDir, 'subrepo', 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'subrepo',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/task-router.md', mode: 'review_or_update' }],
+            reason: 'repo',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['AGENTS.md', 'subrepo/src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 2);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...expectedDocs.keys()].sort(), ['ai/workspace.yaml', 'subrepo/ai/task-router.md']);
+});
+
+test('loadImpactFiles supports repo-root mode', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-repo-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'example',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/validation.md', mode: 'review_or_update' }],
+            reason: 'repo-root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 1);
+  assert.equal(matches.length, 1);
+  assert.deepEqual([...expectedDocs.keys()], ['ai/validation.md']);
+});

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,32 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run ai-doc-lint unit tests
+        run: node --test .github/scripts/ai-doc-lint.test.mjs
+
+      - name: Run ai-doc-lint
+        run: |
+          node .github/scripts/ai-doc-lint.mjs \
+            --mode enforce \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ Do not accept GitHub UI defaults when opening routine PRs.
 
 ## Runtime Facts
 
+- Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
 - Local serve command: `npm start`
 - Baseline local validation: `npm run lint`, `npm run check`
 - `npm run check` walks enabled `supabase/functions/*/index.ts` files plus `test/*.ts`

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -8,14 +8,32 @@
       "scope": "repo",
       "repo": "edge-functions",
       "triggers": [
-        { "path": "AGENTS.md", "kind": "doc-contract" },
-        { "path": "README.md", "kind": "doc-entry" },
-        { "path": "ai/**", "kind": "doc-ai-layer" }
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "ai/**",
+          "kind": "doc-ai-layer"
+        }
       ],
       "requiredDocs": [
-        { "path": "AGENTS.md", "mode": "review_or_update" },
-        { "path": "ai/repo.yaml", "mode": "review_or_update" },
-        { "path": "ai/task-router.md", "mode": "review_or_update" }
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        }
       ],
       "reason": "Entry guidance, repo facts, and routing docs must stay aligned."
     },
@@ -24,15 +42,36 @@
       "scope": "repo",
       "repo": "edge-functions",
       "triggers": [
-        { "path": "supabase/functions/**", "kind": "runtime-code" },
-        { "path": "supabase/functions/_shared/**", "kind": "shared-runtime" }
+        {
+          "path": "supabase/functions/**",
+          "kind": "runtime-code"
+        },
+        {
+          "path": "supabase/functions/_shared/**",
+          "kind": "shared-runtime"
+        }
       ],
       "requiredDocs": [
-        { "path": "AGENTS.md", "mode": "review_or_update" },
-        { "path": "ai/repo.yaml", "mode": "review_or_update" },
-        { "path": "ai/task-router.md", "mode": "review_or_update" },
-        { "path": "ai/validation.md", "mode": "review_or_update" },
-        { "path": "ai/architecture.md", "mode": "review_or_update" }
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
       ],
       "reason": "Runtime and shared module changes can alter repo ownership, routing, validation scope, and architecture hotspots."
     },
@@ -41,15 +80,36 @@
       "scope": "repo",
       "repo": "edge-functions",
       "triggers": [
-        { "path": "test/**", "kind": "runtime-test" },
-        { "path": "scripts/deno-check-all.cjs", "kind": "validation-wrapper" },
-        { "path": ".github/workflows/**", "kind": "ci" }
+        {
+          "path": "test/**",
+          "kind": "runtime-test"
+        },
+        {
+          "path": "scripts/deno-check-all.cjs",
+          "kind": "validation-wrapper"
+        },
+        {
+          "path": ".github/workflows/ci.yml",
+          "kind": "ci"
+        }
       ],
       "requiredDocs": [
-        { "path": "AGENTS.md", "mode": "review_or_update" },
-        { "path": "ai/task-router.md", "mode": "review_or_update" },
-        { "path": "ai/validation.md", "mode": "review_or_update" },
-        { "path": "ai/architecture.md", "mode": "review_or_update" }
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
       ],
       "reason": "Test inventory and CI changes affect how future runtime work is checked and where validation expectations live."
     },
@@ -58,23 +118,100 @@
       "scope": "repo",
       "repo": "edge-functions",
       "triggers": [
-        { "path": "package.json", "kind": "runtime-config" },
-        { "path": "supabase/config.toml", "kind": "deploy-config" },
-        { "path": "scripts/deploy-function.cjs", "kind": "deploy-script" },
-        { "path": "scripts/probe-functions-auth.cjs", "kind": "ops-script" },
-        { "path": "scripts/lca_submit_poll_fetch.sh", "kind": "ops-script" },
-        { "path": "test.example.http", "kind": "request-collection" },
-        { "path": "supabase/.env.example", "kind": "env-template" },
-        { "path": ".github/PULL_REQUEST_TEMPLATE/**", "kind": "pr-contract" }
+        {
+          "path": "package.json",
+          "kind": "runtime-config"
+        },
+        {
+          "path": "supabase/config.toml",
+          "kind": "deploy-config"
+        },
+        {
+          "path": "scripts/deploy-function.cjs",
+          "kind": "deploy-script"
+        },
+        {
+          "path": "scripts/probe-functions-auth.cjs",
+          "kind": "ops-script"
+        },
+        {
+          "path": "scripts/lca_submit_poll_fetch.sh",
+          "kind": "ops-script"
+        },
+        {
+          "path": "test.example.http",
+          "kind": "request-collection"
+        },
+        {
+          "path": "supabase/.env.example",
+          "kind": "env-template"
+        },
+        {
+          "path": ".github/PULL_REQUEST_TEMPLATE/**",
+          "kind": "pr-contract"
+        }
       ],
       "requiredDocs": [
-        { "path": "AGENTS.md", "mode": "review_or_update" },
-        { "path": "ai/repo.yaml", "mode": "review_or_update" },
-        { "path": "ai/task-router.md", "mode": "review_or_update" },
-        { "path": "ai/validation.md", "mode": "review_or_update" },
-        { "path": "ai/architecture.md", "mode": "review_or_update" }
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
       ],
       "reason": "Deploy targets, auth probes, request examples, and PR contracts define how runtime behavior is validated and handed off."
+    },
+    {
+      "id": "edge-functions-ai-doc-maintenance-contract",
+      "scope": "repo",
+      "repo": "edge-functions",
+      "triggers": [
+        {
+          "path": ".github/workflows/ai-doc-lint.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.mjs",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.test.mjs",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Repo-local AI doc maintenance automation changes alter the maintenance gate and should refresh the AI contract docs."
     }
   ]
 }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -32,7 +32,10 @@
       "sharedRoot": "supabase/functions/_shared",
       "testsRoot": "test",
       "localServeCommand": "npm start",
-      "baselineValidationCommands": ["npm run lint", "npm run check"],
+      "baselineValidationCommands": [
+        "npm run lint",
+        "npm run check"
+      ],
       "remoteDeployCommands": [
         "npm run deploy:dev -- <function-name> [more-function-names...]",
         "npm run deploy:main -- <function-name> [more-function-names...]"
@@ -42,11 +45,17 @@
       "deployGatewayRule": "Both scripted remote deploy paths append --no-verify-jwt and therefore rely on function-runtime authentication instead of gateway JWT enforcement.",
       "authModel": {
         "runtimeEntry": "supabase/functions/_shared/auth.ts",
-        "supportedMethods": ["JWT", "USER_API_KEY", "SERVICE_API_KEY"],
+        "supportedMethods": [
+          "JWT",
+          "USER_API_KEY",
+          "SERVICE_API_KEY"
+        ],
         "probeScript": "scripts/probe-functions-auth.cjs"
       },
       "checkBaselineSkips": {
-        "functionPrefixes": ["antchain_"],
+        "functionPrefixes": [
+          "antchain_"
+        ],
         "functionNames": [
           "embedding",
           "webhook_flow_embedding",
@@ -55,7 +64,10 @@
         ],
         "notes": "test/*.ts is always included. embedding_ft_local is local-only and is not part of the index.ts inventory."
       },
-      "remoteProjects": { "dev": "fotofiyqnuyvgtotswie", "main": "qgzvkongdjqiiamzbbts" }
+      "remoteProjects": {
+        "dev": "fotofiyqnuyvgtotswie",
+        "main": "qgzvkongdjqiiamzbbts"
+      }
     },
     "sourceOfTruth": {
       "stableManualEditPaths": [
@@ -99,9 +111,18 @@
           "path": "test.example.http",
           "role": "checked-in request collection for local and remote smoke checks"
         },
-        { "path": "supabase/.env.example", "role": "local environment template" },
-        { "path": "README.md", "role": "human setup and operations guide" },
-        { "path": ".github/workflows/ci.yml", "role": "CI baseline for lint and deno-check" },
+        {
+          "path": "supabase/.env.example",
+          "role": "local environment template"
+        },
+        {
+          "path": "README.md",
+          "role": "human setup and operations guide"
+        },
+        {
+          "path": ".github/workflows/ci.yml",
+          "role": "CI baseline for lint and deno-check"
+        },
         {
           "path": ".github/PULL_REQUEST_TEMPLATE/**",
           "role": "repo-level PR base, deploy, and integration contract"
@@ -191,13 +212,17 @@
       }
     ],
     "validation": {
-      "baselineLocalCommands": ["npm run lint", "npm run check"],
+      "baselineLocalCommands": [
+        "npm run lint",
+        "npm run check"
+      ],
       "ciWorkflow": ".github/workflows/ci.yml",
       "notes": [
         "CI installs Node dependencies, then runs npm run lint and npm run check.",
         "Remote deploy proof is separate from local lint and deno-check proof.",
         "If a function depends on missing SQL, RPC, or state-code semantics, database-engine must validate the database side."
-      ]
+      ],
+      "aiDocLintWorkflow": ".github/workflows/ai-doc-lint.yml"
     }
   }
 }

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -65,6 +65,7 @@ When working inside `tiangong-lca-edge-functions`, load docs in this order:
 | Investigate deploy target, project ref, or `--no-verify-jwt` behavior | `package.json`, `scripts/deploy-function.cjs`, `supabase/config.toml`, `.github/PULL_REQUEST_TEMPLATE/**` | `ai/repo.yaml`, `ai/validation.md` | Do not change deploy targets or auth assumptions silently. |
 | Investigate auth or connectivity drift across many functions | `scripts/probe-functions-auth.cjs`, `test.example.http`, then affected functions | `ai/validation.md` | Use `--dry-run`, `--remote`, or `--local` before editing many handlers. |
 | Decide whether the task is actually a database schema or RPC-truth change | `database-engine`, not this repo | root `ai/task-router.md`, `database-engine/AGENTS.md` | Schema, migrations, SQL tests, and persistent branch governance do not belong here. |
+| Change repo-local AI-doc maintenance only | `AGENTS.md`, `ai/**`, `.github/workflows/ai-doc-lint.yml`, `.github/scripts/ai-doc-lint.*` | `ai/validation.md` when present, otherwise `ai/repo.yaml` | Keep the repo-local maintenance gate aligned with root `ai/ci-lint-spec.md` and `ai/review-matrix.md`. |
 | Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
 
 ## Wrong Turns To Avoid

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -72,7 +72,7 @@ If you reactivate or rely on one of those routes, update the inventory and valid
 | Deploy script, `package.json`, `supabase/config.toml`, or PR contract files | `npm run lint`; inspect branch, project-ref, and deploy-flag changes against `ai/repo.yaml`; run `npm run check` if runtime inventory or imports changed | if the task includes a real deploy, record which environment was deployed and which function names were used | Remote deploy proof is not implied by local lint or type-check. |
 | Auth probe tooling | `npm run lint`; `node scripts/probe-functions-auth.cjs --help`; `npm run probe:auth -- --dry-run` | run `npm run probe:auth -- --remote` or `--local` when the task explicitly includes live probe validation | Dry-run is the safe default when you only changed classification or selection logic. |
 | Repo tests only | `npm run lint`; `npm run check`; targeted `deno check --config supabase/functions/deno.json <changed-test-file>` | run neighboring tests that cover the same shared module or function family | This repo keeps Deno tests in `test/**`, not under each function folder. |
-| AI docs only | run the root warning-only `ai-doc-lint` against touched files | perform scenario-based routing checks from root into this repo | Refresh review metadata even when prose-only docs change. |
+| AI docs only | run repo-local `ai-doc-lint` against touched files or the equivalent local PR check | perform scenario-based routing checks from root into this repo | Refresh review metadata even when prose-only docs change. |
 
 ## Auth And Probe Notes
 
@@ -93,7 +93,7 @@ npm run probe:auth -- --remote --only lca_
 
 ## AI Contract File Notes
 
-Root `ai-doc-lint` currently expects repo-local `ai/*.yaml` files to stay JSON-compatible YAML.
+The repo-local `ai-doc-lint` implementation expects repo-local `ai/*.yaml` files to stay JSON-compatible YAML.
 
 In this repo that means:
 


### PR DESCRIPTION
Closes #88

## Summary
- Add repo-local ai-doc-lint workflow and vendored lint scripts.
- Update AI contract docs and doc-impact rules for the repo-local maintenance gate.

## Key Decisions
- Use the root canonical ai-doc-lint implementation in repo-root mode and vendor it into the child repo.

## Validation
- node --test .github/scripts/ai-doc-lint.test.mjs
- node .github/scripts/ai-doc-lint.mjs --mode enforce --files "$(git status --porcelain | awk '{print $2}' | paste -sd, -)"

## Risks / Rollback
- This PR changes only AI-doc maintenance docs, repo-local lint automation, and doc-impact routing; no edge runtime code paths were changed.

## Workspace Integration
- A later lca-workspace submodule bump may still be required before workspace delivery is complete.