### PR TITLE
Upgrade docpact CI pin to 0.1.4

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-04-23"
-lastReviewedCommit: "4830ccb1e963a121948995ed9b3da620c670f563"
+lastReviewedAt: "2026-04-24"
+lastReviewedCommit: "a88517ffa1247661918261f78dc8c063aca6d133"
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.2 --force
+        run: cargo install docpact --version 0.1.4 --force
 
       - name: Validate docpact config
         run: docpact validate-config --root . --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ checkPaths:
   - supabase/.env.example
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 63e23a8cb916cb49521cbbe869b38d637040a8b5
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - test.example.http
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4830ccb1e963a121948995ed9b3da620c670f563
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - test.example.http
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4830ccb1e963a121948995ed9b3da620c670f563
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #97

## Summary
- Upgrade .github/workflows/ai-doc-lint.yml from docpact 0.1.2 to 0.1.4.
- Preserve the existing ai-doc-lint workflow/check name and command shape.
- Refresh governed doc review metadata required by the repo-local docpact rules for workflow changes.

## Key Decisions
- Do not change runtime code, package versions, release automation, or root workspace submodule pointers.

## Validation
- docpact validate-config --root . --strict with docpact 0.1.4.
- docpact lint --root . --worktree --mode enforce with docpact 0.1.4.
- docpact lint --root . --base origin/dev --head HEAD --mode enforce with docpact 0.1.4.

## Risks / Rollback
- Root workspace integration remains pending until this child PR merges and the submodule pointer is deliberately bumped.

## Workspace Integration
- Part of tiangong-lca/workspace#77; child issue keeps Workspace Integration Pending.