### PR TITLE
Add dataset remote verification endpoint

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: ac19c2bd6a8756eca22b870a25cd64232b3d5ef0
+lastReviewedAt: '2026-05-24'
+lastReviewedCommit: '353b87c5efde6b7138b9d171c0c203a4305991cc'
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: ac19c2bd6a8756eca22b870a25cd64232b3d5ef0
+lastReviewedAt: 2026-05-24
+lastReviewedCommit: 353b87c5efde6b7138b9d171c0c203a4305991cc
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+---
+title: TianGong LCA Edge Functions
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: edge-functions
+language: en
+whenToUse:
+  - when setting up or serving edge functions locally
+  - when finding human-facing request examples and runtime environment notes
+whenToUpdate:
+  - when setup, local serve, request examples, or operator-facing runtime guidance changes
+checkPaths:
+  - README.md
+  - package.json
+  - supabase/config.toml
+  - supabase/.env.example
+  - test.example.http
+lastReviewedAt: 2026-05-24
+lastReviewedCommit: 353b87c5efde6b7138b9d171c0c203a4305991cc
+---
+
 # TianGong-LCA-Edge-Functions
 
 ## Overview
@@ -121,6 +144,7 @@ See `test.example.http` for local and remote examples. Treat it as a supporting 
 - `flow_hybrid_search`
 - `process_hybrid_search`
 - `lifecyclemodel_hybrid_search`
