### PR TITLE
对齐 Hybrid Search 请求参数契约

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-05-26'
-lastReviewedCommit: '1b79d8034e65e44777174a630880d3f41c270464'
+lastReviewedCommit: '27216255c10907f7621013e9ff9bec59f08c85c3'
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 1b79d8034e65e44777174a630880d3f41c270464
+lastReviewedCommit: 27216255c10907f7621013e9ff9bec59f08c85c3
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 1b79d8034e65e44777174a630880d3f41c270464
+lastReviewedCommit: 27216255c10907f7621013e9ff9bec59f08c85c3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-26
-lastReviewedCommit: 1b79d8034e65e44777174a630880d3f41c270464
+lastReviewedCommit: 27216255c10907f7621013e9ff9bec59f08c85c3
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/functions/_shared/hybrid_search_request.ts
+++ b/supabase/functions/_shared/hybrid_search_request.ts
@@ -1,0 +1,172 @@
+export class HybridSearchRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HybridSearchRequestError';
+  }
+}
+
+export interface HybridSearchClientRequest {
+  queryText: string;
+  rpcOptions: HybridSearchRpcOptions;
+}
+
+export interface HybridSearchRpcOptions {
+  filter_condition: string;
+  match_threshold: number;
+  match_count: number;
+  full_text_weight: number;
+  extracted_text_weight: number;
+  semantic_weight: number;
+  rrf_k: number;
+  data_source: string;
+  page_size: number;
+  page_current: number;
+}
+
+export interface HybridSearchRpcRequest extends HybridSearchRpcOptions {
+  query_text: string;
+  query_embedding: string;
+}
+
+const VALID_DATA_SOURCES = new Set(['tg', 'co', 'my', 'te']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseNumber(value: unknown, fieldName: string, fallback: number): number {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+
+  const parsed =
+    typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+
+  if (!Number.isFinite(parsed)) {
+    throw new HybridSearchRequestError(`${fieldName} must be a finite number`);
+  }
+
+  return parsed;
+}
+
+function parsePositiveInteger(value: unknown, fieldName: string, fallback: number): number {
+  const parsed = parseNumber(value, fieldName, fallback);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new HybridSearchRequestError(`${fieldName} must be a positive integer`);
+  }
+
+  return parsed;
+}
+
+function parseNonNegativeNumber(value: unknown, fieldName: string, fallback: number): number {
+  const parsed = parseNumber(value, fieldName, fallback);
+
+  if (parsed < 0) {
+    throw new HybridSearchRequestError(`${fieldName} must be greater than or equal to 0`);
+  }
+
+  return parsed;
+}
+
+function parseMatchThreshold(value: unknown): number {
+  const parsed = parseNumber(value, 'match_threshold', 0.5);
+
+  if (parsed < 0 || parsed > 1) {
+    throw new HybridSearchRequestError('match_threshold must be between 0 and 1');
+  }
+
+  return parsed;
+}
+
+function parseDataSource(value: unknown): string {
+  const dataSource = value === undefined || value === null || value === '' ? 'tg' : String(value);
+
+  if (!VALID_DATA_SOURCES.has(dataSource)) {
+    throw new HybridSearchRequestError('data_source must be one of tg, co, my, or te');
+  }
+
+  return dataSource;
+}
+
+function normalizeFilterCondition(value: unknown): string {
+  if (value === undefined || value === null || value === '') {
+    return '{}';
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return '{}';
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (!isRecord(parsed)) {
+        throw new HybridSearchRequestError('filter_condition must be a JSON object');
+      }
+      return JSON.stringify(parsed);
+    } catch (error) {
+      if (error instanceof HybridSearchRequestError) {
+        throw error;
+      }
+      throw new HybridSearchRequestError('filter_condition must be a valid JSON object string');
+    }
+  }
+
+  if (!isRecord(value)) {
+    throw new HybridSearchRequestError('filter_condition must be a JSON object');
+  }
+
+  return JSON.stringify(value);
+}
+
+export function parseHybridSearchClientRequest(body: unknown): HybridSearchClientRequest {
+  if (!isRecord(body)) {
+    throw new HybridSearchRequestError('request body must be a JSON object');
+  }
+
+  const query = body.query;
+  if (query === undefined || query === null || query === '') {
+    throw new HybridSearchRequestError('Missing query');
+  }
+
+  const queryText = typeof query === 'string' ? query.trim() : String(query).trim();
+  if (!queryText) {
+    throw new HybridSearchRequestError('Missing query');
+  }
+
+  const filterInput = body.filter_condition ?? body.filter;
+
+  return {
+    queryText,
+    rpcOptions: {
+      filter_condition: normalizeFilterCondition(filterInput),
+      match_threshold: parseMatchThreshold(body.match_threshold),
+      match_count: parsePositiveInteger(body.match_count, 'match_count', 20),
+      full_text_weight: parseNonNegativeNumber(body.full_text_weight, 'full_text_weight', 0.3),
+      extracted_text_weight: parseNonNegativeNumber(
+        body.extracted_text_weight,
+        'extracted_text_weight',
+        0.2,
+      ),
+      semantic_weight: parseNonNegativeNumber(body.semantic_weight, 'semantic_weight', 0.5),
+      rrf_k: parsePositiveInteger(body.rrf_k, 'rrf_k', 10),
+      data_source: parseDataSource(body.data_source),
+      page_size: parsePositiveInteger(body.page_size, 'page_size', 10),
+      page_current: parsePositiveInteger(body.page_current, 'page_current', 1),
+    },
+  };
+}
+
+export function buildHybridSearchRpcRequest(
+  queryText: string,
+  queryEmbedding: string,
+  options: HybridSearchRpcOptions,
+): HybridSearchRpcRequest {
+  return {
+    query_text: queryText,
+    query_embedding: queryEmbedding,
+    ...options,
+  };
+}

