### PR TITLE
Promote docpact 0.1.4 upgrade to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-04-23"
-lastReviewedCommit: "4830ccb1e963a121948995ed9b3da620c670f563"
+lastReviewedAt: "2026-04-24"
+lastReviewedCommit: "a88517ffa1247661918261f78dc8c063aca6d133"
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.2 --force
+        run: cargo install docpact --version 0.1.4 --force
 
       - name: Validate docpact config
         run: docpact validate-config --root . --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ checkPaths:
   - supabase/.env.example
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 63e23a8cb916cb49521cbbe869b38d637040a8b5
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - test.example.http
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4830ccb1e963a121948995ed9b3da620c670f563
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - test.example.http
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 4830ccb1e963a121948995ed9b3da620c670f563
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #99

## Summary
- Promotes the docpact 0.1.4 governance upgrade from dev to main.
- Includes the already-merged dev change from PR #98 at 252bbed6651c17d46798370fc274577c03049bea.

## Decisions
- This is an M2 promote PR: base is main, head is a branch pinned to current dev, with no additional working-branch edits.

## Validation
- Dev already passed the repo-level PR checks for the docpact 0.1.4 upgrade.
- This promote PR should rely on GitHub PR checks before merge.

## Risk / rollback
- Low-risk documentation-governance/tooling promote.
- Rollback is reverting the promote merge from main if needed.

## Workspace integration
- After this PR merges, root workspace main may pin the promoted main commit for workspace integration under tiangong-lca/workspace#77.