+- `app_dataset_verify_remote`
 - `ai_suggest`
 - `lca_solve` / `lca_jobs` / `lca_results`
 - `lca_query_results`

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: ac19c2bd6a8756eca22b870a25cd64232b3d5ef0
+lastReviewedAt: 2026-05-24
+lastReviewedCommit: 353b87c5efde6b7138b9d171c0c203a4305991cc
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: ac19c2bd6a8756eca22b870a25cd64232b3d5ef0
+lastReviewedAt: 2026-05-24
+lastReviewedCommit: 353b87c5efde6b7138b9d171c0c203a4305991cc
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/functions/_shared/commands/dataset/verify_remote.ts
+++ b/supabase/functions/_shared/commands/dataset/verify_remote.ts
@@ -1,0 +1,495 @@
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+import { z } from 'zod';
+
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import type { CommandParseResult } from '../../command_runtime/command.ts';
+import type { DatasetCommandExecutionResult } from './types.ts';
+
+type QueryClient = Pick<SupabaseClient, 'from'>;
+
+export const REMOTE_VERIFY_TABLES = [
+  'contacts',
+  'sources',
+  'unitgroups',
+  'flowproperties',
+  'flows',
+  'processes',
+  'lifecyclemodels',
+  'lciamethods',
+] as const;
+
+export type RemoteVerifyTable = (typeof REMOTE_VERIFY_TABLES)[number];
+export type RemoteVerifyRole = 'root' | 'reference';
+export type RemoteVerifyRootPolicy = 'existing' | 'candidate';
+
+export type RemoteVerifyStatus =
+  | 'ok'
+  | 'candidate_root'
+  | 'lookup_failed'
+  | 'missing_dataset'
+  | 'missing_version'
+  | 'payload_hash_mismatch'
+  | 'payload_missing'
+  | 'state_code_mismatch'
+  | 'version_outdated';
+
+export type RemoteVerifyReference = {
+  table: RemoteVerifyTable;
+  id: string;
+  version?: string | null;
+  role: RemoteVerifyRole;
+  path?: string;
+  expectedStateCodes?: number[];
+  expectedJsonSha256?: string;
+  requirePayload?: boolean;
+};
+
+export type VerifyRemoteRequest = {
+  rootPolicy: RemoteVerifyRootPolicy;
+  references: RemoteVerifyReference[];
+};
+
+export type RemoteVerifyRow = {
+  id: string;
+  version: string | null;
+  state_code: number | null;
+  user_id: string | null;
+  modified_at: string | null;
+  json_ordered?: unknown;
+};
+
+export type RemoteVerifyLookup = {
+  exact: RemoteVerifyRow | null;
+  latest: RemoteVerifyRow | null;
+};
+
+export type RemoteVerifyCheck = {
+  index: number;
+  table: RemoteVerifyTable;
+  id: string;
+  version: string | null;
+  role: RemoteVerifyRole;
+  path: string | null;
+  status: RemoteVerifyStatus;
+  message: string;
+  exact_version: string | null;
+  latest_version: string | null;
+  state_code: number | null;
+  user_id: string | null;
+  modified_at: string | null;
+  payload_present: boolean | null;
+  expected_state_codes: number[] | null;
+  expected_json_sha256: string | null;
+  actual_json_sha256: string | null;
+};
+
+export type RemoteVerifyBlocker = {
+  code: RemoteVerifyStatus;
+  message: string;
+  index: number;
+  table: RemoteVerifyTable;
+  id: string;
+  version: string | null;
+  role: RemoteVerifyRole;
+  path: string | null;
+};
+
+export type VerifyRemoteReport = {
+  status: 'passed_remote_verification' | 'blocked_remote_verification';
+  root_policy: RemoteVerifyRootPolicy;
+  checked_at_utc: string;
+  counts: {
+    references: number;
+    blockers: number;
+    by_status: Record<RemoteVerifyStatus, number>;
+  };
+  checks: RemoteVerifyCheck[];
+  blockers: RemoteVerifyBlocker[];
+};
+
+const VERSION_PATTERN = /^\d{2}\.\d{2}\.\d{3}$/;
+const SHA_256_PATTERN = /^[a-f0-9]{64}$/;
+
+const remoteVerifyReferenceSchema = z
+  .object({
+    table: z.enum(REMOTE_VERIFY_TABLES),
+    id: z.string().uuid(),
+    version: z
+      .string()
+      .regex(VERSION_PATTERN, 'version must be in 00.00.000 format')
+      .nullable()
+      .optional(),
+    role: z.enum(['root', 'reference']).default('reference'),
+    path: z.string().trim().min(1).optional(),
+    expectedStateCodes: z.array(z.number().int()).max(20).optional(),
+    expectedJsonSha256: z
+      .string()
+      .regex(SHA_256_PATTERN, 'expectedJsonSha256 must be a lowercase SHA-256 hex digest')
+      .optional(),
+    requirePayload: z.boolean().optional(),
+  })
+  .strict();
+
+export const verifyRemoteRequestSchema = z
+  .object({
+    rootPolicy: z.enum(['existing', 'candidate']).default('existing'),
+    references: z.array(remoteVerifyReferenceSchema).min(1).max(200),
+  })
+  .strict();
+
+const EMPTY_STATUS_COUNTS: Record<RemoteVerifyStatus, number> = {
+  ok: 0,
+  candidate_root: 0,
+  lookup_failed: 0,
+  missing_dataset: 0,
+  missing_version: 0,
+  payload_hash_mismatch: 0,
+  payload_missing: 0,
+  state_code_mismatch: 0,
+  version_outdated: 0,
+};
+
+function invalidPayload<T>(message: string, error: z.ZodError): CommandParseResult<T> {
+  return {
+    ok: false,
+    message,
+    details: error.flatten(),
+  };
+}
+
+function sortedJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortedJson(item));
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter((entry) => entry[1] !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, sortedJson(item)]);
+    return Object.fromEntries(entries);
+  }
+
+  return value;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export async function stableJsonSha256(value: unknown): Promise<string> {
+  const payload = new TextEncoder().encode(JSON.stringify(sortedJson(value)));
+  const digest = await crypto.subtle.digest('SHA-256', payload);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+function normalizeRow(row: unknown): RemoteVerifyRow | null {
+  if (!row || typeof row !== 'object') {
+    return null;
+  }
+
+  const candidate = row as Record<string, unknown>;
+  const id = typeof candidate.id === 'string' ? candidate.id.trim() : '';
+  const version = typeof candidate.version === 'string' ? candidate.version.trim() : null;
+  const stateCode =
+    typeof candidate.state_code === 'number' && Number.isInteger(candidate.state_code)
+      ? candidate.state_code
+      : null;
+  const userId = typeof candidate.user_id === 'string' ? candidate.user_id.trim() || null : null;
+  const modifiedAt =
+    typeof candidate.modified_at === 'string' ? candidate.modified_at.trim() || null : null;
+
+  if (!id) {
+    return null;
+  }
+
+  return {
+    id,
+    version,
+    state_code: stateCode,
+    user_id: userId,
+    modified_at: modifiedAt,
+    json_ordered: candidate.json_ordered,
+  };
+}
+
+async function fetchRows(
+  supabase: QueryClient,
+  reference: Pick<RemoteVerifyReference, 'table' | 'id'> & { version?: string | null },
+  mode: 'exact' | 'latest',
+): Promise<
+  { ok: true; rows: RemoteVerifyRow[] } | { ok: false; message: string; details: unknown }
+> {
+  let query = supabase
+    .from(reference.table)
+    .select('id,version,state_code,user_id,modified_at,json_ordered')
+    .eq('id', reference.id);
+
+  if (mode === 'exact' && reference.version) {
+    query = query.eq('version', reference.version);
+  }
+
+  if (mode === 'latest') {
+    query = query.order('version', { ascending: false });
+  }
+
+  const { data, error } = await query.range(0, mode === 'exact' ? 1 : 0);
+  if (error) {
+    return {
+      ok: false,
+      message: error.message ?? 'Remote dataset lookup failed',
+      details: error,
+    };
+  }
+
+  return {
+    ok: true,
+    rows: (Array.isArray(data) ? data : []).map(normalizeRow).filter((row) => row !== null),
+  };
+}
+
+export async function lookupRemoteDataset(
+  supabase: QueryClient,
+  reference: RemoteVerifyReference,
+): Promise<
+  { ok: true; lookup: RemoteVerifyLookup } | { ok: false; message: string; details: unknown }
+> {
+  const latestRows = await fetchRows(supabase, reference, 'latest');
+  if (!latestRows.ok) {
+    return latestRows;
+  }
+
+  if (!reference.version) {
+    return {
+      ok: true,
+      lookup: {
+        exact: latestRows.rows[0] ?? null,
+        latest: latestRows.rows[0] ?? null,
+      },
+    };
+  }
+
+  const exactRows = await fetchRows(supabase, reference, 'exact');
+  if (!exactRows.ok) {
+    return exactRows;
+  }
+
+  return {
+    ok: true,
+    lookup: {
+      exact: exactRows.rows[0] ?? null,
+      latest: latestRows.rows[0] ?? null,
+    },
+  };
+}
+
+function isCandidateRootAllowed(
+  reference: RemoteVerifyReference,
+  lookup: RemoteVerifyLookup,
+  rootPolicy: RemoteVerifyRootPolicy,
+): boolean {
+  if (rootPolicy !== 'candidate' || reference.role !== 'root') {
+    return false;
+  }
+
+  if (!lookup.latest?.version || !reference.version) {
+    return true;
+  }
+
+  return lookup.latest.version < reference.version;
+}
+
+function isBlocker(status: RemoteVerifyStatus): boolean {
+  return status !== 'ok' && status !== 'candidate_root';
+}
+
+async function buildCheck(
+  reference: RemoteVerifyReference,
+  lookup: RemoteVerifyLookup,
+  rootPolicy: RemoteVerifyRootPolicy,
+  index: number,
+): Promise<RemoteVerifyCheck> {
+  const path = reference.path ?? null;
+  const version = reference.version ?? null;
+  const latestVersion = lookup.latest?.version ?? null;
+  const exactVersion = lookup.exact?.version ?? null;
+
+  if (!lookup.exact) {
+    if (isCandidateRootAllowed(reference, lookup, rootPolicy)) {
+      return {
+        index,
+        table: reference.table,
+        id: reference.id,
+        version,
+        role: reference.role,
+        path,
+        status: 'candidate_root',
+        message: 'Root dataset is a candidate row and is not required to exist before write.',
+        exact_version: null,
+        latest_version: latestVersion,
+        state_code: null,
+        user_id: null,
+        modified_at: null,
+        payload_present: null,
+        expected_state_codes: reference.expectedStateCodes ?? null,
+        expected_json_sha256: reference.expectedJsonSha256 ?? null,
+        actual_json_sha256: null,
+      };
+    }
+
+    return {
+      index,
+      table: reference.table,
+      id: reference.id,
+      version,
+      role: reference.role,
+      path,
+      status: latestVersion ? 'missing_version' : 'missing_dataset',
+      message: latestVersion
+        ? 'Requested dataset version is not visible to the caller.'
+        : 'Dataset id is not visible to the caller.',
+      exact_version: null,
+      latest_version: latestVersion,
+      state_code: null,
+      user_id: null,
+      modified_at: null,
+      payload_present: null,
+      expected_state_codes: reference.expectedStateCodes ?? null,
+      expected_json_sha256: reference.expectedJsonSha256 ?? null,
+      actual_json_sha256: null,
+    };
+  }
+
+  const payloadPresent =
+    lookup.exact.json_ordered !== undefined && lookup.exact.json_ordered !== null;
+  const expectedStateCodes = reference.expectedStateCodes ?? null;
+  const expectedJsonSha256 = reference.expectedJsonSha256 ?? null;
+  const actualJsonSha256 =
+    payloadPresent && expectedJsonSha256 ? await stableJsonSha256(lookup.exact.json_ordered) : null;
+  let status: RemoteVerifyStatus = 'ok';
+  let message = 'Dataset row is visible to the caller.';
+
+  if (latestVersion && exactVersion && latestVersion > exactVersion) {
+    status = 'version_outdated';
+    message = 'Requested dataset version is visible but older than the latest visible version.';
+  } else if (expectedStateCodes && !expectedStateCodes.includes(lookup.exact.state_code ?? NaN)) {
+    status = 'state_code_mismatch';
+    message = 'Dataset row state_code does not match the expected verification policy.';
+  } else if ((reference.requirePayload || expectedJsonSha256) && !payloadPresent) {
+    status = 'payload_missing';
+    message = 'Dataset row is visible but json_ordered payload is missing.';
+  } else if (expectedJsonSha256 && actualJsonSha256 !== expectedJsonSha256) {
+    status = 'payload_hash_mismatch';
+    message = 'Dataset row payload hash does not match the expected SHA-256 digest.';
+  }
+
+  return {
+    index,
+    table: reference.table,
+    id: reference.id,
+    version,
+    role: reference.role,
+    path,
+    status,
+    message,
+    exact_version: exactVersion,
+    latest_version: latestVersion,
+    state_code: lookup.exact.state_code,
+    user_id: lookup.exact.user_id,
+    modified_at: lookup.exact.modified_at,
+    payload_present: payloadPresent,
+    expected_state_codes: expectedStateCodes,
+    expected_json_sha256: expectedJsonSha256,
+    actual_json_sha256: actualJsonSha256,
+  };
+}
+
+function buildBlocker(check: RemoteVerifyCheck): RemoteVerifyBlocker {
+  return {
+    code: check.status,
+    message: check.message,
+    index: check.index,
+    table: check.table,
+    id: check.id,
+    version: check.version,
+    role: check.role,
+    path: check.path,
+  };
+}
+
+export function parseVerifyRemoteCommand(body: unknown): CommandParseResult<VerifyRemoteRequest> {
+  const parsed = verifyRemoteRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload('Invalid dataset verify-remote payload', parsed.error);
+  }
+
+  return {
+    ok: true,
+    value: parsed.data,
+  };
+}
+
+export async function executeVerifyRemoteCommand(
+  request: VerifyRemoteRequest,
+  actor: ActorContext,
+  lookupRemoteDatasetImpl = lookupRemoteDataset,
+): Promise<DatasetCommandExecutionResult> {
+  const checks: RemoteVerifyCheck[] = [];
+
+  for (const [index, reference] of request.references.entries()) {
+    const lookup = await lookupRemoteDatasetImpl(actor.supabase, reference);
+    if (!lookup.ok) {
+      checks.push({
+        index,
+        table: reference.table,
+        id: reference.id,
+        version: reference.version ?? null,
+        role: reference.role,
+        path: reference.path ?? null,
+        status: 'lookup_failed',
+        message: lookup.message,
+        exact_version: null,
+        latest_version: null,
+        state_code: null,
+        user_id: null,
+        modified_at: null,
+        payload_present: null,
+        expected_state_codes: reference.expectedStateCodes ?? null,
+        expected_json_sha256: reference.expectedJsonSha256 ?? null,
+        actual_json_sha256: null,
+      });
+      continue;
+    }
+
+    checks.push(await buildCheck(reference, lookup.lookup, request.rootPolicy, index));
+  }
+
+  const byStatus = { ...EMPTY_STATUS_COUNTS };
+  for (const check of checks) {
+    byStatus[check.status] += 1;
+  }
+
+  const blockers = checks.filter((check) => isBlocker(check.status)).map(buildBlocker);
+  const report: VerifyRemoteReport = {
+    status: blockers.length > 0 ? 'blocked_remote_verification' : 'passed_remote_verification',
+    root_policy: request.rootPolicy,
+    checked_at_utc: new Date().toISOString(),
+    counts: {
+      references: checks.length,
+      blockers: blockers.length,
+      by_status: byStatus,
+    },
+    checks,
+    blockers,
+  };
+
+  return {
+    ok: true,
+    status: blockers.length > 0 ? 409 : 200,
+    body: {
+      ok: blockers.length === 0,
+      command: 'dataset_verify_remote',
+      data: report,
+    },
+  };
+}

