### PR TITLE
docs: promote AI doc rollout from dev to main

### DIFF
--- a/.github/scripts/ai-doc-lint.mjs
+++ b/.github/scripts/ai-doc-lint.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MARKDOWN_METADATA_KEYS = [
+  'docType',
+  'scope',
+  'status',
+  'authoritative',
+  'owner',
+  'language',
+  'whenToUse',
+  'whenToUpdate',
+  'checkPaths',
+  'lastReviewedAt',
+  'lastReviewedCommit',
+];
+
+const YAML_METADATA_KEYS = ['lastReviewedAt', 'lastReviewedCommit'];
+
+export function normalizePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let output = '^';
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        output += '.*';
+        index += 1;
+      } else {
+        output += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      output += '[^/]';
+      continue;
+    }
+
+    output += escapeRegex(char);
+  }
+
+  output += '$';
+  return new RegExp(output);
+}
+
+export function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizePath(filePath));
+}
+
+export function parseJsonCompatibleYaml(text, sourceLabel) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${sourceLabel} is not valid JSON-compatible YAML. Phase 1 contract files must use JSON-compatible YAML syntax. ${error.message}`,
+    );
+  }
+}
+
+export function loadJsonCompatibleYaml(absPath, sourceLabel = absPath) {
+  return parseJsonCompatibleYaml(readFileSync(absPath, 'utf8'), sourceLabel);
+}
+
+export function parseFrontmatterKeys(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return new Set();
+  }
+
+  return new Set(
+    Array.from(match[1].matchAll(/^([A-Za-z][A-Za-z0-9]*)\s*:/gm), (result) => result[1]),
+  );
+}
+
+export function missingMarkdownMetadata(text) {
+  const keys = parseFrontmatterKeys(text);
+  return MARKDOWN_METADATA_KEYS.filter((key) => !keys.has(key));
+}
+
+export function missingYamlMetadata(text, sourceLabel) {
+  const parsed = parseJsonCompatibleYaml(text, sourceLabel);
+  return YAML_METADATA_KEYS.filter((key) => !(key in parsed));
+}
+
+export function isKeyMarkdownDoc(relPath) {
+  const normalized = normalizePath(relPath);
+  return (
+    path.posix.basename(normalized) === 'AGENTS.md' ||
+    ((normalized.startsWith('ai/') || normalized.includes('/ai/')) && normalized.endsWith('.md'))
+  );
+}
+
+export function isKeyYamlContract(relPath) {
+  const normalized = normalizePath(relPath);
+  return normalized.endsWith('.yaml') && (normalized.startsWith('ai/') || normalized.includes('/ai/'));
+}
+
+export function detectImpactLayout(rootDir) {
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact-map.yaml'))) {
+    return 'workspace';
+  }
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact.yaml'))) {
+    return 'repo';
+  }
+  return 'none';
+}
+
+export function listImpactFiles(rootDir) {
+  const layout = detectImpactLayout(rootDir);
+
+  if (layout === 'repo') {
+    return [
+      {
+        absPath: path.join(rootDir, 'ai', 'doc-impact.yaml'),
+        relPath: 'ai/doc-impact.yaml',
+        baseDir: '',
+      },
+    ];
+  }
+
+  if (layout !== 'workspace') {
+    return [];
+  }
+
+  const rootImpact = path.join(rootDir, 'ai', 'doc-impact-map.yaml');
+  const results = [
+    {
+      absPath: rootImpact,
+      relPath: 'ai/doc-impact-map.yaml',
+      baseDir: '',
+    },
+  ];
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const repoImpact = path.join(rootDir, entry.name, 'ai', 'doc-impact.yaml');
+    if (!existsSync(repoImpact)) {
+      continue;
+    }
+
+    results.push({
+      absPath: repoImpact,
+      relPath: normalizePath(path.join(entry.name, 'ai', 'doc-impact.yaml')),
+      baseDir: entry.name,
+    });
+  }
+
+  return results;
+}
+
+export function loadImpactFiles(rootDir) {
+  return listImpactFiles(rootDir).flatMap(({ absPath, relPath, baseDir }) => {
+    const parsed = loadJsonCompatibleYaml(absPath, relPath);
+    const rules = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+    return rules.map((rule) => ({
+      source: relPath,
+      baseDir,
+      rule,
+    }));
+  });
+}
+
+export function resolveRulePath(baseDir, relPattern) {
+  if (!baseDir) {
+    return normalizePath(relPattern);
+  }
+  return normalizePath(path.posix.join(baseDir, relPattern));
+}
+
+export function matchRules(changedPaths, loadedRules) {
+  const matches = [];
+
+  for (const changedPath of changedPaths) {
+    for (const loaded of loadedRules) {
+      const triggers = Array.isArray(loaded.rule.triggers) ? loaded.rule.triggers : [];
+      if (
+        triggers.some((trigger) =>
+          matchesPattern(changedPath, resolveRulePath(loaded.baseDir, trigger.path)),
+        )
+      ) {
+        matches.push({
+          changedPath,
+          source: loaded.source,
+          rule: loaded.rule,
+          baseDir: loaded.baseDir,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+export function collectExpectedDocs(matches) {
+  const expected = new Map();
+
+  for (const match of matches) {
+    const requiredDocs = Array.isArray(match.rule.requiredDocs) ? match.rule.requiredDocs : [];
+    for (const doc of requiredDocs) {
+      const fullPath = resolveRulePath(match.baseDir, doc.path);
+      if (!expected.has(fullPath)) {
+        expected.set(fullPath, {
+          path: fullPath,
+          rules: new Set(),
+          changedPaths: new Set(),
+          modes: new Set(),
+        });
+      }
+
+      const entry = expected.get(fullPath);
+      entry.rules.add(match.rule.id);
+      entry.changedPaths.add(match.changedPath);
+      entry.modes.add(doc.mode);
+    }
+  }
+
+  return expected;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    rootDir: process.cwd(),
+    mode: 'warn',
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      options.rootDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--mode') {
+      options.mode = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--files') {
+      options.files = argv[index + 1]
+        .split(',')
+        .map((value) => normalizePath(value.trim()))
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getChangedPaths({ rootDir, base, head, files }) {
+  if (files.length > 0) {
+    return [...new Set(files)];
+  }
+
+  if (!base || !head) {
+    throw new Error('Pass either --files or both --base and --head.');
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  return [...new Set(output.split(/\r?\n/).map((value) => normalizePath(value.trim())).filter(Boolean))];
+}
+
+export function buildDocProblems({ rootDir, changedPaths }) {
+  const problems = [];
+
+  for (const relPath of changedPaths) {
+    const absPath = path.join(rootDir, relPath);
+    if (!existsSync(absPath)) {
+      continue;
+    }
+
+    if (isKeyMarkdownDoc(relPath)) {
+      const missing = missingMarkdownMetadata(readFileSync(absPath, 'utf8'));
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing Markdown metadata keys: ${missing.join(', ')}`,
+        });
+      }
+      continue;
+    }
+
+    if (isKeyYamlContract(relPath)) {
+      const missing = missingYamlMetadata(readFileSync(absPath, 'utf8'), relPath);
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing YAML metadata keys: ${missing.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
+export function buildMissingDocProblems({ changedPaths, expectedDocs }) {
+  const changed = new Set(changedPaths);
+  const problems = [];
+
+  for (const entry of expectedDocs.values()) {
+    if (changed.has(entry.path)) {
+      continue;
+    }
+
+    problems.push({
+      type: 'missing-review',
+      path: entry.path,
+      message: `Expected reviewed doc was not touched. Triggered by ${Array.from(entry.changedPaths).join(', ')} via rule(s): ${Array.from(entry.rules).join(', ')}`,
+    });
+  }
+
+  return problems;
+}
+
+export function formatProblem(problem) {
+  return `- [${problem.type}] ${problem.path}: ${problem.message}`;
+}
+
+export function emitProblems(problems, mode) {
+  if (problems.length === 0) {
+    console.log('AI doc lint: no problems found.');
+    return;
+  }
+
+  const heading =
+    mode === 'enforce' ? 'AI doc lint found blocking problems:' : 'AI doc lint found warnings:';
+  const annotationLevel = mode === 'enforce' ? 'error' : 'warning';
+  console.log(heading);
+  for (const problem of problems) {
+    console.log(formatProblem(problem));
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::${annotationLevel} file=${problem.path}::${problem.message}`);
+    }
+  }
+}
+
+export function run(options) {
+  const changedPaths = getChangedPaths(options);
+  if (changedPaths.length === 0) {
+    console.log('AI doc lint: no changed paths to inspect.');
+    return { problems: [], changedPaths, matchedRules: [] };
+  }
+
+  const loadedRules = loadImpactFiles(options.rootDir);
+  const matchedRules = matchRules(changedPaths, loadedRules);
+  const expectedDocs = collectExpectedDocs(matchedRules);
+  const problems = [
+    ...buildMissingDocProblems({ changedPaths, expectedDocs }),
+    ...buildDocProblems({ rootDir: options.rootDir, changedPaths }),
+  ];
+
+  emitProblems(problems, options.mode);
+
+  if (options.mode === 'enforce' && problems.length > 0) {
+    process.exitCode = 1;
+  }
+
+  return { problems, changedPaths, matchedRules };
+}
+
+function printHelp() {
+  console.log(`Usage: node .github/scripts/ai-doc-lint.mjs [--mode warn|enforce] [--base <sha> --head <sha> | --files <csv>] [--root <dir>]`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    run(options);
+  } catch (error) {
+    console.error(`AI doc lint error: ${error.message}`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/ai-doc-lint.test.mjs
+++ b/.github/scripts/ai-doc-lint.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectExpectedDocs,
+  detectImpactLayout,
+  globToRegExp,
+  isKeyMarkdownDoc,
+  loadImpactFiles,
+  matchRules,
+  missingMarkdownMetadata,
+  missingYamlMetadata,
+  normalizePath,
+} from './ai-doc-lint.mjs';
+
+test('normalizePath and globToRegExp support repo-relative matching', () => {
+  assert.equal(normalizePath('.\\tiangong-lca-next\\config\\routes.ts'), 'tiangong-lca-next/config/routes.ts');
+  assert.equal(globToRegExp('tiangong-lca-next/**').test('tiangong-lca-next/config/routes.ts'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/quality-rubric.md'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/nested/file.md'), false);
+});
+
+test('detectImpactLayout distinguishes workspace and repo roots', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-layout-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  assert.equal(detectImpactLayout(tempDir), 'none');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'repo');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact-map.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'workspace');
+});
+
+test('isKeyMarkdownDoc excludes YAML contract files', () => {
+  assert.equal(isKeyMarkdownDoc('ai/quality-rubric.md'), true);
+  assert.equal(isKeyMarkdownDoc('AGENTS.md'), true);
+  assert.equal(isKeyMarkdownDoc('ai/workspace.yaml'), false);
+});
+
+test('missingMarkdownMetadata detects absent frontmatter keys', () => {
+  const text = `---
+title: Example
+docType: contract
+scope: workspace
+status: draft
+authoritative: false
+owner: lca-workspace
+language: en
+whenToUse:
+  - x
+whenToUpdate:
+  - y
+checkPaths:
+  - ai/**
+lastReviewedAt: 2026-04-18
+---
+
+# Example
+`;
+
+  assert.deepEqual(missingMarkdownMetadata(text), ['lastReviewedCommit']);
+});
+
+test('missingYamlMetadata detects absent top-level review fields', () => {
+  const text = JSON.stringify({ version: 1, lastReviewedAt: '2026-04-18' });
+  assert.deepEqual(missingYamlMetadata(text, 'ai/example.yaml'), ['lastReviewedCommit']);
+});
+
+test('loadImpactFiles, matchRules, and collectExpectedDocs resolve repo-local paths', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+  mkdirSync(path.join(tempDir, 'subrepo', 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact-map.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'root-rule',
+            scope: 'workspace',
+            repo: 'lca-workspace',
+            triggers: [{ path: 'AGENTS.md', kind: 'doc-contract' }],
+            requiredDocs: [{ path: 'ai/workspace.yaml', mode: 'review_or_update' }],
+            reason: 'root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    path.join(tempDir, 'subrepo', 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'subrepo',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/task-router.md', mode: 'review_or_update' }],
+            reason: 'repo',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['AGENTS.md', 'subrepo/src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 2);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...expectedDocs.keys()].sort(), ['ai/workspace.yaml', 'subrepo/ai/task-router.md']);
+});
+
+test('loadImpactFiles supports repo-root mode', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-repo-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'example',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/validation.md', mode: 'review_or_update' }],
+            reason: 'repo-root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 1);
+  assert.equal(matches.length, 1);
+  assert.deepEqual([...expectedDocs.keys()], ['ai/validation.md']);
+});

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,32 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run ai-doc-lint unit tests
+        run: node --test .github/scripts/ai-doc-lint.test.mjs
+
+      - name: Run ai-doc-lint
+        run: |
+          node .github/scripts/ai-doc-lint.mjs \
+            --mode enforce \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -12,5 +12,11 @@ module.exports = {
         parser: 'json',
       },
     },
+    {
+      files: 'ai/**/*.yaml',
+      options: {
+        parser: 'json',
+      },
+    },
   ],
 };

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,186 +1,138 @@
-# AGENTS.md
+---
+title: edge-functions AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: edge-functions
+language: en
+whenToUse:
+  - when a task may change Edge Function runtime behavior, auth handling, request or response semantics, deploy scripts, or repo validation flow
+  - when routing work from the workspace root into tiangong-lca-edge-functions
+  - when deciding whether a change belongs here, in database-engine, in tiangong-lca-next, or in lca-workspace
+whenToUpdate:
+  - when repo ownership or source-of-truth boundaries change
+  - when branch, deploy, auth-probe, or validation contracts change
+  - when the repo-local AI bootstrap docs under ai/ change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - ai/**/*.md
+  - ai/**/*.yaml
+  - package.json
+  - supabase/config.toml
+  - supabase/functions/**
+  - test/**
+  - scripts/**
+  - test.example.http
+  - supabase/.env.example
+  - .github/workflows/**
+  - .github/PULL_REQUEST_TEMPLATE/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 94889a43af4e63a496bcbbb2e2bf5f3a69677dc0
+related:
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - README.md
+  - test.example.http
+---
 
-## 1. Purpose
+# AGENTS.md — edge-functions AI Working Guide
 
-本文件用于约束后续 AI 在本仓库的开发行为，目标是：
+`tiangong-lca-edge-functions` owns the checked-in Supabase Edge Function runtime contract for TianGong LCA. Start here when the task may change function behavior, shared runtime modules, deploy scripts, or repo-local validation expectations.
 
-- 保证修改可执行、可验证、可回溯。
-- 降低上下文切换成本，让 AI 能快速接手。
-- 保持代码、文档、运行方式同步。
-- 仅维护最终状态，不记录历史变更过程（历史记录由 Git/PR 承载）。
+## AI Load Order
 
-## 2. Project Snapshot
+Load docs in this order:
 
-- 项目类型：Supabase Edge Functions（Deno 2.1.x）+ Node 工具链。
-- 分支模型：本仓库保持 GitHub default branch 为 `main` 这一平台层例外，但日常 trunk 是 Git `dev`；routine PR 默认回 `dev`，promote 路径是 `dev -> main`，hotfix 从 `main` 起并在合并后 `main -> dev` 回合并。
-- 入口目录：`supabase/functions/*/index.ts`。
-- 共享模块：`supabase/functions/_shared/*`。
-- Deno 测试文件统一放在仓库根目录 `test/*`，不要放在 `supabase/functions/**` 下。
-- 依赖锁定：`supabase/functions/deno.json` 的 `imports` 使用精确版本（exact pin），避免无版本映射。
-- 远端环境映射：
-  - Git `main` / 远端 `main` project ref：`qgzvkongdjqiiamzbbts`
-  - Git `dev` / 持久化远端 `dev` branch project ref：`fotofiyqnuyvgtotswie`
-- 数据库 schema / migration / branch config 真相源位于 `tiangong-lca/database-engine`；本仓只负责 Edge Function 运行时代码与部署，不负责数据库真相源治理。
-- 本地启动：
-  - `npm install`
-  - `npm start`（等价于 `supabase functions serve --env-file ./supabase/.env.local --no-verify-jwt`）
-  - `npm run probe:auth -- --remote`（远端 edge functions 连通性 / 鉴权探测；也可用 `--local` 或 `--base-url`）
-- 基线校验命令：
-  - `npm run lint`
-  - `npm run check`（依次对当前启用的 `supabase/functions/*/index.ts` 与 `test/*.ts` 执行 `deno check`；当前默认排除 README 中已标记为 not enabled 的 `antchain_*` 与 legacy 非 `*_ft` embedding/webhook 入口）
-- 正式远端部署入口：
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/task-router.md`
+4. `ai/validation.md`
+5. `ai/architecture.md`
+6. `README.md` and `test.example.http` only when you need human setup details or concrete request examples
+
+Do not start with the long README, raw function inventories, or GitHub default-branch UI.
+
+## Repo Ownership
+
+This repo owns:
+
+- `supabase/functions/**` for Edge Function entrypoints, handlers, and runtime request or response behavior
+- `supabase/functions/_shared/**` for auth, command runtime, DB-RPC wrappers, OpenAI, Redis, Supabase client helpers, and shared domain utilities
+- `test/**` for repo-level Deno tests
+- `scripts/deno-check-all.cjs`, `scripts/deploy-function.cjs`, `scripts/probe-functions-auth.cjs`, and `scripts/lca_submit_poll_fetch.sh`
+- `package.json` for Node scripts, Supabase CLI pinning, and remote project-ref mapping
+- `supabase/config.toml` for local serve and edge deploy bindings
+- `.github/workflows/ci.yml` and `.github/PULL_REQUEST_TEMPLATE/**`
+- `test.example.http` and `supabase/.env.example` as checked-in request and env examples
+
+This repo does not own:
+
+- database schema, migrations, persistent Supabase branch governance, or SQL regression-test truth
+- frontend page behavior, app-side workflow behavior, or frontend env selection
+- workspace submodule pointer bumps or delivery completion
+
+Route those tasks to:
+
+- `tiangong-lca/database-engine` for schema truth, migrations, SQL tests, and Supabase branch governance
+- `linancn/tiangong-lca-next` for frontend behavior and app-side flows
+- `tiangong-lca/workspace` for root integration after merge
+
+## Branch Facts
+
+- GitHub default branch: `main`
+- True daily trunk: `dev`
+- Routine branch base: `dev`
+- Routine PR base: `dev`
+- Promote path: `dev -> main`
+- Hotfix path: branch from `main`, merge back into `main`, then back-merge `main -> dev`
+
+Do not accept GitHub UI defaults when opening routine PRs.
+
+## Runtime Facts
+
+- Local serve command: `npm start`
+- Baseline local validation: `npm run lint`, `npm run check`
+- `npm run check` walks enabled `supabase/functions/*/index.ts` files plus `test/*.ts`
+- Baseline `npm run check` intentionally skips `antchain_*`, `embedding`, `webhook_flow_embedding`, `webhook_model_embedding`, and `webhook_process_embedding`
+- Remote deploy entrypoints:
   - `npm run deploy:dev -- <function-name> [more-function-names...]`
   - `npm run deploy:main -- <function-name> [more-function-names...]`
-  - 两类远端部署都固定追加 `--no-verify-jwt`
-- 安全边界：
-  - 远端 `main` 与 `dev` gateway 都不负责 JWT 校验
-  - 函数运行时必须继续完成认证与授权
-  - 新函数不得假设 gateway `verify_jwt=true` 已经帮你兜底
-- 主要测试样例：`test.example.http`
-- 鉴权排障脚本：`scripts/probe-functions-auth.cjs`
-- 主要说明文档：`README.md`
+- Both deploy scripts append `--no-verify-jwt`
+- Local serve also uses `--no-verify-jwt`
+- Gateway JWT verification being off does not mean runtime auth is optional; functions must still authenticate and authorize requests
+- Auth and connectivity drift triage starts with `npm run probe:auth -- --remote` or `npm run probe:auth -- --local`
 
-## 3. Directory Guide
+## Quick Routes
 
-- `supabase/functions/flow_hybrid_search`、`process_hybrid_search`、`lifecyclemodel_hybrid_search`
-  - 混合检索函数（LLM query rewrite + 向量/全文检索）。
-- `supabase/functions/ai_suggest`
-  - AI 建议生成函数。
-- `supabase/functions/embedding*`、`webhook_*embedding*`
-  - 嵌入与 webhook 处理链路。
-- `supabase/functions/lca_*`
-  - LCA 求解、任务查询、结果查询。
-  - `lca_solve`
-    - `data_scope` 可选 `current_user` / `open_data` / `all_data`
-    - 三个 scope 都复用同一类用户增强 snapshot（公开数据 + 当前用户数据）
-    - 请求时仍按根过程语义区分：`current_user = 当前用户过程`，`open_data = 公开过程`，`all_data = 当前用户 + 公开过程`
-    - 三个 scope 在缺少 ready snapshot 时都可自动触发构建
-  - `lca_query_results` 当前同时支持：
-    - `process_all_impacts`
-    - `processes_one_impact` 显式 `process_ids` 对比
-    - `processes_one_impact` 通过 `top_n/offset/sort_by/sort_direction` 做 snapshot 级热点排名
-    - `data_scope` 可选 `current_user` / `open_data` / `all_data`
-    - 三个 scope 都复用同一类用户增强 snapshot（公开数据 + 当前用户数据）
-    - 请求时仍按过程 scope 过滤：`current_user = 当前用户过程`，`open_data = 公开过程`，`all_data = 当前用户 + 公开过程`
-    - 三个 scope 在缺少 ready snapshot 时都可自动触发构建
-  - `lca_contribution_path`
-    - 提交某个 `process + impact` 的路径分析异步作业
-    - 复用 `lca_jobs + lca_result_cache + lca_results`
-    - `data_scope` 规则与 `lca_query_results` 一致
-  - `lca_contribution_path_result`
-    - 读取 `contribution-path:v1` JSON artifact 并返回解析结果
-- `supabase/functions/import_tidas_package`
-  - TIDAS ZIP 导入入口。
-  - `POST` only。
-  - 支持 `AuthMethod.JWT` 与 `AuthMethod.USER_API_KEY`。
-  - JWT 请求不应依赖 Redis；Redis 仅用于 `USER_API_KEY` 鉴权缓存。
-  - action `prepare_upload` 负责创建 import job / source artifact 并返回 signed upload URL。
-  - action `enqueue` 负责将 source artifact 标记为 ready 并触发 `lca_package_enqueue_job`。
-- `supabase/functions/tidas_package_jobs`
-  - 查询 package job 与关联 artifact。
-  - 支持 `GET`/`POST`。
-  - 支持 `AuthMethod.JWT` 与 `AuthMethod.USER_API_KEY`。
-  - 成功响应在保留原始 `diagnostics` 的同时，额外返回 `diagnostics_summary`，用于稳定暴露 `error_code`、`message`、`stage`、`upload_mode`、`artifact_byte_size`、`http_status`、`storage_error_code`、`is_oversize`
-  - package export `open_data` scope 现在按 `state_code` `100..199` 识别公开数据，不再把旧的 `99` 视作公开数据
-- `supabase/functions/_shared`
-  - 认证、OpenAI、Redis、Supabase client、通用工具。
-- `supabase/functions/app_dataset_save_draft`、`app_dataset_assign_team`、`app_dataset_publish`、`app_dataset_submit_review`
-  - 数据集命令入口。
-  - 统一走 command runtime + request-scoped Supabase client，不再让 repository 隐式回退到 service-role client。
-- `supabase/functions/_shared/command_runtime`
-  - 命令式函数的 HTTP、JSON 解析、actor context、审计 payload、公用 handler 骨架。
-- `supabase/functions/_shared/db_rpc`
-  - Edge 到数据库 command/query RPC 的薄封装。
-- `supabase/functions/_shared/commands/dataset`
-  - 数据集命令的类型、校验、policy、repository 和执行器。
-- `test/*`
-  - 仓库级 Deno 测试文件；共享模块和函数相关测试也放这里，通过相对路径引用 `supabase/functions/**` 代码。
-- `scripts/lca_submit_poll_fetch.sh`
-  - LCA submit/poll/fetch 联调脚本（依赖 `jq`）。
+| If the task is about... | Load next |
+| --- | --- |
+| adding or changing one Edge Function or shared runtime module | `ai/task-router.md`, then `ai/validation.md` |
+| changing auth, credential precedence, or command-runtime behavior | `ai/task-router.md`, then `ai/architecture.md` |
+| changing deploy targets, project refs, or auth-probe behavior | `ai/repo.yaml`, then `ai/validation.md` |
+| changing request examples, smoke-test workflow, or repo-level tests | `ai/validation.md`, then `README.md` or `test.example.http` |
+| deciding whether missing SQL or RPC behavior belongs here | `ai/task-router.md`, then root `ai/task-router.md` and `database-engine/AGENTS.md` |
+| deciding whether a merged repo PR is delivery-complete | root `AGENTS.md` and `_docs/workspace-branch-policy-contract.md` in `lca-workspace` |
 
-## 4. OpenAI Integration Baseline
+## Hard Boundaries
 
-- 当前统一依赖映射在 `supabase/functions/deno.json`：
-  - `@openai/openai -> npm:openai@6.27.0`
-  - `@supabase/functions-js/edge-runtime.d.ts -> jsr:@supabase/functions-js@2.98.0/edge-runtime.d.ts`
-  - `@supabase/supabase-js@2 -> jsr:@supabase/supabase-js@2.98.0`
-- 代码中统一使用：
-  - `import OpenAI from "@openai/openai";`
-- 默认优先 `responses.create`；若需要兼容，允许在共享层做回退逻辑。
-- 与同义词相关逻辑统一放在：
-  - `supabase/functions/_shared/hybrid_query_utils.ts`
+- Do not invent schema truth or migration history in this repo.
+- Do not interpret `--no-verify-jwt` as permission for anonymous business logic.
+- Do not move repo-level tests into `supabase/functions/**`; current convention keeps them in `test/**`.
+- Do not treat GitHub default branch `main` as the daily trunk.
+- Do not mark delivery complete if root workspace integration is still pending.
 
-## 5. Non-Negotiable Workflow (MUST)
+## Workspace Integration
 
-每次 AI 对代码做任何改动后，必须执行以下步骤：
+A merged PR in `tiangong-lca-edge-functions` is repo-complete, not delivery-complete.
 
-1. 运行格式与规范脚本：
-   - `npm run lint`
-2. 运行校验脚本：
-   - `npm run check` 是默认基线，提交前 / PR 前应通过。
-   - 若涉及 `supabase/functions` 下代码改动（`.ts`/`.js`），`deno check` 属于强制步骤，不可跳过。
-   - scoped 迭代时仍按影响范围补跑针对性 `deno check`：
-     - 单函数改动：`deno check --config supabase/functions/deno.json <changed-file>`
-     - 共享模块改动：至少覆盖所有直接依赖该模块的函数。
-3. 同步文档：
-   - 若改动影响开发流程、依赖版本、函数行为、验证方式，必须同步更新 `AGENTS.md`（必要时同时更新 `README.md`）。
-4. 输出结果时明确：
-   - 改了哪些文件
-   - 运行了哪些命令
-   - 哪些校验通过/未执行及原因
+If the change must ship through the workspace:
 
-## 6. AGENTS.md Sync Rules (MUST)
+1. merge the child PR into `tiangong-lca-edge-functions`
+2. make sure the intended SHA is eligible for root integration
+3. update the `lca-workspace` submodule pointer deliberately
 
-出现以下任一情况，必须更新本文件：
-
-- 新增/删除函数目录。
-- 变更核心依赖（如 OpenAI SDK、Supabase runtime 相关依赖）。
-- 变更统一开发命令、lint/format/test 命令。
-- 变更共享模块职责边界（`_shared` 下）。
-- 变更“必做流程”、分支模型或发布/部署流程。
-
-如果改动不涉及以上内容，可不改 `AGENTS.md`，但需要在最终说明中声明“本次无需更新 AGENTS.md”。
-
-## 7. Validation Matrix
-
-- 混合检索相关改动（`flow/process/lifecyclemodel` 或其 shared 依赖）：
-  - `npm run check`
-  - `deno check` 三个函数至少各跑一次。
-  - 用 `test.example.http` 里的对应请求做 smoke test（本地或远程至少一端）。
-- OpenAI 共享层改动（`openai_structured.ts` / `openai_chat.ts`）：
-  - `npm run check`
-  - 至少验证 `responses.create` 可用（`deno eval` 或实际函数调用）。
-- LCA 链路改动：
-  - `npm run check`
-  - 优先用 `scripts/lca_submit_poll_fetch.sh` 验证端到端（本地需 `jq`）。
-- TIDAS package import 改动：
-  - `npm run lint`
-  - `npm run check`
-  - `deno check --config supabase/functions/deno.json supabase/functions/import_tidas_package/index.ts`
-  - 如果改动触及 `_shared/auth.ts` / `_shared/tidas_package.ts` / `_shared/redis_client.ts`，至少补跑所有直接依赖这些共享模块的 package 相关函数
-  - 用 `test.example.http` 中的 `import_tidas_package` / `tidas_package_jobs` 示例至少验证一组本地或远程请求
-
-## 8. Environment & Secrets
-
-- 环境文件：
-  - 本地函数运行：`supabase/.env.local`
-  - HTTP 调试变量：仓库根目录 `.env`
-- 如果本地 serve 需要把 `app_dataset_*` 请求转发到远端 Supabase 项目并保留用户 JWT 语义，补充 `REMOTE_SUPABASE_PUBLISHABLE_KEY`（或 `REMOTE_SUPABASE_ANON_KEY`）供 request-scoped client 使用。
-- 严禁在提交、日志、回答中泄露密钥、token、完整连接串。
-- 展示命令输出时，默认对敏感字段脱敏。
-
-## 9. Change Strategy for AI
-
-- 优先改共享层，避免在多个函数复制逻辑。
-- 优先“小步可验证”，一次只解决一个明确问题。
-- 不做与请求无关的大范围重构。
-- 不引入新依赖，除非有明确必要并在 `AGENTS.md`/`README.md` 记录原因。
-
-## 10. Suggested Final Response Template
-
-每次完成开发后，建议按以下结构输出：
-
-1. 结果摘要（1-3 句）。
-2. 变更文件列表。
-3. 执行的验证命令与结果。
-4. 风险/后续建议（如有）。
+For normal root `main` integration, `lca-workspace/main` should point only at commits already promoted onto `tiangong-lca-edge-functions/main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ Do not accept GitHub UI defaults when opening routine PRs.
 
 ## Runtime Facts
 
+- Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
 - Local serve command: `npm start`
 - Baseline local validation: `npm run lint`, `npm run check`
 - `npm run check` walks enabled `supabase/functions/*/index.ts` files plus `test/*.ts`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ Supabase Edge Functions for LCA search, embedding, and solving workflows.
 - Functions root: `supabase/functions`
 - Local serve command: `npm start`
 
+## AI Docs Entry
+
+For the AI-facing checked-in contract layer, start with:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/task-router.md`
+4. `ai/validation.md`
+5. `ai/architecture.md`
+
+These files are the low-token entry path for repo ownership, branch and deploy rules, validation, and cross-repo boundaries. `README.md` remains the human-oriented setup and operations guide.
+
 ## Branch & Deployment Contract
 
 - 本仓库采用以下分支规则：Git `dev` 是日常 trunk，routine PR 默认回 `dev`，`dev -> main` 是 promote 路径，hotfix 从 `main` 起并在合并后回合并到 `dev`。

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -1,0 +1,194 @@
+---
+title: edge-functions Architecture Notes
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: edge-functions
+language: en
+whenToUse:
+  - when you need a compact mental model of the repo before editing runtime code, shared helpers, tests, or deploy tooling
+  - when deciding which function family or shared module owns a behavior change
+  - when auth, command-runtime, LCA, TIDAS, or embedding hotspots are mentioned without file paths
+whenToUpdate:
+  - when major repo paths or hotspot families change
+  - when shared runtime boundaries move
+  - when deploy or validation architecture changes enough to make this map misleading
+checkPaths:
+  - ai/architecture.md
+  - ai/repo.yaml
+  - package.json
+  - supabase/config.toml
+  - supabase/functions/**
+  - test/**
+  - scripts/**
+  - test.example.http
+  - .github/workflows/**
+  - .github/PULL_REQUEST_TEMPLATE/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 94889a43af4e63a496bcbbb2e2bf5f3a69677dc0
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./validation.md
+  - ../README.md
+  - ../test.example.http
+---
+
+# edge-functions Architecture Notes
+
+## Repo Shape
+
+This repo is organized around Edge Function families plus a shared runtime layer under `supabase/functions/_shared`.
+
+## Stable Path Map
+
+| Path group | Stability | Why it matters |
+| --- | --- | --- |
+| `supabase/functions/<name>/index.ts` | stable | default Edge Function entrypoint; baseline `npm run check` walks enabled `index.ts` files |
+| `supabase/functions/<name>/handler.ts` | stable | larger routes sometimes split real logic here while `index.ts` stays thin |
+| `supabase/functions/_shared/auth.ts` | stable | central runtime auth and credential-selection logic |
+| `supabase/functions/_shared/command_runtime/**` | stable | request parsing, actor context, audit payload, and command-handler skeleton |
+| `supabase/functions/_shared/commands/**` | stable | dataset, review, membership, notification, and profile command logic |
+| `supabase/functions/_shared/db_rpc/**` | stable | thin wrappers over database RPC calls; SQL truth still lives in `database-engine` |
+| `supabase/functions/_shared/openai_*.ts` and `hybrid_query_utils.ts` | stable | shared OpenAI and query-rewrite helpers used by AI-backed routes |
+| `supabase/functions/_shared/lca_*.ts` | stable | scope and snapshot helpers for LCA endpoints |
+| `supabase/functions/_shared/tidas_package.ts` | stable | import, export, and diagnostics shaping for TIDAS package flows |
+| `test/**` | stable | repo-level Deno tests for functions and shared modules |
+| `scripts/**` | stable | deno-check inventory, deploy contract, auth probe, and LCA smoke helper |
+| `supabase/config.toml` | stable | local serve and remote edge deploy config; not database schema truth |
+| `test.example.http` | stable | checked-in smoke request collection for local and remote routes |
+
+## Branch Model In Practice
+
+`tiangong-lca-edge-functions` is an M2 repo:
+
+- Git `dev` is the daily integration trunk
+- Git `main` is the promoted release line
+- routine feature or fix PRs target `dev`
+- promotion PRs target `main`
+- `.github/PULL_REQUEST_TEMPLATE/feature-to-dev.md` and `promote-dev-to-main.md` encode those expectations
+
+This means branch behavior is part of the repo contract, not just a GitHub UI preference.
+
+## Auth And Deploy Architecture
+
+The repo intentionally keeps gateway JWT verification off in its standard operator paths:
+
+- local serve: `npm start`
+- scripted remote deploys: `npm run deploy:dev`, `npm run deploy:main`
+
+Both paths use `--no-verify-jwt`.
+
+The real auth boundary is therefore inside runtime code, primarily:
+
+- `supabase/functions/_shared/auth.ts`
+- `supabase/functions/_shared/cognito_auth.ts`
+- `supabase/functions/_shared/decode_api_key.ts`
+
+Supported runtime auth modes currently include:
+
+- `JWT`
+- `USER_API_KEY`
+- `SERVICE_API_KEY`
+
+`scripts/probe-functions-auth.cjs` exists because gateway rejection and runtime-auth rejection are different operational failures.
+
+## Current Function Families
+
+### Command-style app and admin endpoints
+
+These endpoints usually share the same runtime skeleton:
+
+- `supabase/functions/app_dataset_*`
+- `supabase/functions/app_review_*`
+- `supabase/functions/app_team_*`
+- `supabase/functions/app_user_*`
+- `supabase/functions/admin_*`
+
+The shared layers that matter most are:
+
+- `supabase/functions/_shared/command_runtime/**`
+- `supabase/functions/_shared/commands/**`
+- `supabase/functions/_shared/db_rpc/**`
+
+### Search, embedding, and AI-backed routes
+
+These routes cluster around:
+
+- `flow_hybrid_search`
+- `process_hybrid_search`
+- `lifecyclemodel_hybrid_search`
+- `ai_suggest`
+- `embedding_ft`
+- `webhook_*_embedding_ft`
+
+Important shared helpers:
+
+- `supabase/functions/_shared/openai_chat.ts`
+- `supabase/functions/_shared/openai_structured.ts`
+- `supabase/functions/_shared/hybrid_query_utils.ts`
+
+Legacy non-`*_ft` embedding and webhook routes still exist in the tree, but the default deno-check baseline skips them.
+
+### LCA async job and result routes
+
+This cluster includes:
+
+- `lca_solve`
+- `lca_jobs`
+- `lca_results`
+- `lca_query_results`
+- `lca_contribution_path`
+- `lca_contribution_path_result`
+
+Shared scope logic lives in:
+
+- `supabase/functions/_shared/lca_process_scope.ts`
+- `supabase/functions/_shared/lca_snapshot_scope.ts`
+
+### TIDAS package flows
+
+This cluster includes:
+
+- `import_tidas_package`
+- `export_tidas_package`
+- `tidas_package_jobs`
+
+Shared behavior lives in:
+
+- `supabase/functions/_shared/tidas_package.ts`
+- `supabase/functions/_shared/redis_client.ts`
+
+## Database Boundary
+
+This repo consumes database truth but does not own it.
+
+Typical signs the task also belongs in `database-engine`:
+
+- a route depends on a missing RPC such as `lca_enqueue_job`
+- command wrappers need new SQL contract or policy behavior
+- published-state or `state_code` semantics changed
+
+Fix the runtime here. Fix schema truth there.
+
+## Validation Hotspots
+
+The widest fan-out changes usually touch:
+
+1. `_shared/auth.ts`
+2. `_shared/command_runtime/**`
+3. `_shared/db_rpc/**`
+4. `_shared/openai_*.ts`
+5. `scripts/deno-check-all.cjs`
+6. `scripts/probe-functions-auth.cjs`
+
+If one of those changes, assume more than one function family is affected.
+
+## Common Misreads
+
+- GitHub default branch `main` is not the daily trunk
+- `supabase/config.toml` does not own database schema truth
+- `--no-verify-jwt` does not remove runtime auth requirements
+- a merged child PR does not finish workspace delivery

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -1,0 +1,80 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "94889a43af4e63a496bcbbb2e2bf5f3a69677dc0",
+  "rules": [
+    {
+      "id": "edge-functions-bootstrap-contract",
+      "scope": "repo",
+      "repo": "edge-functions",
+      "triggers": [
+        { "path": "AGENTS.md", "kind": "doc-contract" },
+        { "path": "README.md", "kind": "doc-entry" },
+        { "path": "ai/**", "kind": "doc-ai-layer" }
+      ],
+      "requiredDocs": [
+        { "path": "AGENTS.md", "mode": "review_or_update" },
+        { "path": "ai/repo.yaml", "mode": "review_or_update" },
+        { "path": "ai/task-router.md", "mode": "review_or_update" }
+      ],
+      "reason": "Entry guidance, repo facts, and routing docs must stay aligned."
+    },
+    {
+      "id": "edge-functions-runtime-contract",
+      "scope": "repo",
+      "repo": "edge-functions",
+      "triggers": [
+        { "path": "supabase/functions/**", "kind": "runtime-code" },
+        { "path": "supabase/functions/_shared/**", "kind": "shared-runtime" }
+      ],
+      "requiredDocs": [
+        { "path": "AGENTS.md", "mode": "review_or_update" },
+        { "path": "ai/repo.yaml", "mode": "review_or_update" },
+        { "path": "ai/task-router.md", "mode": "review_or_update" },
+        { "path": "ai/validation.md", "mode": "review_or_update" },
+        { "path": "ai/architecture.md", "mode": "review_or_update" }
+      ],
+      "reason": "Runtime and shared module changes can alter repo ownership, routing, validation scope, and architecture hotspots."
+    },
+    {
+      "id": "edge-functions-validation-and-ci-contract",
+      "scope": "repo",
+      "repo": "edge-functions",
+      "triggers": [
+        { "path": "test/**", "kind": "runtime-test" },
+        { "path": "scripts/deno-check-all.cjs", "kind": "validation-wrapper" },
+        { "path": ".github/workflows/**", "kind": "ci" }
+      ],
+      "requiredDocs": [
+        { "path": "AGENTS.md", "mode": "review_or_update" },
+        { "path": "ai/task-router.md", "mode": "review_or_update" },
+        { "path": "ai/validation.md", "mode": "review_or_update" },
+        { "path": "ai/architecture.md", "mode": "review_or_update" }
+      ],
+      "reason": "Test inventory and CI changes affect how future runtime work is checked and where validation expectations live."
+    },
+    {
+      "id": "edge-functions-deploy-and-ops-contract",
+      "scope": "repo",
+      "repo": "edge-functions",
+      "triggers": [
+        { "path": "package.json", "kind": "runtime-config" },
+        { "path": "supabase/config.toml", "kind": "deploy-config" },
+        { "path": "scripts/deploy-function.cjs", "kind": "deploy-script" },
+        { "path": "scripts/probe-functions-auth.cjs", "kind": "ops-script" },
+        { "path": "scripts/lca_submit_poll_fetch.sh", "kind": "ops-script" },
+        { "path": "test.example.http", "kind": "request-collection" },
+        { "path": "supabase/.env.example", "kind": "env-template" },
+        { "path": ".github/PULL_REQUEST_TEMPLATE/**", "kind": "pr-contract" }
+      ],
+      "requiredDocs": [
+        { "path": "AGENTS.md", "mode": "review_or_update" },
+        { "path": "ai/repo.yaml", "mode": "review_or_update" },
+        { "path": "ai/task-router.md", "mode": "review_or_update" },
+        { "path": "ai/validation.md", "mode": "review_or_update" },
+        { "path": "ai/architecture.md", "mode": "review_or_update" }
+      ],
+      "reason": "Deploy targets, auth probes, request examples, and PR contracts define how runtime behavior is validated and handed off."
+    }
+  ]
+}

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -8,14 +8,32 @@
       "scope": "repo",
       "repo": "edge-functions",
       "triggers": [
-        { "path": "AGENTS.md", "kind": "doc-contract" },
-        { "path": "README.md", "kind": "doc-entry" },
-        { "path": "ai/**", "kind": "doc-ai-layer" }
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "ai/**",
+          "kind": "doc-ai-layer"
+        }
       ],
       "requiredDocs": [
-        { "path": "AGENTS.md", "mode": "review_or_update" },
-        { "path": "ai/repo.yaml", "mode": "review_or_update" },
-        { "path": "ai/task-router.md", "mode": "review_or_update" }
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        }
       ],
       "reason": "Entry guidance, repo facts, and routing docs must stay aligned."
     },
@@ -24,15 +42,36 @@
       "scope": "repo",
       "repo": "edge-functions",
       "triggers": [
-        { "path": "supabase/functions/**", "kind": "runtime-code" },
-        { "path": "supabase/functions/_shared/**", "kind": "shared-runtime" }
+        {
+          "path": "supabase/functions/**",
+          "kind": "runtime-code"
+        },
+        {
+          "path": "supabase/functions/_shared/**",
+          "kind": "shared-runtime"
+        }
       ],
       "requiredDocs": [
-        { "path": "AGENTS.md", "mode": "review_or_update" },
-        { "path": "ai/repo.yaml", "mode": "review_or_update" },
-        { "path": "ai/task-router.md", "mode": "review_or_update" },
-        { "path": "ai/validation.md", "mode": "review_or_update" },
-        { "path": "ai/architecture.md", "mode": "review_or_update" }
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
       ],
       "reason": "Runtime and shared module changes can alter repo ownership, routing, validation scope, and architecture hotspots."
     },
@@ -41,15 +80,36 @@
       "scope": "repo",
       "repo": "edge-functions",
       "triggers": [
-        { "path": "test/**", "kind": "runtime-test" },
-        { "path": "scripts/deno-check-all.cjs", "kind": "validation-wrapper" },
-        { "path": ".github/workflows/**", "kind": "ci" }
+        {
+          "path": "test/**",
+          "kind": "runtime-test"
+        },
+        {
+          "path": "scripts/deno-check-all.cjs",
+          "kind": "validation-wrapper"
+        },
+        {
+          "path": ".github/workflows/ci.yml",
+          "kind": "ci"
+        }
       ],
       "requiredDocs": [
-        { "path": "AGENTS.md", "mode": "review_or_update" },
-        { "path": "ai/task-router.md", "mode": "review_or_update" },
-        { "path": "ai/validation.md", "mode": "review_or_update" },
-        { "path": "ai/architecture.md", "mode": "review_or_update" }
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
       ],
       "reason": "Test inventory and CI changes affect how future runtime work is checked and where validation expectations live."
     },
@@ -58,23 +118,100 @@
       "scope": "repo",
       "repo": "edge-functions",
       "triggers": [
-        { "path": "package.json", "kind": "runtime-config" },
-        { "path": "supabase/config.toml", "kind": "deploy-config" },
-        { "path": "scripts/deploy-function.cjs", "kind": "deploy-script" },
-        { "path": "scripts/probe-functions-auth.cjs", "kind": "ops-script" },
-        { "path": "scripts/lca_submit_poll_fetch.sh", "kind": "ops-script" },
-        { "path": "test.example.http", "kind": "request-collection" },
-        { "path": "supabase/.env.example", "kind": "env-template" },
-        { "path": ".github/PULL_REQUEST_TEMPLATE/**", "kind": "pr-contract" }
+        {
+          "path": "package.json",
+          "kind": "runtime-config"
+        },
+        {
+          "path": "supabase/config.toml",
+          "kind": "deploy-config"
+        },
+        {
+          "path": "scripts/deploy-function.cjs",
+          "kind": "deploy-script"
+        },
+        {
+          "path": "scripts/probe-functions-auth.cjs",
+          "kind": "ops-script"
+        },
+        {
+          "path": "scripts/lca_submit_poll_fetch.sh",
+          "kind": "ops-script"
+        },
+        {
+          "path": "test.example.http",
+          "kind": "request-collection"
+        },
+        {
+          "path": "supabase/.env.example",
+          "kind": "env-template"
+        },
+        {
+          "path": ".github/PULL_REQUEST_TEMPLATE/**",
+          "kind": "pr-contract"
+        }
       ],
       "requiredDocs": [
-        { "path": "AGENTS.md", "mode": "review_or_update" },
-        { "path": "ai/repo.yaml", "mode": "review_or_update" },
-        { "path": "ai/task-router.md", "mode": "review_or_update" },
-        { "path": "ai/validation.md", "mode": "review_or_update" },
-        { "path": "ai/architecture.md", "mode": "review_or_update" }
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
       ],
       "reason": "Deploy targets, auth probes, request examples, and PR contracts define how runtime behavior is validated and handed off."
+    },
+    {
+      "id": "edge-functions-ai-doc-maintenance-contract",
+      "scope": "repo",
+      "repo": "edge-functions",
+      "triggers": [
+        {
+          "path": ".github/workflows/ai-doc-lint.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.mjs",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.test.mjs",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Repo-local AI doc maintenance automation changes alter the maintenance gate and should refresh the AI contract docs."
     }
   ]
 }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -32,7 +32,10 @@
       "sharedRoot": "supabase/functions/_shared",
       "testsRoot": "test",
       "localServeCommand": "npm start",
-      "baselineValidationCommands": ["npm run lint", "npm run check"],
+      "baselineValidationCommands": [
+        "npm run lint",
+        "npm run check"
+      ],
       "remoteDeployCommands": [
         "npm run deploy:dev -- <function-name> [more-function-names...]",
         "npm run deploy:main -- <function-name> [more-function-names...]"
@@ -42,11 +45,17 @@
       "deployGatewayRule": "Both scripted remote deploy paths append --no-verify-jwt and therefore rely on function-runtime authentication instead of gateway JWT enforcement.",
       "authModel": {
         "runtimeEntry": "supabase/functions/_shared/auth.ts",
-        "supportedMethods": ["JWT", "USER_API_KEY", "SERVICE_API_KEY"],
+        "supportedMethods": [
+          "JWT",
+          "USER_API_KEY",
+          "SERVICE_API_KEY"
+        ],
         "probeScript": "scripts/probe-functions-auth.cjs"
       },
       "checkBaselineSkips": {
-        "functionPrefixes": ["antchain_"],
+        "functionPrefixes": [
+          "antchain_"
+        ],
         "functionNames": [
           "embedding",
           "webhook_flow_embedding",
@@ -55,7 +64,10 @@
         ],
         "notes": "test/*.ts is always included. embedding_ft_local is local-only and is not part of the index.ts inventory."
       },
-      "remoteProjects": { "dev": "fotofiyqnuyvgtotswie", "main": "qgzvkongdjqiiamzbbts" }
+      "remoteProjects": {
+        "dev": "fotofiyqnuyvgtotswie",
+        "main": "qgzvkongdjqiiamzbbts"
+      }
     },
     "sourceOfTruth": {
       "stableManualEditPaths": [
@@ -99,9 +111,18 @@
           "path": "test.example.http",
           "role": "checked-in request collection for local and remote smoke checks"
         },
-        { "path": "supabase/.env.example", "role": "local environment template" },
-        { "path": "README.md", "role": "human setup and operations guide" },
-        { "path": ".github/workflows/ci.yml", "role": "CI baseline for lint and deno-check" },
+        {
+          "path": "supabase/.env.example",
+          "role": "local environment template"
+        },
+        {
+          "path": "README.md",
+          "role": "human setup and operations guide"
+        },
+        {
+          "path": ".github/workflows/ci.yml",
+          "role": "CI baseline for lint and deno-check"
+        },
         {
           "path": ".github/PULL_REQUEST_TEMPLATE/**",
           "role": "repo-level PR base, deploy, and integration contract"
@@ -191,13 +212,17 @@
       }
     ],
     "validation": {
-      "baselineLocalCommands": ["npm run lint", "npm run check"],
+      "baselineLocalCommands": [
+        "npm run lint",
+        "npm run check"
+      ],
       "ciWorkflow": ".github/workflows/ci.yml",
       "notes": [
         "CI installs Node dependencies, then runs npm run lint and npm run check.",
         "Remote deploy proof is separate from local lint and deno-check proof.",
         "If a function depends on missing SQL, RPC, or state-code semantics, database-engine must validate the database side."
-      ]
+      ],
+      "aiDocLintWorkflow": ".github/workflows/ai-doc-lint.yml"
     }
   }
 }

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -1,0 +1,203 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "94889a43af4e63a496bcbbb2e2bf5f3a69677dc0",
+  "repo": {
+    "id": "edge-functions",
+    "path": "tiangong-lca-edge-functions",
+    "canonicalRepo": "linancn/tiangong-lca-edge-functions",
+    "purpose": "Supabase Edge Functions runtime and API orchestration repository for TianGong LCA.",
+    "entryDoc": "AGENTS.md",
+    "taskRouterDoc": "ai/task-router.md",
+    "validationDoc": "ai/validation.md",
+    "architectureDoc": "ai/architecture.md",
+    "readmeDoc": "README.md",
+    "defaultBranch": "main",
+    "dailyTrunk": "dev",
+    "routinePrBase": "dev",
+    "branchModel": "M2",
+    "promotePath": "dev -> main",
+    "hotfixPath": "branch from main, merge back into main, then back-merge main -> dev",
+    "workspaceIntegrationRequired": true,
+    "rootIntegrationRule": "lca-workspace/main should normally bump only commits already promoted onto tiangong-lca-edge-functions/main.",
+    "trackedBy": {
+      "workspaceParentIssue": "https://github.com/tiangong-lca/workspace/issues/73",
+      "repoIssue": "https://github.com/linancn/tiangong-lca-edge-functions/issues/86"
+    },
+    "runtime": {
+      "nodeVersion": "22",
+      "supabaseCliVersion": "2.85.0",
+      "denoConfig": "supabase/functions/deno.json",
+      "functionsRoot": "supabase/functions",
+      "sharedRoot": "supabase/functions/_shared",
+      "testsRoot": "test",
+      "localServeCommand": "npm start",
+      "baselineValidationCommands": ["npm run lint", "npm run check"],
+      "remoteDeployCommands": [
+        "npm run deploy:dev -- <function-name> [more-function-names...]",
+        "npm run deploy:main -- <function-name> [more-function-names...]"
+      ],
+      "authProbeCommand": "npm run probe:auth -- --remote",
+      "requestExamplesDoc": "test.example.http",
+      "deployGatewayRule": "Both scripted remote deploy paths append --no-verify-jwt and therefore rely on function-runtime authentication instead of gateway JWT enforcement.",
+      "authModel": {
+        "runtimeEntry": "supabase/functions/_shared/auth.ts",
+        "supportedMethods": ["JWT", "USER_API_KEY", "SERVICE_API_KEY"],
+        "probeScript": "scripts/probe-functions-auth.cjs"
+      },
+      "checkBaselineSkips": {
+        "functionPrefixes": ["antchain_"],
+        "functionNames": [
+          "embedding",
+          "webhook_flow_embedding",
+          "webhook_model_embedding",
+          "webhook_process_embedding"
+        ],
+        "notes": "test/*.ts is always included. embedding_ft_local is local-only and is not part of the index.ts inventory."
+      },
+      "remoteProjects": { "dev": "fotofiyqnuyvgtotswie", "main": "qgzvkongdjqiiamzbbts" }
+    },
+    "sourceOfTruth": {
+      "stableManualEditPaths": [
+        {
+          "path": "supabase/functions/**",
+          "role": "Edge Function entrypoints, handlers, and runtime request or response behavior"
+        },
+        {
+          "path": "supabase/functions/_shared/**",
+          "role": "shared auth, command runtime, DB-RPC wrappers, OpenAI, Redis, Supabase, and domain helpers"
+        },
+        {
+          "path": "test/**",
+          "role": "repo-level Deno tests for functions and shared modules"
+        },
+        {
+          "path": "scripts/deno-check-all.cjs",
+          "role": "baseline deno-check inventory and skip policy"
+        },
+        {
+          "path": "scripts/deploy-function.cjs",
+          "role": "deploy contract, target project-ref mapping, and enforced --no-verify-jwt flag"
+        },
+        {
+          "path": "scripts/probe-functions-auth.cjs",
+          "role": "auth and connectivity drift classifier for local and remote functions"
+        },
+        {
+          "path": "scripts/lca_submit_poll_fetch.sh",
+          "role": "manual LCA submit, poll, and fetch smoke helper"
+        },
+        {
+          "path": "package.json",
+          "role": "Node scripts, Supabase CLI pin, and remote project refs"
+        },
+        {
+          "path": "supabase/config.toml",
+          "role": "local serve baseline plus persistent dev remote binding for edge deploys; not database schema truth"
+        },
+        {
+          "path": "test.example.http",
+          "role": "checked-in request collection for local and remote smoke checks"
+        },
+        { "path": "supabase/.env.example", "role": "local environment template" },
+        { "path": "README.md", "role": "human setup and operations guide" },
+        { "path": ".github/workflows/ci.yml", "role": "CI baseline for lint and deno-check" },
+        {
+          "path": ".github/PULL_REQUEST_TEMPLATE/**",
+          "role": "repo-level PR base, deploy, and integration contract"
+        }
+      ],
+      "nonOwnerBoundaries": [
+        {
+          "repo": "database-engine",
+          "doesNotOwn": [
+            "database schema and migration history",
+            "persistent Supabase branch governance",
+            "SQL regression test truth"
+          ]
+        },
+        {
+          "repo": "tiangong-lca-next",
+          "doesNotOwn": [
+            "frontend page behavior",
+            "app-side user workflows",
+            "frontend env selection"
+          ]
+        },
+        {
+          "repo": "lca-workspace",
+          "doesNotOwn": [
+            "submodule pointer bumps",
+            "workspace delivery completion",
+            "root integration branch decisions"
+          ]
+        }
+      ]
+    },
+    "taskHotspots": [
+      {
+        "topic": "command-style dataset, review, team, and admin endpoints",
+        "paths": [
+          "supabase/functions/app_dataset_*/**",
+          "supabase/functions/app_review_*/**",
+          "supabase/functions/app_team_*/**",
+          "supabase/functions/app_user_*/**",
+          "supabase/functions/admin_*/**",
+          "supabase/functions/_shared/command_runtime/**",
+          "supabase/functions/_shared/commands/**",
+          "supabase/functions/_shared/db_rpc/**"
+        ]
+      },
+      {
+        "topic": "hybrid search, embeddings, and OpenAI-backed runtime behavior",
+        "paths": [
+          "supabase/functions/flow_hybrid_search/**",
+          "supabase/functions/process_hybrid_search/**",
+          "supabase/functions/lifecyclemodel_hybrid_search/**",
+          "supabase/functions/ai_suggest/**",
+          "supabase/functions/embedding*",
+          "supabase/functions/webhook_*embedding*",
+          "supabase/functions/_shared/openai_*.ts",
+          "supabase/functions/_shared/hybrid_query_utils.ts"
+        ]
+      },
+      {
+        "topic": "LCA solve, queue, result, and scope behavior",
+        "paths": [
+          "supabase/functions/lca_*/**",
+          "supabase/functions/_shared/lca_process_scope.ts",
+          "supabase/functions/_shared/lca_snapshot_scope.ts"
+        ]
+      },
+      {
+        "topic": "TIDAS package import, export, and job orchestration",
+        "paths": [
+          "supabase/functions/import_tidas_package/**",
+          "supabase/functions/export_tidas_package/**",
+          "supabase/functions/tidas_package_jobs/**",
+          "supabase/functions/_shared/tidas_package.ts",
+          "supabase/functions/_shared/redis_client.ts"
+        ]
+      },
+      {
+        "topic": "deploy, auth drift, and repo-level validation operations",
+        "paths": [
+          "package.json",
+          "supabase/config.toml",
+          "scripts/**",
+          ".github/workflows/**",
+          ".github/PULL_REQUEST_TEMPLATE/**"
+        ]
+      }
+    ],
+    "validation": {
+      "baselineLocalCommands": ["npm run lint", "npm run check"],
+      "ciWorkflow": ".github/workflows/ci.yml",
+      "notes": [
+        "CI installs Node dependencies, then runs npm run lint and npm run check.",
+        "Remote deploy proof is separate from local lint and deno-check proof.",
+        "If a function depends on missing SQL, RPC, or state-code semantics, database-engine must validate the database side."
+      ]
+    }
+  }
+}

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -65,6 +65,7 @@ When working inside `tiangong-lca-edge-functions`, load docs in this order:
 | Investigate deploy target, project ref, or `--no-verify-jwt` behavior | `package.json`, `scripts/deploy-function.cjs`, `supabase/config.toml`, `.github/PULL_REQUEST_TEMPLATE/**` | `ai/repo.yaml`, `ai/validation.md` | Do not change deploy targets or auth assumptions silently. |
 | Investigate auth or connectivity drift across many functions | `scripts/probe-functions-auth.cjs`, `test.example.http`, then affected functions | `ai/validation.md` | Use `--dry-run`, `--remote`, or `--local` before editing many handlers. |
 | Decide whether the task is actually a database schema or RPC-truth change | `database-engine`, not this repo | root `ai/task-router.md`, `database-engine/AGENTS.md` | Schema, migrations, SQL tests, and persistent branch governance do not belong here. |
