### PR TITLE
docs: hide README metadata from public landing page

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -193,11 +193,9 @@ rules:
         kind: repo-landing
     requiredDocs:
       - path: AGENTS.md
-        mode: review_or_update
-      - path: README.md
-        mode: review_or_update
+        mode: must_exist
       - path: .docpact/config.yaml
-        mode: review_or_update
+        mode: must_exist
     reason: Repo landing text should stay aligned with the active repo contract and docpact entry surface.
   - id: edge-functions-feature-pr-template-contract
     scope: repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ checkPaths:
   - supabase/.env.example
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 252bbed6651c17d46798370fc274577c03049bea
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -1,31 +1,3 @@
----
-title: TianGong LCA Edge Functions Landing
-docType: overview
-scope: repo
-status: active
-authoritative: false
-owner: edge-functions
-language: en
-whenToUse:
-  - when you need the shortest high-level description of what this repo owns
-  - when landing in the repo without needing the full AI contract surface yet
-whenToUpdate:
-  - when repo purpose, setup, or branch/deploy summary changes
-  - when the AI entry surface listed here changes
-checkPaths:
-  - README.md
-  - AGENTS.md
-  - .docpact/config.yaml
-  - docs/agents/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 63e23a8cb916cb49521cbbe869b38d637040a8b5
-related:
-  - AGENTS.md
-  - .docpact/config.yaml
-  - docs/agents/repo-validation.md
-  - docs/agents/repo-architecture.md
----
-
 # TianGong-LCA-Edge-Functions
 
 ## Overview

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - test.example.http
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 252bbed6651c17d46798370fc274577c03049bea
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - test.example.http
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 252bbed6651c17d46798370fc274577c03049bea
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #101

## Summary
- Remove visible YAML front matter from the root README so GitHub renders the public landing page from the heading.
- Adjust the README landing docpact rule to keep README changes covered without requiring README.md to carry governance metadata.
- Refresh review metadata on the repo entry/governance docs required by the docpact rule change.

## Key Decisions
- README landing rules now use must_exist checks for AGENTS.md and .docpact/config.yaml instead of review_or_update on README.md.

## Validation
- docpact validate-config --strict
- docpact lint --merge-base <target-base> --mode enforce

## Risks / Rollback
- Low-risk docs/governance change; rollback is restoring the prior README front matter and rule modes.

## Workspace Integration
- After merge, lca-workspace should bump the submodule pointer for this repo.