--- a/supabase/functions/app_dataset_verify_remote/index.ts
+++ b/supabase/functions/app_dataset_verify_remote/index.ts
@@ -1,0 +1,27 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+
+import {
+  createCommandHandler,
+  type CommandHandlerOptions,
+} from '../_shared/command_runtime/command.ts';
+import {
+  executeVerifyRemoteCommand,
+  parseVerifyRemoteCommand,
+  type VerifyRemoteRequest,
+} from '../_shared/commands/dataset/verify_remote.ts';
+
+export function createAppDatasetVerifyRemoteHandler(
+  overrides: Partial<CommandHandlerOptions<VerifyRemoteRequest>> = {},
+) {
+  return createCommandHandler<VerifyRemoteRequest>({
+    parse: parseVerifyRemoteCommand,
+    execute: executeVerifyRemoteCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppDatasetVerifyRemote = createAppDatasetVerifyRemoteHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppDatasetVerifyRemote);
+}

--- a/test.example.http
+++ b/test.example.http
@@ -103,6 +103,24 @@ curl -i --location --request POST '{{$dotenv LOCAL_ENDPOINT}}/lifecyclemodel_hyb
     --header 'Authorization: Bearer {{$dotenv USER_API_KEY}}' \
     --data '{"query": "烧结砖"}'
 
+### @name Dataset_Verify_Remote：Local
+curl -i --location --request POST '{{$dotenv LOCAL_ENDPOINT}}/app_dataset_verify_remote' \
+    --header 'Content-Type: application/json' \
+    --header 'Authorization: Bearer {{$dotenv USER_JWT}}' \
+    --data '{
+      "rootPolicy": "existing",
+      "references": [
+        {
+          "table": "processes",
+          "id": "012fc8f6-9a30-4d98-9b03-34ddec3a6f10",
+          "version": "01.01.002",
+          "role": "root",
+          "expectedStateCodes": [0],
+          "requirePayload": true
+        }
+      ]
+    }'
+
 ### @name AI_Suggest：Remote
 curl -i --location --request POST '{{$dotenv REMOTE_ENDPOINT}}/ai_suggest' \
     --header 'Content-Type: application/json' \