+| Change repo-local AI-doc maintenance only | `AGENTS.md`, `ai/**`, `.github/workflows/ai-doc-lint.yml`, `.github/scripts/ai-doc-lint.*` | `ai/validation.md` when present, otherwise `ai/repo.yaml` | Keep the repo-local maintenance gate aligned with root `ai/ci-lint-spec.md` and `ai/review-matrix.md`. |
 | Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
 
 ## Wrong Turns To Avoid

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -1,0 +1,113 @@
+---
+title: edge-functions Task Router
+docType: router
+scope: repo
+status: active
+authoritative: false
+owner: edge-functions
+language: en
+whenToUse:
+  - when you already know the task belongs in tiangong-lca-edge-functions but need the right next path or next doc
+  - when deciding whether a change belongs in one function, a shared runtime module, deploy tooling, or another repo
+  - when routing between edge runtime work, database-engine follow-up, and root workspace integration
+whenToUpdate:
+  - when new high-frequency task categories appear
+  - when cross-repo ownership boundaries change
+  - when validation or deploy routing becomes misleading
+checkPaths:
+  - AGENTS.md
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - package.json
+  - supabase/config.toml
+  - supabase/functions/**
+  - test/**
+  - scripts/**
+  - test.example.http
+  - .github/workflows/**
+  - .github/PULL_REQUEST_TEMPLATE/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 94889a43af4e63a496bcbbb2e2bf5f3a69677dc0
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./validation.md
+  - ./architecture.md
+  - ../README.md
+  - ../test.example.http
+---
+
+# edge-functions Task Router
+
+## Repo Load Order
+
+When working inside `tiangong-lca-edge-functions`, load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. this file
+4. `ai/validation.md` or `ai/architecture.md`
+5. `README.md` or `test.example.http` only when you need setup or concrete request examples
+
+## High-Frequency Task Routing
+
+| Task intent | First code paths to inspect | Next docs to load | Notes |
+| --- | --- | --- | --- |
+| Add or change one Edge Function route | `supabase/functions/<name>/index.ts` and nearby `handler.ts` when present | `ai/validation.md`, `ai/architecture.md` | Keep auth, request parsing, and response semantics with the function entrypoint. |
+| Change shared auth behavior or credential precedence | `supabase/functions/_shared/auth.ts`, `cognito_auth.ts`, `decode_api_key.ts`, then affected functions | `ai/validation.md`, `ai/architecture.md` | Gateway JWT verification is not the contract; function-runtime auth is. |
+| Change command-style dataset, review, team, or admin endpoints | `supabase/functions/app_*`, `supabase/functions/admin_*`, `supabase/functions/_shared/command_runtime/**`, `supabase/functions/_shared/commands/**`, `supabase/functions/_shared/db_rpc/**` | `ai/architecture.md`, `ai/validation.md` | These flows usually change request parsing, actor context, audit payloads, and DB RPC wrappers together. |
+| Change hybrid search, AI suggestion, or OpenAI-backed behavior | `supabase/functions/flow_hybrid_search/**`, `process_hybrid_search/**`, `lifecyclemodel_hybrid_search/**`, `ai_suggest/**`, `supabase/functions/_shared/openai_*.ts`, `hybrid_query_utils.ts` | `ai/validation.md`, `ai/architecture.md` | OpenAI model choice and query rewrite behavior live here, not in frontend docs. |
+| Change embedding or webhook pipeline behavior | `supabase/functions/embedding*`, `supabase/functions/webhook_*embedding*`, `supabase/functions/_shared/redis_client.ts` | `ai/validation.md`, `ai/architecture.md` | Baseline `npm run check` intentionally skips legacy non-`*_ft` embedding and webhook entrypoints. |
+| Change LCA solve, queue, result, or scope behavior | `supabase/functions/lca_*/**`, `supabase/functions/_shared/lca_process_scope.ts`, `lca_snapshot_scope.ts` | `ai/validation.md`, `ai/architecture.md` | Missing queue RPCs or published-state semantics may require `database-engine` follow-up. |
+| Change TIDAS package import, export, or job behavior | `supabase/functions/import_tidas_package/**`, `export_tidas_package/**`, `tidas_package_jobs/**`, `supabase/functions/_shared/tidas_package.ts`, `redis_client.ts` | `ai/validation.md`, `ai/architecture.md` | JWT versus `USER_API_KEY` behavior is part of the runtime contract here. |
+| Investigate deploy target, project ref, or `--no-verify-jwt` behavior | `package.json`, `scripts/deploy-function.cjs`, `supabase/config.toml`, `.github/PULL_REQUEST_TEMPLATE/**` | `ai/repo.yaml`, `ai/validation.md` | Do not change deploy targets or auth assumptions silently. |
+| Investigate auth or connectivity drift across many functions | `scripts/probe-functions-auth.cjs`, `test.example.http`, then affected functions | `ai/validation.md` | Use `--dry-run`, `--remote`, or `--local` before editing many handlers. |
+| Decide whether the task is actually a database schema or RPC-truth change | `database-engine`, not this repo | root `ai/task-router.md`, `database-engine/AGENTS.md` | Schema, migrations, SQL tests, and persistent branch governance do not belong here. |
+| Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
+
+## Wrong Turns To Avoid
+
+### Fixing SQL truth in edge code only
+
+If the bug is really missing migration or RPC truth, do not paper over it only in runtime code. Route the database side to `database-engine`.
+
+### Assuming routine PRs should target `main`
+
+`tiangong-lca-edge-functions` is an M2 repo:
+
+- GitHub default branch: `main`
+- true daily trunk: `dev`
+- routine PR base: `dev`
+
+### Treating `gateway_invalid_jwt` as a function-runtime result
+
+`scripts/probe-functions-auth.cjs` distinguishes:
+
+- `gateway_invalid_jwt`: rejected before the function likely ran
+- `function_auth_failed`: request reached the runtime but the runtime auth path rejected it
+
+Do not debug those as the same failure.
+
+## Cross-Repo Handoffs
+
+Use these handoffs when work crosses repo boundaries:
+
+1. runtime change depends on new SQL or RPC behavior
+   - start here for runtime code
+   - then coordinate with `database-engine`
+2. Edge API contract change impacts frontend flows
+   - start here for runtime truth
+   - then notify `tiangong-lca-next`
+3. merged repo PR still needs to ship through the workspace
+   - return to `lca-workspace`
+   - do the submodule pointer bump there
+
+## If You Still Need More Context
+
+Load:
+
+1. `ai/architecture.md` for repo shape and hotspot map
+2. `ai/validation.md` for minimum proof
+3. `README.md` and `test.example.http` only for human setup or request examples

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -1,0 +1,137 @@
+---
+title: edge-functions Validation Guide
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: edge-functions
+language: en
+whenToUse:
+  - when an edge-functions change is ready for local validation
+  - when deciding the minimum proof required for runtime, shared-module, test, script, config, or docs changes
+  - when writing PR validation notes for tiangong-lca-edge-functions work
+whenToUpdate:
+  - when the repo gains a new canonical validation command or wrapper
+  - when change categories require different minimum proof
+  - when deploy or auth-probe behavior changes
+checkPaths:
+  - ai/validation.md
+  - ai/task-router.md
+  - package.json
+  - supabase/config.toml
+  - supabase/functions/**
+  - test/**
+  - scripts/**
+  - test.example.http
+  - .github/workflows/**
+  - .github/PULL_REQUEST_TEMPLATE/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: 94889a43af4e63a496bcbbb2e2bf5f3a69677dc0
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./architecture.md
+  - ../README.md
+  - ../test.example.http
+---
+
+# edge-functions Validation Guide
+
+## Default Baseline
+
+Unless the change is doc-only, the default local baseline is:
+
+```bash
+npm run lint
+npm run check
+```
+
+`npm run check` runs `scripts/deno-check-all.cjs`, which walks enabled `supabase/functions/*/index.ts` files plus `test/*.ts`.
+
+The current baseline intentionally skips:
+
+- `antchain_*`
+- `embedding`
+- `webhook_flow_embedding`
+- `webhook_model_embedding`
+- `webhook_process_embedding`
+
+If you reactivate or rely on one of those routes, update the inventory and validation story in the same change.
+
+## Validation Matrix
+
+| Change type | Minimum local proof | Additional proof when risk is higher | Notes |
+| --- | --- | --- | --- |
+| One function entrypoint or nearby handler | `npm run lint`; `npm run check`; targeted `deno check --config supabase/functions/deno.json <changed-entry-or-handler>` | use `test.example.http` or an equivalent request to smoke the changed path | For handler-based functions, validate both the entrypoint and the extracted handler file. |
+| Shared auth modules | `npm run lint`; `npm run check`; targeted `deno check` on `_shared/auth.ts` and directly affected consumers | run `npm run probe:auth -- --dry-run`; run a local or remote probe if the change affects credential selection | `gateway_invalid_jwt` and `function_auth_failed` are different failure classes. |
+| Command runtime, command handlers, or DB-RPC wrappers | `npm run lint`; `npm run check`; targeted `deno check` on changed `_shared/command_runtime/**`, `_shared/commands/**`, `_shared/db_rpc/**`, and at least one direct consumer | run nearby repo tests such as `test/command_runtime_test.ts`, `test/dataset_command_rpc_contract_test.ts`, or `test/review_command_rpc_contract_test.ts` | If the change depends on new SQL or RPC truth, record the `database-engine` follow-up explicitly. |
+| Hybrid search, AI suggestion, or OpenAI shared layer | `npm run lint`; `npm run check`; targeted `deno check` on changed function and shared OpenAI helper files | smoke one relevant request from `test.example.http` or equivalent local or remote call | Model defaults and query-rewrite helpers live in repo code, not only in env or README prose. |
+| LCA solve, queue, result, or scope helpers | `npm run lint`; `npm run check`; targeted `deno check` on changed `lca_*` files and `_shared/lca_*` helpers | run `scripts/lca_submit_poll_fetch.sh` when the task explicitly touches the submit, poll, or fetch path; otherwise record why that proof is deferred | Missing `lca_enqueue_job` or related DB-side truth is validated in `database-engine`, not here. |
+| TIDAS package import, export, or job paths | `npm run lint`; `npm run check`; targeted `deno check` on changed package files and `_shared/tidas_package.ts` | use the relevant requests in `test.example.http`; if auth or payload shaping changed, run a local or remote smoke path | JWT and `USER_API_KEY` coverage matters for these routes. |
+| Deploy script, `package.json`, `supabase/config.toml`, or PR contract files | `npm run lint`; inspect branch, project-ref, and deploy-flag changes against `ai/repo.yaml`; run `npm run check` if runtime inventory or imports changed | if the task includes a real deploy, record which environment was deployed and which function names were used | Remote deploy proof is not implied by local lint or type-check. |
+| Auth probe tooling | `npm run lint`; `node scripts/probe-functions-auth.cjs --help`; `npm run probe:auth -- --dry-run` | run `npm run probe:auth -- --remote` or `--local` when the task explicitly includes live probe validation | Dry-run is the safe default when you only changed classification or selection logic. |
+| Repo tests only | `npm run lint`; `npm run check`; targeted `deno check --config supabase/functions/deno.json <changed-test-file>` | run neighboring tests that cover the same shared module or function family | This repo keeps Deno tests in `test/**`, not under each function folder. |
+| AI docs only | run the root warning-only `ai-doc-lint` against touched files | perform scenario-based routing checks from root into this repo | Refresh review metadata even when prose-only docs change. |
+
+## Auth And Probe Notes
+
+Facts that matter:
+
+- local serve uses `--no-verify-jwt`
+- scripted remote deploys also use `--no-verify-jwt`
+- runtime auth still happens inside functions, primarily through `supabase/functions/_shared/auth.ts`
+- `scripts/probe-functions-auth.cjs` is the fastest way to separate gateway rejection from runtime-auth rejection
+
+Useful low-risk commands:
+
+```bash
+node scripts/probe-functions-auth.cjs --help
+npm run probe:auth -- --dry-run
+npm run probe:auth -- --remote --only lca_
+```
+
+## AI Contract File Notes
+
+Root `ai-doc-lint` currently expects repo-local `ai/*.yaml` files to stay JSON-compatible YAML.
+
+In this repo that means:
+
+- `ai/repo.yaml` and `ai/doc-impact.yaml` should remain parseable by a JSON parser
+- repo Prettier is configured to format `ai/**/*.yaml` with the JSON parser instead of YAML syntax
+- if `npm run lint` rewrites those files into YAML-style single-quoted objects, the contract is broken
+
+## Remote Deploy Notes
+
+Remote deploy proof is separate from local type-check proof.
+
+If the task includes a real deploy, record:
+
+1. which command ran
+2. which target environment was used
+3. which function names were deployed
+4. which smoke proof was run after deploy, if any
+
+If no deploy happened, say so explicitly in the PR note.
+
+## Database Boundary Notes
+
+When a runtime change depends on database truth:
+
+- runtime validation stays here
+- migration, RPC, or persistent branch proof stays in `database-engine`
+
+Common examples:
+
+- missing `lca_enqueue_job`
+- changed command RPC signature or policy behavior
+- changed published-state or `state_code` semantics
+
+## Minimum PR Note Quality
+
+A good PR note for this repo should say:
+
+1. which local commands ran
+2. which targeted `deno check` or repo test files were exercised
+3. whether any deploy or probe proof was performed or deferred
+4. whether any required database-side proof lives in `database-engine`

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -72,7 +72,7 @@ If you reactivate or rely on one of those routes, update the inventory and valid
 | Deploy script, `package.json`, `supabase/config.toml`, or PR contract files | `npm run lint`; inspect branch, project-ref, and deploy-flag changes against `ai/repo.yaml`; run `npm run check` if runtime inventory or imports changed | if the task includes a real deploy, record which environment was deployed and which function names were used | Remote deploy proof is not implied by local lint or type-check. |
 | Auth probe tooling | `npm run lint`; `node scripts/probe-functions-auth.cjs --help`; `npm run probe:auth -- --dry-run` | run `npm run probe:auth -- --remote` or `--local` when the task explicitly includes live probe validation | Dry-run is the safe default when you only changed classification or selection logic. |
 | Repo tests only | `npm run lint`; `npm run check`; targeted `deno check --config supabase/functions/deno.json <changed-test-file>` | run neighboring tests that cover the same shared module or function family | This repo keeps Deno tests in `test/**`, not under each function folder. |
-| AI docs only | run the root warning-only `ai-doc-lint` against touched files | perform scenario-based routing checks from root into this repo | Refresh review metadata even when prose-only docs change. |
+| AI docs only | run repo-local `ai-doc-lint` against touched files or the equivalent local PR check | perform scenario-based routing checks from root into this repo | Refresh review metadata even when prose-only docs change. |
 
 ## Auth And Probe Notes
 
@@ -93,7 +93,7 @@ npm run probe:auth -- --remote --only lca_
 
 ## AI Contract File Notes
 
-Root `ai-doc-lint` currently expects repo-local `ai/*.yaml` files to stay JSON-compatible YAML.
+The repo-local `ai-doc-lint` implementation expects repo-local `ai/*.yaml` files to stay JSON-compatible YAML.
 
 In this repo that means:
 


### PR DESCRIPTION
## Summary
- Promote the merged AI-doc rollout from `dev` to `main`.
- Carry the checked-in AGENTS / ai contract layer and repo-local `ai-doc-lint` enforcement onto the release branch.

## Included Dev Merges
- `#89` docs: add repo-local ai-doc-lint gate for issue #88

## Validation
- No new code or docs were added on this promote branch; this PR promotes the already-merged `dev` snapshot.
- The source rollout PR `#89` passed `ai-doc-lint` and `validate` before merge into `dev`.

## Workspace Integration
- Merging this promote PR makes the current `dev` doc-system snapshot eligible for the root workspace integration candidate tracked by `tiangong-lca/workspace#74`.
