### PR TITLE
Add compact dataset extraction worker

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-05-25'
-lastReviewedCommit: '2deff4a164fe57167c7a7bf6a68c9524ed0fa345'
+lastReviewedAt: '2026-05-26'
+lastReviewedCommit: 'fc96a4fe75242d5212f26652aac2a61e20795026'
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 2deff4a164fe57167c7a7bf6a68c9524ed0fa345
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: fc96a4fe75242d5212f26652aac2a61e20795026
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 2deff4a164fe57167c7a7bf6a68c9524ed0fa345
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: fc96a4fe75242d5212f26652aac2a61e20795026
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: 2deff4a164fe57167c7a7bf6a68c9524ed0fa345
+lastReviewedAt: 2026-05-26
+lastReviewedCommit: fc96a4fe75242d5212f26652aac2a61e20795026
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/functions/_shared/dataset_extraction_worker.ts
+++ b/supabase/functions/_shared/dataset_extraction_worker.ts
@@ -1,0 +1,302 @@
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+
+import {
+  generateFlowMarkdown,
+  generateFlowTextSummary,
+  normalizeJsonOrdered,
+} from './flow_extraction.ts';
+import type { OpenAIChatResult } from './openai_chat.ts';
+
+export type DatasetExtractionKind = 'extracted_md' | 'extracted_text';
+export type DatasetEntityKind = 'flow' | 'process';
+
+export interface DatasetExtractionJobMessage {
+  schema: string;
+  table: string;
+  id: string;
+  version: string;
+  entity_kind: DatasetEntityKind;
+  extraction_kind: DatasetExtractionKind;
+  created_at?: string;
+}
+
+export interface ClaimedDatasetExtractionJob {
+  msg_id: number;
+  read_ct: number;
+  message: DatasetExtractionJobMessage;
+}
+
+export interface DatasetExtractionJobResult {
+  msg_id: number;
+  entity_kind?: string;
+  extraction_kind?: string;
+  table?: string;
+  id?: string;
+  version?: string;
+  status: 'success' | 'retry' | 'failed' | 'unsupported';
+  duration_ms: number;
+  error_code?: string;
+  error_message?: string;
+}
+
+export interface DatasetExtractionWorkerResult {
+  claimed: number;
+  acked: number;
+  results: DatasetExtractionJobResult[];
+}
+
+export interface DatasetExtractionWorkerOptions {
+  supabase: SupabaseClient;
+  batchSize?: number;
+  visibilityTimeoutSeconds?: number;
+  maxReadCount?: number;
+  markdownGenerator?: (flowJson: unknown) => string;
+  textGenerator?: (
+    flowJson: unknown,
+    chat?: (input: string, options?: { stream?: boolean }) => Promise<OpenAIChatResult>,
+  ) => Promise<string>;
+}
+
+interface RpcEnvelope<T> {
+  ok?: boolean;
+  data?: T;
+  code?: string;
+  status?: number;
+  message?: string;
+}
+
+function positiveInteger(value: number | undefined, fallback: number, max: number): number {
+  if (!Number.isFinite(value ?? NaN)) return fallback;
+  return Math.min(Math.max(Math.trunc(value!), 1), max);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string'
+    ? value
+    : value === undefined || value === null
+      ? ''
+      : String(value);
+}
+
+function parseClaimedJob(value: unknown): ClaimedDatasetExtractionJob {
+  const raw = asRecord(value);
+  const message = asRecord(raw.message);
+  return {
+    msg_id: Number(raw.msg_id),
+    read_ct: Number(raw.read_ct ?? 0),
+    message: {
+      schema: asString(message.schema),
+      table: asString(message.table),
+      id: asString(message.id),
+      version: asString(message.version),
+      entity_kind: asString(message.entity_kind) as DatasetEntityKind,
+      extraction_kind: asString(message.extraction_kind) as DatasetExtractionKind,
+      created_at: message.created_at === undefined ? undefined : asString(message.created_at),
+    },
+  };
+}
+
+function assertFlowJob(job: ClaimedDatasetExtractionJob): void {
+  const message = job.message;
+  if (message.schema !== 'public' || message.table !== 'flows' || message.entity_kind !== 'flow') {
+    throw Object.assign(new Error('Unsupported dataset extraction job entity'), {
+      code: 'UNSUPPORTED_ENTITY_KIND',
+    });
+  }
+  if (message.extraction_kind !== 'extracted_md' && message.extraction_kind !== 'extracted_text') {
+    throw Object.assign(new Error('Unsupported dataset extraction kind'), {
+      code: 'UNSUPPORTED_EXTRACTION_KIND',
+    });
+  }
+  if (!message.id || !message.version) {
+    throw Object.assign(new Error('Dataset extraction job is missing id or version'), {
+      code: 'INVALID_JOB_MESSAGE',
+    });
+  }
+}
+
+function errorCode(error: unknown): string {
+  if (typeof error === 'object' && error !== null) {
+    const code = Reflect.get(error, 'code');
+    if (typeof code === 'string' && code.trim()) return code;
+  }
+  return 'DATASET_EXTRACTION_JOB_FAILED';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function recordTerminalFailure(
+  supabase: SupabaseClient,
+  job: ClaimedDatasetExtractionJob,
+  reason: string,
+  message: string,
+): Promise<void> {
+  const { error } = await supabase.rpc('cmd_dataset_extraction_record_failure', {
+    p_msg_id: job.msg_id,
+    p_read_count: job.read_ct,
+    p_reason: reason,
+    p_message: job.message,
+    p_last_error: message,
+    p_delete: true,
+  });
+
+  if (error) throw error;
+}
+
+async function fetchFlowJson(
+  supabase: SupabaseClient,
+  id: string,
+  version: string,
+): Promise<unknown> {
+  const { data, error } = await supabase
+    .from('flows')
+    .select('id,version,json_ordered')
+    .eq('id', id)
+    .eq('version', version)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) {
+    throw Object.assign(new Error('Flow row was not found for dataset extraction job'), {
+      code: 'FLOW_NOT_FOUND',
+    });
+  }
+
+  return normalizeJsonOrdered((data as { json_ordered?: unknown }).json_ordered);
+}
+
+async function updateFlowExtraction(
+  supabase: SupabaseClient,
+  id: string,
+  version: string,
+  values: { extracted_md?: string; extracted_text?: string },
+): Promise<void> {
+  const { error } = await supabase.from('flows').update(values).eq('id', id).eq('version', version);
+  if (error) throw error;
+}
+
+async function processFlowJob(
+  supabase: SupabaseClient,
+  job: ClaimedDatasetExtractionJob,
+  markdownGenerator: (flowJson: unknown) => string,
+  textGenerator: (flowJson: unknown) => Promise<string>,
+): Promise<void> {
+  assertFlowJob(job);
+  const { id, version, extraction_kind } = job.message;
+  const flowJson = await fetchFlowJson(supabase, id, version);
+
+  if (extraction_kind === 'extracted_md') {
+    const markdown = markdownGenerator(flowJson);
+    if (!markdown.trim()) {
+      throw Object.assign(new Error('Empty extracted markdown'), {
+        code: 'EMPTY_EXTRACTED_MD',
+      });
+    }
+    await updateFlowExtraction(supabase, id, version, { extracted_md: markdown });
+    return;
+  }
+
+  const summary = await textGenerator(flowJson);
+  await updateFlowExtraction(supabase, id, version, { extracted_text: summary });
+}
+
+export async function processDatasetExtractionJobs(
+  options: DatasetExtractionWorkerOptions,
+): Promise<DatasetExtractionWorkerResult> {
+  const batchSize = positiveInteger(options.batchSize, 5, 50);
+  const visibilityTimeoutSeconds = positiveInteger(options.visibilityTimeoutSeconds, 300, 3600);
+  const maxReadCount = positiveInteger(options.maxReadCount, 5, 100);
+  const markdownGenerator = options.markdownGenerator ?? generateFlowMarkdown;
+  const textGenerator = options.textGenerator ?? generateFlowTextSummary;
+
+  const { data, error } = await options.supabase.rpc('cmd_dataset_extraction_claim', {
+    p_qty: batchSize,
+    p_vt_seconds: visibilityTimeoutSeconds,
+    p_max_read_count: maxReadCount,
+  });
+
+  if (error) throw error;
+
+  const envelope = data as RpcEnvelope<unknown[]>;
+  if (envelope?.ok === false) {
+    throw Object.assign(new Error(envelope.message ?? 'Dataset extraction claim failed'), {
+      code: envelope.code ?? 'DATASET_EXTRACTION_CLAIM_FAILED',
+      status: envelope.status,
+    });
+  }
+
+  const jobs = Array.isArray(envelope?.data) ? envelope.data.map(parseClaimedJob) : [];
+  const ackIds: number[] = [];
+  const results: DatasetExtractionJobResult[] = [];
+
+  for (const job of jobs) {
+    const start = Date.now();
+    const baseLog = {
+      msg_id: job.msg_id,
+      entity_kind: job.message.entity_kind,
+      table: job.message.table,
+      id: job.message.id,
+      version: job.message.version,
+      extraction_kind: job.message.extraction_kind,
+      retry_count: job.read_ct,
+    };
+
+    try {
+      await processFlowJob(options.supabase, job, markdownGenerator, (flowJson) =>
+        textGenerator(flowJson),
+      );
+      ackIds.push(job.msg_id);
+      const result = {
+        ...baseLog,
+        status: 'success' as const,
+        duration_ms: Date.now() - start,
+      };
+      console.log('[dataset_extraction_job]', { ...result, stage: 'success' });
+      results.push(result);
+    } catch (caught) {
+      const code = errorCode(caught);
+      const message = errorMessage(caught);
+      const terminal = code === 'UNSUPPORTED_ENTITY_KIND' || job.read_ct >= maxReadCount;
+
+      if (terminal) {
+        await recordTerminalFailure(options.supabase, job, code, message);
+      }
+
+      const result = {
+        ...baseLog,
+        status:
+          code === 'UNSUPPORTED_ENTITY_KIND'
+            ? ('unsupported' as const)
+            : terminal
+              ? ('failed' as const)
+              : ('retry' as const),
+        duration_ms: Date.now() - start,
+        error_code: code,
+        error_message: message,
+      };
+      console.error('[dataset_extraction_job]', { ...result, stage: result.status });
+      results.push(result);
+    }
+  }
+
+  if (ackIds.length > 0) {
+    const { error: ackError } = await options.supabase.rpc('cmd_dataset_extraction_ack', {
+      p_msg_ids: ackIds,
+    });
+    if (ackError) throw ackError;
+  }
+
+  return {
+    claimed: jobs.length,
+    acked: ackIds.length,
+    results,
+  };
+}