--- a/test/app_dataset_verify_remote_test.ts
+++ b/test/app_dataset_verify_remote_test.ts
@@ -1,0 +1,331 @@
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+
+import type { DatasetCommandExecutionResult } from '../supabase/functions/_shared/commands/dataset/types.ts';
+import {
+  executeVerifyRemoteCommand,
+  parseVerifyRemoteCommand,
+  stableJsonSha256,
+} from '../supabase/functions/_shared/commands/dataset/verify_remote.ts';
+
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+const PROCESS_ID = '22222222-2222-4222-8222-222222222222';
+const FLOW_ID = '33333333-3333-4333-8333-333333333333';
+const SOURCE_ID = '44444444-4444-4444-8444-444444444444';
+
+type Row = {
+  id: string;
+  version: string;
+  state_code?: number | null;
+  user_id?: string | null;
+  modified_at?: string | null;
+  json_ordered?: unknown;
+};
+
+class FakeQuery {
+  private filters: Array<{ field: string; value: unknown }> = [];
+  private orderField: string | null = null;
+  private ascending = true;
+
+  constructor(
+    private rows: Row[],
+    private error: { message: string; code?: string } | null = null,
+  ) {}
+
+  select(_columns: string) {
+    return this;
+  }
+
+  eq(field: string, value: unknown) {
+    this.filters.push({ field, value });
+    return this;
+  }
+
+  order(field: string, options: { ascending?: boolean } = {}) {
+    this.orderField = field;
+    this.ascending = options.ascending ?? true;
+    return this;
+  }
+
+  async range(from: number, to: number) {
+    if (this.error) {
+      return { data: null, error: this.error };
+    }
+
+    let rows = this.rows.filter((row) =>
+      this.filters.every(
+        (filter) => (row as unknown as Record<string, unknown>)[filter.field] === filter.value,
+      ),
+    );
+
+    if (this.orderField) {
+      rows = rows.toSorted((left, right) => {
+        const leftValue = String(
+          (left as unknown as Record<string, unknown>)[this.orderField ?? ''] ?? '',
+        );
+        const rightValue = String(
+          (right as unknown as Record<string, unknown>)[this.orderField ?? ''] ?? '',
+        );
+        return this.ascending
+          ? leftValue.localeCompare(rightValue)
+          : rightValue.localeCompare(leftValue);
+      });
+    }
+
+    return { data: rows.slice(from, to + 1), error: null };
+  }
+}
+
+class FakeSupabase {
+  errors = new Map<string, { message: string; code?: string }>();
+
+  constructor(private rowsByTable: Record<string, Row[]>) {}
+
+  from(table: string) {
+    return new FakeQuery(this.rowsByTable[table] ?? [], this.errors.get(table) ?? null);
+  }
+}
+
+function buildActor(supabase: FakeSupabase) {
+  return {
+    userId: TEST_USER_ID,
+    accessToken: 'access-token',
+    supabase: supabase as unknown as SupabaseClient,
+  };
+}
+
+function commandBody<T>(result: DatasetCommandExecutionResult): T {
+  if (!result.ok) {
+    throw new Error(`Expected command success, got ${result.code}`);
+  }
+
+  return result.body as T;
+}
+
+Deno.test('parseVerifyRemoteCommand rejects malformed payloads', () => {
+  const result = parseVerifyRemoteCommand({
+    references: [{ table: 'processes', id: 'not-a-uuid', version: '1' }],
+  });
+
+  assertEquals(result.ok, false);
+});
+
+Deno.test(
+  'executeVerifyRemoteCommand passes exact rows with expected state and payload hash',
+  async () => {
+    const payload = { b: 2, a: { z: true, c: [3, 1] } };
+    const expectedHash = await stableJsonSha256(payload);
+    const supabase = new FakeSupabase({
+      processes: [
+        {
+          id: PROCESS_ID,
+          version: '01.01.000',
+          state_code: 0,
+          user_id: TEST_USER_ID,
+          modified_at: '2026-05-23T00:00:00Z',
+          json_ordered: payload,
+        },
+      ],
+    });
+
+    const result = await executeVerifyRemoteCommand(
+      {
+        rootPolicy: 'existing',
+        references: [
+          {
+            table: 'processes',
+            id: PROCESS_ID,
+            version: '01.01.000',
+            role: 'root',
+            expectedStateCodes: [0],
+            expectedJsonSha256: expectedHash,
+            requirePayload: true,
+          },
+        ],
+      },
+      buildActor(supabase),
+    );
+
+    assertEquals(result.ok, true);
+    assertEquals(result.status, 200);
+    const body = commandBody<{
+      ok: boolean;
+      data: { status: string; checks: Array<{ actual_json_sha256: string | null }> };
+    }>(result);
+
+    assertEquals(body.ok, true);
+    assertEquals(body.data.status, 'passed_remote_verification');
+    assertEquals(body.data.checks[0]?.actual_json_sha256, expectedHash);
+  },
+);
+
+Deno.test(
+  'executeVerifyRemoteCommand blocks missing versions and outdated exact versions',
+  async () => {
+    const supabase = new FakeSupabase({
+      flows: [
+        { id: FLOW_ID, version: '01.00.000', state_code: 100, json_ordered: {} },
+        { id: FLOW_ID, version: '01.01.000', state_code: 100, json_ordered: {} },
+      ],
+      sources: [{ id: SOURCE_ID, version: '20.20.002', state_code: 100, json_ordered: {} }],
+    });
+
+    const result = await executeVerifyRemoteCommand(
+      {
+        rootPolicy: 'existing',
+        references: [
+          { table: 'flows', id: FLOW_ID, version: '01.00.000', role: 'reference' },
+          { table: 'sources', id: SOURCE_ID, version: '01.00.000', role: 'reference' },
+        ],
+      },
+      buildActor(supabase),
+    );
+
+    const body = commandBody<{
+      ok: boolean;
+      data: { counts: { blockers: number }; checks: Array<{ status: string }> };
+    }>(result);
+
+    assertEquals(result.ok, true);
+    assertEquals(result.status, 409);
+    assertEquals(body.ok, false);
+    assertEquals(body.data.counts.blockers, 2);
+    assertEquals(
+      body.data.checks.map((check) => check.status),
+      ['version_outdated', 'missing_version'],
+    );
+  },
+);
+
+Deno.test(
+  'executeVerifyRemoteCommand allows new candidate roots but still blocks missing nested references',
+  async () => {
+    const supabase = new FakeSupabase({
+      processes: [{ id: PROCESS_ID, version: '01.00.000', state_code: 0, json_ordered: {} }],
+      sources: [],
+    });
+
+    const result = await executeVerifyRemoteCommand(
+      {
+        rootPolicy: 'candidate',
+        references: [
+          { table: 'processes', id: PROCESS_ID, version: '01.01.000', role: 'root' },
+          {
+            table: 'sources',
+            id: SOURCE_ID,
+            version: '20.20.002',
+            role: 'reference',
+            path: '/source',
+          },
+        ],
+      },
+      buildActor(supabase),
+    );
+
+    const body = commandBody<{
+      ok: boolean;
+      data: {
+        counts: { blockers: number };
+        checks: Array<{ status: string; path: string | null }>;
+      };
+    }>(result);
+
+    assertEquals(result.status, 409);
+    assertEquals(body.ok, false);
+    assertEquals(body.data.counts.blockers, 1);
+    assertEquals(
+      body.data.checks.map((check) => check.status),
+      ['candidate_root', 'missing_dataset'],
+    );
+    assertEquals(body.data.checks[1]?.path, '/source');
+  },
+);
+
+Deno.test('executeVerifyRemoteCommand blocks state and payload hash mismatches', async () => {
+  const supabase = new FakeSupabase({
+    processes: [
+      {
+        id: PROCESS_ID,
+        version: '01.01.000',
+        state_code: 20,
+        json_ordered: { value: 'actual' },
+      },
+    ],
+    flows: [
+      { id: FLOW_ID, version: '01.00.000', state_code: 100, json_ordered: { value: 'actual' } },
+    ],
+  });
+
+  const result = await executeVerifyRemoteCommand(
+    {
+      rootPolicy: 'existing',
+      references: [
+        {
+          table: 'processes',
+          id: PROCESS_ID,
+          version: '01.01.000',
+          role: 'root',
+          expectedStateCodes: [0],
+        },
+        {
+          table: 'flows',
+          id: FLOW_ID,
+          version: '01.00.000',
+          role: 'reference',
+          expectedJsonSha256: await stableJsonSha256({ value: 'expected' }),
+        },
+      ],
+    },
+    buildActor(supabase),
+  );
+
+  const body = commandBody<{ data: { checks: Array<{ status: string }> } }>(result);
+
+  assertEquals(result.status, 409);
+  assertEquals(
+    body.data.checks.map((check) => check.status),
+    ['state_code_mismatch', 'payload_hash_mismatch'],
+  );
+});
+
+Deno.test('executeVerifyRemoteCommand maps lookup errors to classified blockers', async () => {
+  const supabase = new FakeSupabase({ processes: [] });
+  supabase.errors.set('processes', { code: '42501', message: 'permission denied' });
+
+  const result = await executeVerifyRemoteCommand(
+    {
+      rootPolicy: 'existing',
+      references: [{ table: 'processes', id: PROCESS_ID, version: '01.01.000', role: 'root' }],
+    },
+    buildActor(supabase),
+  );
+
+  const body = commandBody<{
+    data: {
+      counts: { blockers: number };
+      blockers: Array<{
+        code: string;
+        message: string;
+        index: number;
+        table: string;
+        id: string;
+        version: string | null;
+        role: string;
+        path: string | null;
+      }>;
+    };
+  }>(result);
+
+  assertEquals(result.status, 409);
+  assertEquals(body.data.counts.blockers, 1);
+  assertEquals(body.data.blockers[0], {
+    code: 'lookup_failed',
+    message: 'permission denied',
+    index: 0,
+    table: 'processes',
+    id: PROCESS_ID,
+    version: '01.01.000',
+    role: 'root',
+    path: null,
+  });
+});