--- a/supabase/functions/flow_hybrid_search/index.ts
+++ b/supabase/functions/flow_hybrid_search/index.ts
@@ -9,6 +9,10 @@ import {
   HybridSearchQuery,
   sanitizeHybridQueryOutput,
 } from '../_shared/hybrid_query_utils.ts';
+import {
+  buildHybridSearchRpcRequest,
+  parseHybridSearchClientRequest,
+} from '../_shared/hybrid_search_request.ts';
 import { openaiStructuredOutput } from '../_shared/openai_structured.ts';
 import { getRedisClient } from '../_shared/redis_client.ts';
 import { supabaseClient as supabase, supabaseAuthClient } from '../_shared/supabase_client.ts';
@@ -191,12 +195,16 @@ Deno.serve(async (req) => {
 
   console.log('Auth Success:', authResult);
 
-  const { query, filter } = await req.json();
-
-  if (!query) {
-    return new Response('Missing query', { status: 400 });
+  let parsedRequest;
+  try {
+    parsedRequest = parseHybridSearchClientRequest(await req.json());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid request body';
+    return new Response(JSON.stringify({ error: message }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 400,
+    });
   }
-  const queryText = typeof query === 'string' ? query.trim() : String(query);
 
   const rawRes = await openaiStructuredOutput<HybridSearchQuery>({
     schemaName: 'flow_hybrid_search_queries',
@@ -204,11 +212,11 @@ Deno.serve(async (req) => {
     systemPrompt: `Field: Life Cycle Assessment (LCA)
 Task: Transform description of flows into three specific queries: SemanticQueryEN, FulltextQueryEN and FulltextQueryZH.
 ${HYBRID_SYNONYM_RULES}`,
-    userPrompt: `Flow description: ${queryText}`,
+    userPrompt: `Flow description: ${parsedRequest.queryText}`,
     options: { model: openai_chat_model, temperature: 0 },
   });
 
-  const normalizedRes = sanitizeHybridQueryOutput(rawRes, queryText);
+  const normalizedRes = sanitizeHybridQueryOutput(rawRes, parsedRequest.queryText);
   const semanticQueryEn = normalizedRes.semantic_query_en;
   const fulltextQueryZh = normalizedRes.fulltext_query_zh;
   const fulltextQueryEn = normalizedRes.fulltext_query_en;
@@ -225,14 +233,11 @@ ${HYBRID_SYNONYM_RULES}`,
   const embedding = await generateEmbedding(semanticQueryEn);
   const vectorStr = `[${embedding.join(',')}]`;
 
-  const filterCondition =
-    filter !== undefined ? (typeof filter === 'string' ? filter : JSON.stringify(filter)) : {};
-
-  const requestBody = {
-    query_text: queryFulltextString,
-    query_embedding: vectorStr,
-    filter_condition: filterCondition,
-  };
+  const requestBody = buildHybridSearchRpcRequest(
+    queryFulltextString,
+    vectorStr,
+    parsedRequest.rpcOptions,
+  );
 
   const { data, error } = await supabase.rpc('hybrid_search_flows', requestBody);
 

--- a/supabase/functions/lifecyclemodel_hybrid_search/index.ts
+++ b/supabase/functions/lifecyclemodel_hybrid_search/index.ts
@@ -9,6 +9,10 @@ import {
   HybridSearchQuery,
   sanitizeHybridQueryOutput,
 } from '../_shared/hybrid_query_utils.ts';
+import {
+  buildHybridSearchRpcRequest,
+  parseHybridSearchClientRequest,
+} from '../_shared/hybrid_search_request.ts';
 import { openaiStructuredOutput } from '../_shared/openai_structured.ts';
 import { getRedisClient } from '../_shared/redis_client.ts';
 import { supabaseClient as supabase, supabaseAuthClient } from '../_shared/supabase_client.ts';
@@ -191,12 +195,16 @@ Deno.serve(async (req) => {
 
   console.log('Auth Success:', authResult);
 
-  const { query, filter } = await req.json();
-
-  if (!query) {
-    return new Response('Missing query', { status: 400 });
+  let parsedRequest;
+  try {
+    parsedRequest = parseHybridSearchClientRequest(await req.json());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid request body';
+    return new Response(JSON.stringify({ error: message }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 400,
+    });
   }
-  const queryText = typeof query === 'string' ? query.trim() : String(query);
 
   const rawRes = await openaiStructuredOutput<HybridSearchQuery>({
     schemaName: 'lifecyclemodel_hybrid_search_queries',
@@ -204,11 +212,11 @@ Deno.serve(async (req) => {
     systemPrompt: `Field: Life Cycle Assessment (LCA)
 Task: Transform description of lifecycle models into three specific queries: SemanticQueryEN, FulltextQueryEN and FulltextQueryZH.
 ${HYBRID_SYNONYM_RULES}`,
-    userPrompt: `Lifecycle model description: ${queryText}`,
+    userPrompt: `Lifecycle model description: ${parsedRequest.queryText}`,
     options: { model: openai_chat_model, temperature: 0 },
   });
 
-  const normalizedRes = sanitizeHybridQueryOutput(rawRes, queryText);
+  const normalizedRes = sanitizeHybridQueryOutput(rawRes, parsedRequest.queryText);
   const semanticQueryEn = normalizedRes.semantic_query_en;
   const fulltextQueryZh = normalizedRes.fulltext_query_zh;
   const fulltextQueryEn = normalizedRes.fulltext_query_en;
@@ -225,14 +233,11 @@ ${HYBRID_SYNONYM_RULES}`,
   const embedding = await generateEmbedding(semanticQueryEn);
   const vectorStr = `[${embedding.join(',')}]`;
 
-  const filterCondition =
-    filter !== undefined ? (typeof filter === 'string' ? filter : JSON.stringify(filter)) : {};
-
-  const requestBody = {
-    query_text: queryFulltextString,
-    query_embedding: vectorStr,
-    filter_condition: filterCondition,
-  };
+  const requestBody = buildHybridSearchRpcRequest(
+    queryFulltextString,
+    vectorStr,
+    parsedRequest.rpcOptions,
+  );
 
   // console.log('LLM structured res:', JSON.stringify(res, null, 2));
   // console.log('combinedFulltextQueries:', combinedFulltextQueries);

--- a/supabase/functions/process_hybrid_search/index.ts
+++ b/supabase/functions/process_hybrid_search/index.ts
@@ -10,6 +10,10 @@ import {
   HybridSearchQuery,
   sanitizeHybridQueryOutput,
 } from '../_shared/hybrid_query_utils.ts';
+import {
+  buildHybridSearchRpcRequest,
+  parseHybridSearchClientRequest,
+} from '../_shared/hybrid_search_request.ts';
 import { openaiStructuredOutput } from '../_shared/openai_structured.ts';
 import { getRedisClient } from '../_shared/redis_client.ts';
 import { supabaseClient as supabase, supabaseAuthClient } from '../_shared/supabase_client.ts';
@@ -194,12 +198,16 @@ Deno.serve(async (req) => {
 
   console.log('Auth Success:', authResult);
 
-  const { query, filter } = await req.json();
-
-  if (!query) {
-    return new Response('Missing query', { status: 400 });
+  let parsedRequest;
+  try {
+    parsedRequest = parseHybridSearchClientRequest(await req.json());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid request body';
+    return new Response(JSON.stringify({ error: message }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 400,
+    });
   }
-  const queryText = typeof query === 'string' ? query.trim() : String(query);
 
   const rawRes = await openaiStructuredOutput<HybridSearchQuery>({
     schemaName: 'process_hybrid_search_queries',
@@ -207,11 +215,11 @@ Deno.serve(async (req) => {
     systemPrompt: `Field: Life Cycle Assessment (LCA)
 Task: Transform description of processes into three specific queries: SemanticQueryEN, FulltextQueryEN and FulltextQueryZH.
 ${HYBRID_SYNONYM_RULES}`,
-    userPrompt: `Process description: ${queryText}`,
+    userPrompt: `Process description: ${parsedRequest.queryText}`,
     options: { model: openai_chat_model, temperature: 0 },
   });
 
-  const normalizedRes = sanitizeHybridQueryOutput(rawRes, queryText);
+  const normalizedRes = sanitizeHybridQueryOutput(rawRes, parsedRequest.queryText);
   const semanticQueryEn = normalizedRes.semantic_query_en;
   const fulltextQueryZh = normalizedRes.fulltext_query_zh;
   const fulltextQueryEn = normalizedRes.fulltext_query_en;
@@ -228,14 +236,10 @@ ${HYBRID_SYNONYM_RULES}`,
   const embedding = await generateEmbedding(semanticQueryEn);
   const vectorStr = `[${embedding.join(',')}]`;
 
-  const filterCondition =
-    filter !== undefined ? (typeof filter === 'string' ? filter : JSON.stringify(filter)) : {};
-
-  const { data, error } = await supabase.rpc('hybrid_search_processes', {
-    query_text: queryFulltextString,
-    query_embedding: vectorStr,
-    filter_condition: filterCondition,
-  });
+  const { data, error } = await supabase.rpc(
+    'hybrid_search_processes',
+    buildHybridSearchRpcRequest(queryFulltextString, vectorStr, parsedRequest.rpcOptions),
+  );
 
   if (error) {
     console.error('Hybrid search error:', error);

--- a/test/hybrid_search_request_test.ts
+++ b/test/hybrid_search_request_test.ts
@@ -1,0 +1,119 @@
+import { assertEquals, assertInstanceOf, assertThrows } from 'jsr:@std/assert';
+
+import {
+  buildHybridSearchRpcRequest,
+  HybridSearchRequestError,
+  parseHybridSearchClientRequest,
+} from '../supabase/functions/_shared/hybrid_search_request.ts';
+
+Deno.test('parseHybridSearchClientRequest normalizes full hybrid search options', () => {
+  const parsed = parseHybridSearchClientRequest({
+    query: '  electricity  ',
+    filter: { flowType: 'Elementary flow' },
+    data_source: 'my',
+    page_size: '25',
+    page_current: 3,
+    match_threshold: '0.42',
+    match_count: '50',
+    full_text_weight: '0.4',
+    extracted_text_weight: '0.1',
+    semantic_weight: '0.7',
+    rrf_k: '60',
+  });
+
+  assertEquals(parsed.queryText, 'electricity');
+  assertEquals(parsed.rpcOptions, {
+    filter_condition: '{"flowType":"Elementary flow"}',
+    match_threshold: 0.42,
+    match_count: 50,
+    full_text_weight: 0.4,
+    extracted_text_weight: 0.1,
+    semantic_weight: 0.7,
+    rrf_k: 60,
+    data_source: 'my',
+    page_size: 25,
+    page_current: 3,
+  });
+});
+
+Deno.test('parseHybridSearchClientRequest accepts explicit filter_condition string', () => {
+  const parsed = parseHybridSearchClientRequest({
+    query: 'steel',
+    filter_condition: '{"classification":["materials"]}',
+  });
+
+  assertEquals(parsed.rpcOptions.filter_condition, '{"classification":["materials"]}');
+  assertEquals(parsed.rpcOptions.data_source, 'tg');
+  assertEquals(parsed.rpcOptions.page_size, 10);
+  assertEquals(parsed.rpcOptions.page_current, 1);
+});
+
+Deno.test('parseHybridSearchClientRequest rejects invalid filter_condition JSON', () => {
+  const error = assertThrows(
+    () =>
+      parseHybridSearchClientRequest({
+        query: 'steel',
+        filter_condition: 'classification = materials',
+      }),
+    HybridSearchRequestError,
+  );
+
+  assertEquals(error.message, 'filter_condition must be a valid JSON object string');
+});
+
+Deno.test('parseHybridSearchClientRequest rejects unsupported data_source', () => {
+  const error = assertThrows(
+    () =>
+      parseHybridSearchClientRequest({
+        query: 'steel',
+        data_source: 'public',
+      }),
+    HybridSearchRequestError,
+  );
+
+  assertEquals(error.message, 'data_source must be one of tg, co, my, or te');
+});
+
+Deno.test('parseHybridSearchClientRequest rejects non-positive pagination', () => {
+  const error = assertThrows(
+    () =>
+      parseHybridSearchClientRequest({
+        query: 'steel',
+        page_size: 0,
+      }),
+    HybridSearchRequestError,
+  );
+
+  assertEquals(error.message, 'page_size must be a positive integer');
+});
+
+Deno.test('buildHybridSearchRpcRequest builds the database RPC payload', () => {
+  const parsed = parseHybridSearchClientRequest({
+    query: 'steel',
+    filter: {},
+    data_source: 'co',
+  });
+
+  const payload = buildHybridSearchRpcRequest('[steel]', '[0.1,0.2]', parsed.rpcOptions);
+
+  assertEquals(payload, {
+    query_text: '[steel]',
+    query_embedding: '[0.1,0.2]',
+    filter_condition: '{}',
+    match_threshold: 0.5,
+    match_count: 20,
+    full_text_weight: 0.3,
+    extracted_text_weight: 0.2,
+    semantic_weight: 0.5,
+    rrf_k: 10,
+    data_source: 'co',
+    page_size: 10,
+    page_current: 1,
+  });
+});
+
+Deno.test('HybridSearchRequestError keeps its concrete error type', () => {
+  const error = assertThrows(() => parseHybridSearchClientRequest(null), HybridSearchRequestError);
+
+  assertInstanceOf(error, HybridSearchRequestError);
+});


### PR DESCRIPTION
## 摘要
- 新增共享 `hybrid_search_request` normalizer，统一三个 hybrid search Edge Function 的请求解析。
- `flow_hybrid_search`、`process_hybrid_search`、`lifecyclemodel_hybrid_search` 现在一致传递 `filter_condition`、`data_source`、分页、match 参数和权重参数到 DB RPC。
- `filter` / `filter_condition` 都收敛成 JSON object string，匹配 database-engine 新的 text-source hybrid search contract。
- 增加 Deno tests 覆盖 request mapping、默认值和无效参数。

## 关键说明
- RPC 名称仍然使用 `hybrid_search_flows` / `hybrid_search_processes` / `hybrid_search_lifecyclemodels`；database-engine#82 已经把这些 RPC 内部迁到 text-source full-text + semantic vector。
- 当前 DB hybrid RPC 不暴露 `state_code` 参数；本 PR 不向 RPC 传递 unsupported argument，避免 PostgREST RPC 签名不匹配。需要 `state_code_filter` 的 hybrid search 应作为 database-engine contract follow-up 单独处理。

## 验证
- `npm run lint`
- `npm run check`
- `deno test --config supabase/functions/deno.json test/hybrid_search_request_test.ts`
- `deno check --config supabase/functions/deno.json supabase/functions/_shared/hybrid_search_request.ts test/hybrid_search_request_test.ts supabase/functions/flow_hybrid_search/index.ts supabase/functions/process_hybrid_search/index.ts supabase/functions/lifecyclemodel_hybrid_search/index.ts`
- `./scripts/docpact lint --root . --worktree --mode enforce --output /tmp/edge-functions-docpact-hybrid-final.json`

## 部署
- 本 PR 合并到 `dev` 后需要部署 `flow_hybrid_search`、`process_hybrid_search`、`lifecyclemodel_hybrid_search`。

Closes #127