--- a/supabase/functions/_shared/flow_extraction.ts
+++ b/supabase/functions/_shared/flow_extraction.ts
@@ -1,0 +1,444 @@
+import { openaiChat, type OpenAIChatResult } from './openai_chat.ts';
+
+const DEFAULT_LANG = 'en';
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const pickProperty = (obj: unknown, names: string[]): unknown => {
+  if (!isObject(obj)) return undefined;
+  for (const name of names) {
+    const value = obj[name];
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+};
+
+const ensureArray = <T>(value: T | T[] | null | undefined): T[] => {
+  if (value === null || value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+};
+
+const getTextFromDict = (data: unknown): string | null => {
+  if (data === null || data === undefined) return null;
+  if (typeof data === 'string' || typeof data === 'number' || typeof data === 'boolean') {
+    const text = String(data).trim();
+    return text || null;
+  }
+  if (!isObject(data)) return null;
+  const text = data['#text'] ?? data.text ?? data._text;
+  if (typeof text !== 'string') return null;
+  const trimmed = text.trim();
+  return trimmed || null;
+};
+
+const collectTexts = (value: unknown, lang = DEFAULT_LANG): string[] => {
+  if (value === null || value === undefined) return [];
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    const text = String(value).trim();
+    return text ? [text] : [];
+  }
+
+  const entries = Array.isArray(value) ? value : isObject(value) ? [value] : [];
+  const langMatches: string[] = [];
+  const fallback: string[] = [];
+
+  for (const entry of entries) {
+    if (entry === null || entry === undefined) continue;
+    if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
+      const text = String(entry).trim();
+      if (text) fallback.push(text);
+      continue;
+    }
+    if (!isObject(entry)) continue;
+    const entryLang = pickProperty(entry, ['@xml:lang', 'xml:lang', 'xml_lang', 'lang']);
+    const text = getTextFromDict(entry);
+    if (!text) continue;
+    if (lang && entryLang === lang) {
+      langMatches.push(text);
+    } else {
+      fallback.push(text);
+    }
+  }
+
+  return langMatches.length ? langMatches : fallback;
+};
+
+const pickText = (value: unknown, lang = DEFAULT_LANG): string | null => {
+  if (isObject(value)) {
+    const getText = Reflect.get(value, 'get_text');
+    if (typeof getText === 'function') {
+      const text = getText.call(value, lang);
+      if (text) {
+        const trimmed = String(text).trim();
+        if (trimmed) return trimmed;
+      }
+    }
+  }
+
+  const texts = collectTexts(value, lang);
+  if (texts.length) return texts[0];
+  if (isObject(value)) return getTextFromDict(value);
+  return null;
+};
+
+const joinTexts = (value: unknown, lang = DEFAULT_LANG, sep = '\n\n'): string | null => {
+  const texts = collectTexts(value, lang)
+    .map((text) => text.trim())
+    .filter(Boolean);
+  return texts.length ? texts.join(sep) : null;
+};
+
+const toDisplayText = (value: unknown, lang = DEFAULT_LANG): string | null => {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    const text = String(value).trim();
+    return text || null;
+  }
+  return pickText(value, lang);
+};
+
+const findFlowDataSet = (data: unknown): Record<string, unknown> | null => {
+  if (!isObject(data)) return null;
+
+  const direct =
+    pickProperty(data, ['flowDataSet', 'flow_data_set']) ??
+    pickProperty(data, ['flowdataset', 'flow_dataset']);
+  if (isObject(direct)) return direct;
+
+  if (pickProperty(data, ['flowInformation', 'flow_information'])) return data;
+
+  for (const value of Object.values(data)) {
+    const found = findFlowDataSet(value);
+    if (found) return found;
+  }
+
+  return null;
+};
+
+const getDataSetVersion = (dataset: Record<string, unknown>): string | null => {
+  const admin = pickProperty(dataset, ['administrativeInformation', 'administrative_information']);
+  const publication = pickProperty(admin, ['publicationAndOwnership', 'publication_and_ownership']);
+  const version = pickProperty(publication, [
+    'common:dataSetVersion',
+    'common_data_set_version',
+    'dataSetVersion',
+    'data_set_version',
+    'version',
+  ]);
+  return version ? toDisplayText(version) : null;
+};
+
+const getClassificationPath = (dataInfo: unknown): string | null => {
+  const classification = pickProperty(dataInfo, [
+    'classificationInformation',
+    'classification_information',
+  ]);
+  const container = pickProperty(classification, [
+    'common:elementaryFlowCategorization',
+    'common:classification',
+    'elementaryFlowCategorization',
+    'classification',
+    'common_elementary_flow_categorization',
+    'common_classification',
+  ]);
+  const categories = ensureArray(
+    pickProperty(container, [
+      'common:category',
+      'common:class',
+      'category',
+      'class',
+      'common_category',
+      'common_class',
+    ]),
+  );
+
+  const levelOf = (entry: unknown): number | null => {
+    const level = pickProperty(entry, ['@level', 'level']);
+    if (level === undefined || level === null) return null;
+    const parsed = Number(level);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
+  const parts = categories
+    .slice()
+    .sort((a, b) => {
+      const levelA = levelOf(a);
+      const levelB = levelOf(b);
+      if (levelA === null && levelB === null) return 0;
+      if (levelA === null) return 1;
+      if (levelB === null) return -1;
+      return levelA - levelB;
+    })
+    .map((entry) => getTextFromDict(entry))
+    .filter((text): text is string => Boolean(text));
+  return parts.length ? parts.join(' > ') : null;
+};
+
+const composeFlowTitle = (dataInfo: unknown, lang = DEFAULT_LANG): string => {
+  const nameObj = pickProperty(dataInfo, ['name']);
+  const parts = [
+    joinTexts(pickProperty(nameObj, ['baseName', 'base_name', 'basename']), lang, ' | '),
+    joinTexts(
+      pickProperty(nameObj, ['mixAndLocationTypes', 'mix_and_location_types']),
+      lang,
+      ' | ',
+    ),
+    joinTexts(
+      pickProperty(nameObj, ['treatmentStandardsRoutes', 'treatment_standards_routes']),
+      lang,
+      ' | ',
+    ),
+  ].filter((part): part is string => Boolean(part));
+  return parts.length ? parts.join(' | ') : 'Flow';
+};
+
+const formatNumber = (value: unknown): string => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value.toString() : String(value);
+  }
+  const parsed = Number(String(value));
+  return Number.isFinite(parsed) ? parsed.toString() : String(value);
+};
+
+const pickShortDescription = (ref: unknown, lang = DEFAULT_LANG): string | null => {
+  if (ref === null || ref === undefined) return null;
+  if (Array.isArray(ref)) {
+    for (const entry of ref) {
+      const text = pickShortDescription(entry, lang);
+      if (text) return text;
+    }
+    return null;
+  }
+
+  const shortDescription = pickProperty(ref, [
+    'common:shortDescription',
+    'common_short_description',
+    'shortDescription',
+    'short_description',
+  ]);
+  const text = pickText(shortDescription, lang);
+  if (text) return text;
+
+  const direct = getTextFromDict(ref);
+  if (direct) return direct;
+
+  if (typeof ref === 'string' || typeof ref === 'number' || typeof ref === 'boolean') {
+    const primitive = String(ref).trim();
+    return primitive || null;
+  }
+
+  return null;
+};
+
+const getReferencePropertySummary = (
+  dataset: Record<string, unknown>,
+  lang = DEFAULT_LANG,
+): { name: string | null; value: string | null } => {
+  const flowInfo = pickProperty(dataset, ['flowInformation', 'flow_information']);
+  const quantitativeReference = pickProperty(flowInfo, [
+    'quantitativeReference',
+    'quantitative_reference',
+  ]);
+  const refId = pickProperty(quantitativeReference, [
+    'referenceToReferenceFlowProperty',
+    'reference_to_reference_flow_property',
+    '@ref',
+  ]);
+
+  const properties = pickProperty(dataset, ['flowProperties', 'flow_properties']);
+  const propItems = ensureArray(
+    pickProperty(properties, ['flowProperty', 'flow_property']) ?? properties,
+  );
+
+  if (!propItems.length || refId === null || refId === undefined) {
+    return { name: null, value: null };
+  }
+
+  const refItem = propItems.find((item) => {
+    const itemId = pickProperty(item, [
+      'dataSetInternalID',
+      'data_set_internal_id',
+      '@dataSetInternalID',
+      '@data_set_internal_id',
+    ]);
+    return itemId !== undefined && itemId !== null && String(itemId) === String(refId);
+  });
+
+  if (!refItem) {
+    return { name: null, value: null };
+  }
+
+  const refInfo = pickProperty(refItem, [
+    'referenceToFlowPropertyDataSet',
+    'reference_to_flow_property_data_set',
+  ]);
+  const meanValue = pickProperty(refItem, ['meanValue', 'mean_value']);
+  return {
+    name: pickShortDescription(refInfo, lang),
+    value: meanValue !== undefined && meanValue !== null ? formatNumber(meanValue) : null,
+  };
+};
+
+const getEcNumber = (dataInfo: unknown): string | null => {
+  const other = pickProperty(dataInfo, ['common:other', 'common_other', 'other']);
+  const ecContainer = pickProperty(other, [
+    'ecn:ECNumber',
+    'ECNumber',
+    'ecn_ec_number',
+    'ec_number',
+  ]);
+  return toDisplayText(ecContainer);
+};
+
+const getMethodology = (dataset: Record<string, unknown>): string | null => {
+  const modelling = pickProperty(dataset, ['modellingAndValidation', 'modelling_and_validation']);
+  const lci = pickProperty(modelling, ['LCIMethod', 'lciMethod', 'lci_method']);
+  const dataSetType = pickProperty(lci, ['typeOfDataSet', 'type_of_data_set']);
+  const typeText = toDisplayText(dataSetType);
+  return typeText ? `**Data Set Type:** ${typeText}` : null;
+};
+
+const getGeography = (flowInfo: unknown, lang = DEFAULT_LANG): string | null => {
+  const geography = pickProperty(flowInfo, ['geography']);
+  const location = pickProperty(geography, ['locationOfSupply', 'location_of_supply', 'location']);
+  const locationText = toDisplayText(location, lang);
+  return locationText ? `**Location of Supply:** ${locationText}` : null;
+};
+
+const getTechnology = (flowInfo: unknown, lang = DEFAULT_LANG): string | null => {
+  const technology = pickProperty(flowInfo, ['technology']);
+  if (isObject(technology)) {
+    return joinTexts(
+      pickProperty(technology, ['technologicalApplicability', 'technological_applicability']),
+      lang,
+    );
+  }
+  return joinTexts(technology, lang);
+};
+
+const getFlowProperties = (dataset: Record<string, unknown>, lang = DEFAULT_LANG): string[] => {
+  const props = pickProperty(dataset, ['flowProperties', 'flow_properties']);
+  const items = ensureArray(pickProperty(props, ['flowProperty', 'flow_property']) ?? props);
+  const lines: string[] = [];
+
+  for (const item of items) {
+    const ref = pickProperty(item, [
+      'referenceToFlowPropertyDataSet',
+      'reference_to_flow_property_data_set',
+    ]);
+    const meanValue = pickProperty(item, ['meanValue', 'mean_value']);
+    const name = pickShortDescription(ref, lang) || 'Flow property';
+    lines.push(`- ${name}: ${formatNumber(meanValue)}`);
+  }
+
+  return lines;
+};
+
+export function normalizeJsonOrdered(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  return JSON.parse(value);
+}
+
+export function generateFlowMarkdown(flowJson: unknown, lang = DEFAULT_LANG): string {
+  const flowDataSet = findFlowDataSet(flowJson);
+  if (!flowDataSet) {
+    throw new Error('Invalid flow JSON: missing flow data set');
+  }
+
+  const flowInformation = pickProperty(flowDataSet, ['flowInformation', 'flow_information']) ?? {};
+  const dataSetInformation =
+    pickProperty(flowInformation, ['dataSetInformation', 'data_set_information']) ?? {};
+  const title = composeFlowTitle(dataSetInformation, lang);
+  const lines: string[] = [`# ${title}`, '', '**Entity:** Flow'];
+
+  const uuid =
+    pickProperty(dataSetInformation, ['common:UUID', 'common_uuid', 'uuid', 'UUID']) ??
+    pickProperty(dataSetInformation, ['common:uuid']);
+  const uuidText = toDisplayText(uuid, lang);
+  if (uuidText) lines.push(`**UUID:** \`${uuidText}\``);
+
+  const version = getDataSetVersion(flowDataSet);
+  if (version) lines.push(`**Version:** ${version}`);
+
+  const { name: refPropName, value: refPropValue } = getReferencePropertySummary(flowDataSet, lang);
+  if (refPropName || refPropValue) {
+    lines.push(`**Reference Property:** ${refPropName || 'N/A'}`);
+  }
+  if (refPropValue) lines.push(`**Property Mean:** ${refPropValue}`);
+
+  const methodology = getMethodology(flowDataSet);
+  if (methodology) lines.push(methodology);
+
+  const casNumber = toDisplayText(
+    pickProperty(dataSetInformation, ['CASNumber', 'casNumber', 'cas_number']),
+    lang,
+  );
+  if (casNumber) lines.push(`**CAS:** ${casNumber}`);
+
+  const ecNumber = getEcNumber(dataSetInformation);
+  if (ecNumber) lines.push(`**EC Number:** ${ecNumber}`);
+
+  const classification = getClassificationPath(dataSetInformation);
+  if (classification) lines.push(`**Classification:** ${classification}`, '');
+
+  const synonyms = joinTexts(
+    pickProperty(dataSetInformation, ['common:synonyms', 'common_synonyms', 'synonyms']),
+    lang,
+  );
+  if (synonyms) lines.push(`**Synonyms:** ${synonyms}`);
+
+  if (lines.length && lines[lines.length - 1] !== '') {
+    lines.push('');
+  }
+
+  const description = joinTexts(
+    pickProperty(dataSetInformation, [
+      'common:generalComment',
+      'common_general_comment',
+      'generalComment',
+      'general_comment',
+    ]),
+    lang,
+  );
+  if (description) lines.push('## Description', '', description, '');
+
+  const geography = getGeography(flowInformation, lang);
+  if (geography) lines.push('## Geography', '', geography, '');
+
+  const technology = getTechnology(flowInformation, lang);
+  if (technology) lines.push('## Technology', '', technology, '');
+
+  const flowProperties = getFlowProperties(flowDataSet, lang);
+  if (flowProperties.length) lines.push('## Flow Properties', '', ...flowProperties, '');
+
+  if (lines.length && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+
+  return lines.join('\n');
+}
+
+const FLOW_TEXT_SUMMARY_PROMPT = `From the given life cycle assessment ILCD flow JSON, write one continuous English paragraph (<500 tokens) suitable for embedding and retrieval. The paragraph must strictly follow the natural language template below. Fill in values only if explicitly available. Do not add, remove, or reorder sentences. If a field has no value, omit the entire sentence where it belongs, not just the placeholder. When joining multiple qualifiers from name.treatmentStandardsRoutes or name.mixAndLocationTypes, separate them with commas, not semicolons. If the classification path or names already contain semicolons as part of the original text, keep them, but never add additional semicolons when combining values. The output must contain only English text - translate all non-English words or characters into English. Never include Chinese, Japanese, or other non-English text. Always output as a single continuous paragraph in English only and without mechanical punctuation, never a list or key-value format.
+
+Template:
+<name.baseName [plus any qualifiers from name.treatmentStandardsRoutes and name.mixAndLocationTypes, joined with commas as non-geographic tags]> is classified under <classification path highest to lowest, using classificationInformation.elementaryFlowCategorization for elementary flows or classificationInformation.classification for product or waste flows>. [If common:synonyms exists] It is also known as <common:synonyms>, with identifiers such as CAS number <CAS> and EC number <EC> if available. This dataset is of type <typeOfDataSet> and includes the following general comment: <generalComment>. The reference flow property is <referenceFlowProperty.name> with a mean value of <referenceFlowProperty.meanValue>. It follows the compliance system <complianceSystem> with approval status <approvalStatus>. The dataset is provided in version <version> and was last updated on <timeStamp>, with ownership or publisher described as <ownership/publisher>. (<UUID>)
+
+Additional rules:
+Must include name.baseName, translated to English if necessary.
+Preserve any codes or IDs verbatim.
+Exclude all URIs or schema references.
+Never interpret mixAndLocationTypes as geography (treat them only as non-geographic tags).
+Do not infer or invent values.`;
+
+export async function generateFlowTextSummary(
+  flowJson: unknown,
+  chat: (input: string, options?: { stream?: boolean }) => Promise<OpenAIChatResult> = openaiChat,
+): Promise<string> {
+  const modelInput = `${FLOW_TEXT_SUMMARY_PROMPT}\nJSON:\n${JSON.stringify(flowJson)}`;
+  const { text } = await chat(modelInput, { stream: false });
+  const summary = (text || '').trim();
+  if (!summary) throw new Error('Empty summary from model');
+  return summary;
+}

--- a/supabase/functions/process_dataset_extraction_jobs/index.ts
+++ b/supabase/functions/process_dataset_extraction_jobs/index.ts
@@ -1,0 +1,66 @@
+// Setup type definitions for built-in Supabase Runtime APIs
+import '@supabase/functions-js/edge-runtime.d.ts';
+
+import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
+import { corsHeaders } from '../_shared/cors.ts';
+import { processDatasetExtractionJobs } from '../_shared/dataset_extraction_worker.ts';
+import { supabaseClient } from '../_shared/supabase_client.ts';
+
+interface WorkerRequestBody {
+  batchSize?: number;
+  visibilityTimeoutSeconds?: number;
+  maxReadCount?: number;
+}
+
+async function parseBody(req: Request): Promise<WorkerRequestBody> {
+  const contentType = req.headers.get('content-type') ?? '';
+  if (!contentType.toLowerCase().includes('application/json')) return {};
+  const body = await req.json();
+  return typeof body === 'object' && body !== null && !Array.isArray(body)
+    ? (body as WorkerRequestBody)
+    : {};
+}
+
+export async function handleProcessDatasetExtractionJobs(req: Request): Promise<Response> {
+  const authResult = await authenticateRequest(req, {
+    allowedMethods: [AuthMethod.SERVICE_API_KEY],
+  });
+
+  if (!authResult.isAuthenticated) {
+    return authResult.response!;
+  }
+
+  try {
+    const body = await parseBody(req);
+    const result = await processDatasetExtractionJobs({
+      supabase: supabaseClient,
+      batchSize: body.batchSize,
+      visibilityTimeoutSeconds: body.visibilityTimeoutSeconds,
+      maxReadCount: body.maxReadCount,
+    });
+
+    return new Response(JSON.stringify({ success: true, ...result }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 200,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const code =
+      typeof error === 'object' && error !== null && typeof Reflect.get(error, 'code') === 'string'
+        ? Reflect.get(error, 'code')
+        : 'DATASET_EXTRACTION_WORKER_FAILED';
+
+    console.error('[process_dataset_extraction_jobs] caught error', {
+      code,
+      message,
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+
+    return new Response(JSON.stringify({ success: false, code, error: message }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 500,
+    });
+  }
+}
+
+Deno.serve(handleProcessDatasetExtractionJobs);

--- a/supabase/functions/webhook_flow_embedding/index.ts
+++ b/supabase/functions/webhook_flow_embedding/index.ts
@@ -3,7 +3,7 @@ import '@supabase/functions-js/edge-runtime.d.ts';
 
 import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
-import { openaiChat } from '../_shared/openai_chat.ts';
+import { generateFlowTextSummary, normalizeJsonOrdered } from '../_shared/flow_extraction.ts';
 import { supabaseClient } from '../_shared/supabase_client.ts';
 
 interface WebhookPayload {
@@ -39,29 +39,14 @@ Deno.serve(async (req) => {
       throw new Error('No record data found');
     }
 
-    const jsonData = record.json_ordered;
+    const jsonData = normalizeJsonOrdered(record.json_ordered);
     if (!jsonData) {
       throw new Error('No json_ordered data found in record');
     }
 
     // console.log(`${table} ${record.id} ${record.version} summary ${type} request`);
 
-    const systemPrompt = `From the given life cycle assessment ILCD flow JSON, write one continuous English paragraph (<500 tokens) suitable for embedding and retrieval. The paragraph must strictly follow the natural language template below. Fill in values only if explicitly available. Do not add, remove, or reorder sentences. If a field has no value, omit the entire sentence where it belongs, not just the placeholder. When joining multiple qualifiers from name.treatmentStandardsRoutes or name.mixAndLocationTypes, separate them with commas, not semicolons. If the classification path or names already contain semicolons as part of the original text, keep them, but never add additional semicolons when combining values. The output must contain only English text — translate all non-English words or characters into English. Never include Chinese, Japanese, or other non-English text. Always output as a single continuous paragraph in English only and without mechanical punctuation, never a list or key-value format.
-
-Template:
-<name.baseName [plus any qualifiers from name.treatmentStandardsRoutes and name.mixAndLocationTypes, joined with commas as non-geographic tags]> is classified under <classification path highest→lowest, using classificationInformation.elementaryFlowCategorization for elementary flows or classificationInformation.classification for product or waste flows>. [If common:synonyms exists] It is also known as <common:synonyms>, with identifiers such as CAS number <CAS> and EC number <EC> if available. This dataset is of type <typeOfDataSet> and includes the following general comment: <generalComment>. The reference flow property is <referenceFlowProperty.name> with a mean value of <referenceFlowProperty.meanValue>. It follows the compliance system <complianceSystem> with approval status <approvalStatus>. The dataset is provided in version <version> and was last updated on <timeStamp>, with ownership or publisher described as <ownership/publisher>. (<UUID>)
-
-Additional rules:
-Must include name.baseName, translated to English if necessary.
-Preserve any codes or IDs verbatim.
-Exclude all URIs or schema references.
-Never interpret mixAndLocationTypes as geography (treat them only as non-geographic tags).
-Do not infer or invent values.`;
-    const modelInput = `${systemPrompt}\nJSON:\n${JSON.stringify(jsonData)}`;
-
-    const { text } = await openaiChat(modelInput, { stream: false });
-    const summary = (text || '').trim();
-    if (!summary) throw new Error('Empty summary from model');
+    const summary = await generateFlowTextSummary(jsonData);
 
     const { error: updateError } = await supabaseClient
       .from(table)

--- a/supabase/functions/webhook_flow_embedding_ft/index.ts
+++ b/supabase/functions/webhook_flow_embedding_ft/index.ts
@@ -3,6 +3,7 @@ import '@supabase/functions-js/edge-runtime.d.ts';
 
 import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
+import { generateFlowMarkdown, normalizeJsonOrdered } from '../_shared/flow_extraction.ts';
 import { supabaseClient } from '../_shared/supabase_client.ts';
 
 interface WebhookPayload {
@@ -617,33 +618,25 @@ Deno.serve(async (req) => {
         throw new Error(`batch index ${index}: Record is missing id or version`);
       }
 
-      const jsonDataRaw = (record as Record<string, any>).json_ordered;
-      // console.log("[webhook_flow_embedding_ft] json_ordered type", {
-      //   index,
-      //   type: typeof jsonDataRaw,
-      //   isString: typeof jsonDataRaw === "string",
-      // });
-      if (typeof jsonDataRaw === 'string') {
-        try {
-          (record as Record<string, any>).json_ordered = JSON.parse(jsonDataRaw);
-        } catch (error) {
-          console.error('[webhook_flow_embedding_ft] json parse failed', {
-            index,
-            message: error instanceof Error ? error.message : String(error),
-          });
-          throw new Error(
-            `batch index ${index}: Failed to parse json_ordered string: ${
-              error instanceof Error ? error.message : 'unknown'
-            }`,
-          );
-        }
+      let jsonData: unknown;
+      try {
+        jsonData = normalizeJsonOrdered((record as Record<string, unknown>).json_ordered);
+      } catch (error) {
+        console.error('[webhook_flow_embedding_ft] json parse failed', {
+          index,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        throw new Error(
+          `batch index ${index}: Failed to parse json_ordered string: ${
+            error instanceof Error ? error.message : 'unknown'
+          }`,
+        );
       }
-      const jsonData = (record as Record<string, any>).json_ordered;
       if (!jsonData) {
         throw new Error(`batch index ${index}: No json_ordered data found in record`);
       }
 
-      const markdown = tidasFlowToMarkdown(jsonData);
+      const markdown = generateFlowMarkdown(jsonData);
       console.log(markdown);
       // console.log("[webhook_flow_embedding_ft] markdown generated", {
       //   index,

--- a/test/dataset_extraction_worker_test.ts
+++ b/test/dataset_extraction_worker_test.ts
@@ -1,0 +1,251 @@
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+
+import { processDatasetExtractionJobs } from '../supabase/functions/_shared/dataset_extraction_worker.ts';
+import {
+  generateFlowMarkdown,
+  normalizeJsonOrdered,
+} from '../supabase/functions/_shared/flow_extraction.ts';
+
+type JsonRecord = Record<string, unknown>;
+type Filter = { field: string; value: unknown };
+
+const FLOW_JSON = {
+  flowDataSet: {
+    flowInformation: {
+      dataSetInformation: {
+        'common:UUID': '97000000-0000-0000-0000-000000000001',
+        name: {
+          baseName: [{ '@xml:lang': 'en', '#text': 'Test flow' }],
+        },
+      },
+    },
+    administrativeInformation: {
+      publicationAndOwnership: {
+        'common:dataSetVersion': '01.00.000',
+      },
+    },
+  },
+};
+
+class FakeSupabase {
+  flows: JsonRecord[] = [];
+  claimedJobs: JsonRecord[] = [];
+  rpcCalls: Array<{ fn: string; args: unknown }> = [];
+
+  rpc(fn: string, args: unknown) {
+    this.rpcCalls.push({ fn, args: structuredClone(args) });
+
+    if (fn === 'cmd_dataset_extraction_claim') {
+      return Promise.resolve({
+        data: {
+          ok: true,
+          data: this.claimedJobs.map((job) => structuredClone(job)),
+        },
+        error: null,
+      });
+    }
+
+    return Promise.resolve({
+      data: { ok: true },
+      error: null,
+    });
+  }
+
+  from(table: string): FakeFlowQuery {
+    if (table !== 'flows') {
+      throw new Error(`unexpected table ${table}`);
+    }
+    return new FakeFlowQuery(this);
+  }
+}
+
+class FakeFlowQuery implements PromiseLike<{ data: unknown; error: unknown }> {
+  private filters: Filter[] = [];
+  private mode: 'select' | 'update' | null = null;
+  private updateValues: JsonRecord = {};
+
+  constructor(private readonly supabase: FakeSupabase) {}
+
+  select(_columns: string): this {
+    this.mode = 'select';
+    return this;
+  }
+
+  update(values: JsonRecord): this {
+    this.mode = 'update';
+    this.updateValues = structuredClone(values);
+    return this;
+  }
+
+  eq(field: string, value: unknown): this {
+    this.filters.push({ field, value });
+    return this;
+  }
+
+  maybeSingle() {
+    const rows = this.matchingRows();
+    return Promise.resolve({
+      data: rows[0] ? structuredClone(rows[0]) : null,
+      error: null,
+    });
+  }
+
+  then<TResult1 = { data: unknown; error: unknown }, TResult2 = never>(
+    onfulfilled?:
+      | ((value: { data: unknown; error: unknown }) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    const result =
+      this.mode === 'update'
+        ? Promise.resolve(this.executeUpdate())
+        : Promise.resolve({ data: null, error: null });
+    return result.then(onfulfilled, onrejected);
+  }
+
+  private matchingRows(): JsonRecord[] {
+    return this.supabase.flows.filter((row) =>
+      this.filters.every((filter) => row[filter.field] === filter.value),
+    );
+  }
+
+  private executeUpdate() {
+    for (const row of this.matchingRows()) {
+      Object.assign(row, structuredClone(this.updateValues));
+    }
+    return { data: null, error: null };
+  }
+}
+
+function buildFlowJob(
+  msgId: number,
+  extractionKind: 'extracted_md' | 'extracted_text',
+  readCt = 1,
+) {
+  return {
+    msg_id: msgId,
+    read_ct: readCt,
+    message: {
+      schema: 'public',
+      table: 'flows',
+      id: '97000000-0000-0000-0000-000000000001',
+      version: '01.00.000',
+      entity_kind: 'flow',
+      extraction_kind: extractionKind,
+      created_at: '2026-05-26T00:00:00Z',
+    },
+  };
+}
+
+Deno.test(
+  'processDatasetExtractionJobs updates flow markdown/text jobs and acks successes',
+  async () => {
+    const supabase = new FakeSupabase();
+    supabase.flows.push({
+      id: '97000000-0000-0000-0000-000000000001',
+      version: '01.00.000',
+      json_ordered: FLOW_JSON,
+    });
+    supabase.claimedJobs = [buildFlowJob(1, 'extracted_md'), buildFlowJob(2, 'extracted_text')];
+
+    const result = await processDatasetExtractionJobs({
+      supabase: supabase as unknown as SupabaseClient,
+      markdownGenerator: () => '# Test flow',
+      textGenerator: async () => 'Test flow summary.',
+    });
+
+    assertEquals(result.claimed, 2);
+    assertEquals(result.acked, 2);
+    assertEquals(supabase.flows[0].extracted_md, '# Test flow');
+    assertEquals(supabase.flows[0].extracted_text, 'Test flow summary.');
+    assertEquals(supabase.rpcCalls.at(-1), {
+      fn: 'cmd_dataset_extraction_ack',
+      args: { p_msg_ids: [1, 2] },
+    });
+  },
+);
+
+Deno.test('processDatasetExtractionJobs leaves transient failures unacked for retry', async () => {
+  const supabase = new FakeSupabase();
+  supabase.flows.push({
+    id: '97000000-0000-0000-0000-000000000001',
+    version: '01.00.000',
+    json_ordered: FLOW_JSON,
+  });
+  supabase.claimedJobs = [buildFlowJob(3, 'extracted_text', 1)];
+
+  const result = await processDatasetExtractionJobs({
+    supabase: supabase as unknown as SupabaseClient,
+    textGenerator: async () => {
+      throw new Error('temporary OpenAI failure');
+    },
+  });
+
+  assertEquals(result.acked, 0);
+  assertEquals(result.results[0].status, 'retry');
+  assertEquals(
+    supabase.rpcCalls.some((call) => call.fn === 'cmd_dataset_extraction_ack'),
+    false,
+  );
+  assertEquals(
+    supabase.rpcCalls.some((call) => call.fn === 'cmd_dataset_extraction_record_failure'),
+    false,
+  );
+});
+
+Deno.test('processDatasetExtractionJobs records terminal retry failures', async () => {
+  const supabase = new FakeSupabase();
+  supabase.flows.push({
+    id: '97000000-0000-0000-0000-000000000001',
+    version: '01.00.000',
+    json_ordered: FLOW_JSON,
+  });
+  supabase.claimedJobs = [buildFlowJob(4, 'extracted_text', 5)];
+
+  const result = await processDatasetExtractionJobs({
+    supabase: supabase as unknown as SupabaseClient,
+    maxReadCount: 5,
+    textGenerator: async () => {
+      throw new Error('terminal OpenAI failure');
+    },
+  });
+
+  assertEquals(result.acked, 0);
+  assertEquals(result.results[0].status, 'failed');
+  assertEquals(supabase.rpcCalls.at(-1)?.fn, 'cmd_dataset_extraction_record_failure');
+});
+
+Deno.test('processDatasetExtractionJobs records process jobs as unsupported in v1', async () => {
+  const supabase = new FakeSupabase();
+  supabase.claimedJobs = [
+    {
+      msg_id: 5,
+      read_ct: 1,
+      message: {
+        schema: 'public',
+        table: 'processes',
+        id: '98000000-0000-0000-0000-000000000001',
+        version: '01.00.000',
+        entity_kind: 'process',
+        extraction_kind: 'extracted_md',
+      },
+    },
+  ];
+
+  const result = await processDatasetExtractionJobs({
+    supabase: supabase as unknown as SupabaseClient,
+  });
+
+  assertEquals(result.acked, 0);
+  assertEquals(result.results[0].status, 'unsupported');
+  assertEquals(supabase.rpcCalls.at(-1)?.fn, 'cmd_dataset_extraction_record_failure');
+});
+
+Deno.test('flow extraction helpers keep legacy string json_ordered payloads compatible', () => {
+  const parsed = normalizeJsonOrdered(JSON.stringify(FLOW_JSON));
+  const markdown = generateFlowMarkdown(parsed);
+
+  assertEquals(markdown.includes('# Test flow'), true);
+  assertEquals(markdown.includes('**Version:** 01.00.000'), true);
+});


### PR DESCRIPTION
Closes #119

## Summary
- Add process_dataset_extraction_jobs Edge Function with service API key auth for compact dataset extraction jobs.
- Add shared worker logic to claim dataset_extraction_jobs, update flow extracted_md/extracted_text, ack successes, and record terminal failures.
- Share flow markdown/text extraction helpers with the legacy flow webhooks so existing full-row webhook payloads remain compatible.

## Key Decisions
- v1 only processes entity_kind=flow; process jobs are recorded as unsupported instead of silently succeeding until the tracked process follow-up is implemented.
- Worker depends on the service-role RPCs introduced in tiangong-lca/database-engine#72.

## Validation
- npm run lint
- npm run check
- deno test --config supabase/functions/deno.json test/dataset_extraction_worker_test.ts

## Risks / Rollback
- No remote deploy was performed from this PR; deploy process_dataset_extraction_jobs before applying the database migration in tiangong-lca/database-engine#72.

## Follow-ups
- Enable process entity handling only after flow canary passes and the database process follow-up is started.

## Workspace Integration
- Workspace integration is still required after this repo change is merged and promoted according to the M2 branch policy.