### PR TITLE
chore: promote README metadata cleanup to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -193,11 +193,9 @@ rules:
         kind: repo-landing
     requiredDocs:
       - path: AGENTS.md
-        mode: review_or_update
-      - path: README.md
-        mode: review_or_update
+        mode: must_exist
       - path: .docpact/config.yaml
-        mode: review_or_update
+        mode: must_exist
     reason: Repo landing text should stay aligned with the active repo contract and docpact entry surface.
   - id: edge-functions-feature-pr-template-contract
     scope: repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ checkPaths:
   - supabase/.env.example
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 252bbed6651c17d46798370fc274577c03049bea
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -1,31 +1,3 @@
----
-title: TianGong LCA Edge Functions Landing
-docType: overview
-scope: repo
-status: active
-authoritative: false
-owner: edge-functions
-language: en
-whenToUse:
-  - when you need the shortest high-level description of what this repo owns
-  - when landing in the repo without needing the full AI contract surface yet
-whenToUpdate:
-  - when repo purpose, setup, or branch/deploy summary changes
-  - when the AI entry surface listed here changes
-checkPaths:
-  - README.md
-  - AGENTS.md
-  - .docpact/config.yaml
-  - docs/agents/**
-lastReviewedAt: 2026-04-23
-lastReviewedCommit: 63e23a8cb916cb49521cbbe869b38d637040a8b5
-related:
-  - AGENTS.md
-  - .docpact/config.yaml
-  - docs/agents/repo-validation.md
-  - docs/agents/repo-architecture.md
----
-
 # TianGong-LCA-Edge-Functions
 
 ## Overview

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - test.example.http
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 252bbed6651c17d46798370fc274577c03049bea
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - test.example.http
   - .github/workflows/**
   - .github/PULL_REQUEST_TEMPLATE/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: a88517ffa1247661918261f78dc8c063aca6d133
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: 252bbed6651c17d46798370fc274577c03049bea
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #103

## Summary
- Promote the README metadata cleanup delta from dev to main.
- This enables root workspace main to integrate the submodule pointer after merge.

## Key Decisions
- origin/main..origin/dev contains only the README metadata cleanup delta for this promote.

## Validation
- docpact validate-config --strict
- docpact lint --base origin/main --head origin/dev --mode enforce

## Risks / Rollback
- Low-risk docs/governance promote; rollback is reverting the promote merge on main if needed.

## Workspace Integration
- After merge, update the lca-workspace root main submodule pointer.