--- a/test/notification_command_test.ts
+++ b/test/notification_command_test.ts
@@ -40,18 +40,21 @@ function buildActor(supabase: FakeRpcSupabase) {
   };
 }
 
-Deno.test('notification validation-issue payload parser rejects removed source dataset fields', () => {
-  const parsed = parseNotificationSendValidationIssueCommand({
-    recipientUserId: TEST_RECIPIENT_ID,
-    datasetType: 'process data set',
-    datasetId: TEST_DATASET_ID,
-    datasetVersion: '01.00.000',
-    issueCodes: ['ruleVerificationFailed'],
-    sourceDatasetType: 'process data set',
-  });
+Deno.test(
+  'notification validation-issue payload parser rejects removed source dataset fields',
+  () => {
+    const parsed = parseNotificationSendValidationIssueCommand({
+      recipientUserId: TEST_RECIPIENT_ID,
+      datasetType: 'process data set',
+      datasetId: TEST_DATASET_ID,
+      datasetVersion: '01.00.000',
+      issueCodes: ['ruleVerificationFailed'],
+      sourceDatasetType: 'process data set',
+    });
 
-  assertEquals(parsed.ok, false);
-});
+    assertEquals(parsed.ok, false);
+  },
+);
 
 Deno.test('createNotificationCommandRepository requires an explicit Supabase client', () => {
   assertThrows(

--- a/test/tidas_package_api_test.ts
+++ b/test/tidas_package_api_test.ts
@@ -242,7 +242,9 @@ function normalizeSortValue(value: unknown): string | number {
 }
 
 async function sha256Hex(bytes: Uint8Array): Promise<string> {
-  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  const payload = new Uint8Array(bytes.byteLength);
+  payload.set(bytes);
+  const digest = await crypto.subtle.digest('SHA-256', payload.buffer as ArrayBuffer);
   return Array.from(new Uint8Array(digest))
     .map((byte) => byte.toString(16).padStart(2, '0'))
     .join('');


### PR DESCRIPTION
## Summary
- add read-only `app_dataset_verify_remote` Edge Function for post-write/readback verification callers
- verify submitted dataset references by table/id/version with classified statuses for missing dataset, missing version, latest-version drift, state_code mismatch, missing payload, payload hash mismatch, lookup failure, and allowed candidate roots
- return machine-readable verification reports with checks, blockers, counts, root policy, state_code, owner visibility, modified time, and optional stable JSON SHA-256 comparison
- add request collection coverage and repo docpact review evidence

## Validation
- `deno check --config supabase/functions/deno.json supabase/functions/app_dataset_verify_remote/index.ts test/app_dataset_verify_remote_test.ts`
- `deno test --config supabase/functions/deno.json test/app_dataset_verify_remote_test.ts` (6 tests)
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH npm run lint`
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH npm run check`
- `../scripts/docpact lint --root /Users/huimin/projets/workspace/tiangong-lca-edge-functions --staged --format json --output .docpact/runs/latest.json`
- `git diff --cached --check`

## Notes
- No deploy was performed in this local implementation pass.
- This endpoint does not move BuildPlan, schema, or ruleset logic into Edge Functions. CLI/Foundry still decide production policy; Edge only proves remote row visibility and classified readback state.

Closes #111
Refs tiangong-lca/workspace#143
