### PR TITLE
fix: preserve hybrid search text recall

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-05-26'
-lastReviewedCommit: '27216255c10907f7621013e9ff9bec59f08c85c3'
+lastReviewedAt: "2026-05-27"
+lastReviewedCommit: "1e3474675a0d1aa1271d337e2f6ce2aa704f9f34"
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 27216255c10907f7621013e9ff9bec59f08c85c3
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 1e3474675a0d1aa1271d337e2f6ce2aa704f9f34
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 27216255c10907f7621013e9ff9bec59f08c85c3
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 1e3474675a0d1aa1271d337e2f6ce2aa704f9f34
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-26
-lastReviewedCommit: 27216255c10907f7621013e9ff9bec59f08c85c3
+lastReviewedAt: 2026-05-27
+lastReviewedCommit: 1e3474675a0d1aa1271d337e2f6ce2aa704f9f34
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/functions/_shared/dataset_extraction_worker.ts
+++ b/supabase/functions/_shared/dataset_extraction_worker.ts
@@ -1,11 +1,6 @@
 import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import {
-  generateFlowMarkdown,
-  generateFlowTextSummary,
-  normalizeJsonOrdered,
-} from './flow_extraction.ts';
-import type { OpenAIChatResult } from './openai_chat.ts';
+import { generateFlowMarkdown, normalizeJsonOrdered } from './flow_extraction.ts';
 
 export type DatasetExtractionKind = 'extracted_md' | 'extracted_text';
 export type DatasetEntityKind = 'flow' | 'process';
@@ -51,10 +46,6 @@ export interface DatasetExtractionWorkerOptions {
   visibilityTimeoutSeconds?: number;
   maxReadCount?: number;
   markdownGenerator?: (flowJson: unknown) => string;
-  textGenerator?: (
-    flowJson: unknown,
-    chat?: (input: string, options?: { stream?: boolean }) => Promise<OpenAIChatResult>,
-  ) => Promise<string>;
 }
 
 interface RpcEnvelope<T> {
@@ -109,7 +100,7 @@ function assertFlowJob(job: ClaimedDatasetExtractionJob): void {
       code: 'UNSUPPORTED_ENTITY_KIND',
     });
   }
-  if (message.extraction_kind !== 'extracted_md' && message.extraction_kind !== 'extracted_text') {
+  if (message.extraction_kind !== 'extracted_md') {
     throw Object.assign(new Error('Unsupported dataset extraction kind'), {
       code: 'UNSUPPORTED_EXTRACTION_KIND',
     });
@@ -177,7 +168,7 @@ async function updateFlowExtraction(
   supabase: SupabaseClient,
   id: string,
   version: string,
-  values: { extracted_md?: string; extracted_text?: string },
+  values: { extracted_md: string },
 ): Promise<void> {
   const { error } = await supabase.from('flows').update(values).eq('id', id).eq('version', version);
   if (error) throw error;
@@ -187,7 +178,6 @@ async function processFlowJob(
   supabase: SupabaseClient,
   job: ClaimedDatasetExtractionJob,
   markdownGenerator: (flowJson: unknown) => string,
-  textGenerator: (flowJson: unknown) => Promise<string>,
 ): Promise<void> {
   assertFlowJob(job);
   const { id, version, extraction_kind } = job.message;
@@ -203,9 +193,6 @@ async function processFlowJob(
     await updateFlowExtraction(supabase, id, version, { extracted_md: markdown });
     return;
   }
-
-  const summary = await textGenerator(flowJson);
-  await updateFlowExtraction(supabase, id, version, { extracted_text: summary });
 }
 
 export async function processDatasetExtractionJobs(
@@ -215,7 +202,6 @@ export async function processDatasetExtractionJobs(
   const visibilityTimeoutSeconds = positiveInteger(options.visibilityTimeoutSeconds, 300, 3600);
   const maxReadCount = positiveInteger(options.maxReadCount, 5, 100);
   const markdownGenerator = options.markdownGenerator ?? generateFlowMarkdown;
-  const textGenerator = options.textGenerator ?? generateFlowTextSummary;
 
   const { data, error } = await options.supabase.rpc('cmd_dataset_extraction_claim', {
     p_qty: batchSize,
@@ -250,9 +236,7 @@ export async function processDatasetExtractionJobs(
     };
 
     try {
-      await processFlowJob(options.supabase, job, markdownGenerator, (flowJson) =>
-        textGenerator(flowJson),
-      );
+      await processFlowJob(options.supabase, job, markdownGenerator);
       ackIds.push(job.msg_id);
       const result = {
         ...baseLog,
@@ -264,7 +248,10 @@ export async function processDatasetExtractionJobs(
     } catch (caught) {
       const code = errorCode(caught);
       const message = errorMessage(caught);
-      const terminal = code === 'UNSUPPORTED_ENTITY_KIND' || job.read_ct >= maxReadCount;
+      const terminal =
+        code === 'UNSUPPORTED_ENTITY_KIND' ||
+        code === 'UNSUPPORTED_EXTRACTION_KIND' ||
+        job.read_ct >= maxReadCount;
 
       if (terminal) {
         await recordTerminalFailure(options.supabase, job, code, message);
@@ -273,7 +260,7 @@ export async function processDatasetExtractionJobs(
       const result = {
         ...baseLog,
         status:
-          code === 'UNSUPPORTED_ENTITY_KIND'
+          code === 'UNSUPPORTED_ENTITY_KIND' || code === 'UNSUPPORTED_EXTRACTION_KIND'
             ? ('unsupported' as const)
             : terminal
               ? ('failed' as const)

--- a/supabase/functions/_shared/hybrid_query_utils.ts
+++ b/supabase/functions/_shared/hybrid_query_utils.ts
@@ -195,6 +195,8 @@ export function sanitizeHybridQueryOutput(
   );
 
   const normalizedUserQuery = normalizeTerm(userQuery);
+  const userQueryHasCjk = CJK_PATTERN.test(normalizedUserQuery);
+  const userQueryHasLatin = LATIN_CHAR_PATTERN.test(normalizedUserQuery);
 
   if (fulltextQueryEn.length === 0 && semanticQueryEn) {
     fulltextQueryEn = [semanticQueryEn];
@@ -203,16 +205,31 @@ export function sanitizeHybridQueryOutput(
     fulltextQueryZh = [normalizedUserQuery];
   }
 
+  if (normalizedUserQuery && (userQueryHasLatin || CAS_PATTERN.test(normalizedUserQuery))) {
+    fulltextQueryEn = prependSeedTerm(fulltextQueryEn, normalizedUserQuery);
+  }
+  if (normalizedUserQuery && userQueryHasCjk) {
+    fulltextQueryZh = prependSeedTerm(fulltextQueryZh, normalizedUserQuery);
+  }
+
   const enSeed = semanticQueryEn || fulltextQueryEn[0] || '';
+  const rawEnSeed =
+    normalizedUserQuery && (userQueryHasLatin || CAS_PATTERN.test(normalizedUserQuery))
+      ? normalizedUserQuery
+      : '';
   const zhSeed =
     normalizedUserQuery && CJK_PATTERN.test(normalizedUserQuery)
       ? normalizedUserQuery
       : fulltextQueryZh[0] || '';
-  const enRest = fulltextQueryEn.filter((term) => term.toLowerCase() !== enSeed.toLowerCase());
+  const enRest = fulltextQueryEn.filter(
+    (term) =>
+      term.toLowerCase() !== enSeed.toLowerCase() &&
+      (!rawEnSeed || term.toLowerCase() !== rawEnSeed.toLowerCase()),
+  );
   const zhRest = fulltextQueryZh.filter((term) => term !== zhSeed);
   const sortedEnRest = sortTermsDeterministically(dedupeNearDuplicates(enRest), 'en');
   const sortedZhRest = sortTermsDeterministically(dedupeNearDuplicates(zhRest), 'zh-Hans-CN');
-  fulltextQueryEn = enSeed ? [enSeed, ...sortedEnRest] : sortedEnRest;
+  fulltextQueryEn = uniqueTerms([enSeed, rawEnSeed, ...sortedEnRest].filter(Boolean));
   fulltextQueryZh = zhSeed ? [zhSeed, ...sortedZhRest] : sortedZhRest;
 
   return {
@@ -220,4 +237,11 @@ export function sanitizeHybridQueryOutput(
     fulltext_query_en: fulltextQueryEn.slice(0, 6),
     fulltext_query_zh: fulltextQueryZh.slice(0, 6),
   };
+}
+
+export function buildHybridFulltextQueryString(query: HybridSearchQuery): string {
+  return [...query.fulltext_query_zh, ...query.fulltext_query_en]
+    .filter((term) => term.trim().length > 0)
+    .map((term) => `(${term})`)
+    .join(' OR ');
 }

--- a/supabase/functions/flow_hybrid_search/index.ts
+++ b/supabase/functions/flow_hybrid_search/index.ts
@@ -4,6 +4,7 @@ import { InvokeEndpointCommand, SageMakerRuntimeClient } from '@aws-sdk/client-s
 import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
 import {
+  buildHybridFulltextQueryString,
   HYBRID_SYNONYM_RULES,
   hybridQuerySchema,
   HybridSearchQuery,
@@ -225,10 +226,7 @@ ${HYBRID_SYNONYM_RULES}`,
     throw new Error('OpenAI structured output missing semantic_query_en');
   }
 
-  const combinedFulltextQueries = [...fulltextQueryZh, ...fulltextQueryEn].map(
-    (query) => `(${query})`,
-  );
-  const queryFulltextString = combinedFulltextQueries.join(' OR ');
+  const queryFulltextString = buildHybridFulltextQueryString(normalizedRes);
 
   const embedding = await generateEmbedding(semanticQueryEn);
   const vectorStr = `[${embedding.join(',')}]`;
@@ -239,15 +237,56 @@ ${HYBRID_SYNONYM_RULES}`,
     parsedRequest.rpcOptions,
   );
 
-  const { data, error } = await supabase.rpc('hybrid_search_flows', requestBody);
+  const rpcLogBase = {
+    function: 'flow_hybrid_search',
+    entity_kind: 'flow',
+    query_raw: parsedRequest.queryText,
+    semantic_query_en: semanticQueryEn,
+    fulltext_query_en: fulltextQueryEn,
+    fulltext_query_zh: fulltextQueryZh,
+    query_fulltext_string: queryFulltextString,
+    match_threshold: requestBody.match_threshold,
+    data_source: requestBody.data_source,
+  };
+  const rpcStartedAt = Date.now();
+  console.log('[hybrid_search]', { ...rpcLogBase, stage: 'rpc_start' });
+
+  let { data, error } = await supabase.rpc('hybrid_search_flows', requestBody);
+  let fallbackUsed = false;
+
+  if (!error && Array.isArray(data) && data.length === 0 && requestBody.match_threshold > 0) {
+    fallbackUsed = true;
+    const fallbackRequestBody = { ...requestBody, match_threshold: 0 };
+    console.log('[hybrid_search]', {
+      ...rpcLogBase,
+      stage: 'rpc_empty_fallback',
+      match_threshold: fallbackRequestBody.match_threshold,
+      duration_ms: Date.now() - rpcStartedAt,
+    });
+    ({ data, error } = await supabase.rpc('hybrid_search_flows', fallbackRequestBody));
+  }
 
   if (error) {
-    console.error('Hybrid search error:', error);
+    console.error('[hybrid_search]', {
+      ...rpcLogBase,
+      stage: 'rpc_error',
+      duration_ms: Date.now() - rpcStartedAt,
+      error_code: error.code ?? 'HYBRID_SEARCH_RPC_ERROR',
+      error_message: error.message,
+      fallback_used: fallbackUsed,
+    });
     return new Response(JSON.stringify({ error: error.message }), {
       headers: { 'Content-Type': 'application/json' },
       status: 500,
     });
   }
+  console.log('[hybrid_search]', {
+    ...rpcLogBase,
+    stage: 'rpc_success',
+    duration_ms: Date.now() - rpcStartedAt,
+    result_count: Array.isArray(data) ? data.length : 0,
+    fallback_used: fallbackUsed,
+  });
   if (data) {
     if (data.length > 0) {
       return new Response(

--- a/supabase/functions/lifecyclemodel_hybrid_search/index.ts
+++ b/supabase/functions/lifecyclemodel_hybrid_search/index.ts
@@ -4,6 +4,7 @@ import { InvokeEndpointCommand, SageMakerRuntimeClient } from '@aws-sdk/client-s
 import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
 import {
+  buildHybridFulltextQueryString,
   HYBRID_SYNONYM_RULES,
   hybridQuerySchema,
   HybridSearchQuery,
@@ -225,10 +226,7 @@ ${HYBRID_SYNONYM_RULES}`,
     throw new Error('OpenAI structured output missing semantic_query_en');
   }
 
-  const combinedFulltextQueries = [...fulltextQueryZh, ...fulltextQueryEn].map(
-    (query) => `(${query})`,
-  );
-  const queryFulltextString = combinedFulltextQueries.join(' OR ');
+  const queryFulltextString = buildHybridFulltextQueryString(normalizedRes);
 
   const embedding = await generateEmbedding(semanticQueryEn);
   const vectorStr = `[${embedding.join(',')}]`;
@@ -239,21 +237,56 @@ ${HYBRID_SYNONYM_RULES}`,
     parsedRequest.rpcOptions,
   );
 
-  // console.log('LLM structured res:', JSON.stringify(res, null, 2));
-  // console.log('combinedFulltextQueries:', combinedFulltextQueries);
-  // console.log('queryFulltextString.len:', queryFulltextString.length);
-  // console.log('semanticQueryEn:', semanticQueryEn);
-  // console.log('requestBody:', JSON.stringify(requestBody, null, 2));
+  const rpcLogBase = {
+    function: 'lifecyclemodel_hybrid_search',
+    entity_kind: 'lifecyclemodel',
+    query_raw: parsedRequest.queryText,
+    semantic_query_en: semanticQueryEn,
+    fulltext_query_en: fulltextQueryEn,
+    fulltext_query_zh: fulltextQueryZh,
+    query_fulltext_string: queryFulltextString,
+    match_threshold: requestBody.match_threshold,
+    data_source: requestBody.data_source,
+  };
+  const rpcStartedAt = Date.now();
+  console.log('[hybrid_search]', { ...rpcLogBase, stage: 'rpc_start' });
 
-  const { data, error } = await supabase.rpc('hybrid_search_lifecyclemodels', requestBody);
+  let { data, error } = await supabase.rpc('hybrid_search_lifecyclemodels', requestBody);
+  let fallbackUsed = false;
+
+  if (!error && Array.isArray(data) && data.length === 0 && requestBody.match_threshold > 0) {
+    fallbackUsed = true;
+    const fallbackRequestBody = { ...requestBody, match_threshold: 0 };
+    console.log('[hybrid_search]', {
+      ...rpcLogBase,
+      stage: 'rpc_empty_fallback',
+      match_threshold: fallbackRequestBody.match_threshold,
+      duration_ms: Date.now() - rpcStartedAt,
+    });
+    ({ data, error } = await supabase.rpc('hybrid_search_lifecyclemodels', fallbackRequestBody));
+  }
 
   if (error) {
-    console.error('Hybrid search error:', error);
+    console.error('[hybrid_search]', {
+      ...rpcLogBase,
+      stage: 'rpc_error',
+      duration_ms: Date.now() - rpcStartedAt,
+      error_code: error.code ?? 'HYBRID_SEARCH_RPC_ERROR',
+      error_message: error.message,
+      fallback_used: fallbackUsed,
+    });
     return new Response(JSON.stringify({ error: error.message }), {
       headers: { 'Content-Type': 'application/json' },
       status: 500,
     });
   }
+  console.log('[hybrid_search]', {
+    ...rpcLogBase,
+    stage: 'rpc_success',
+    duration_ms: Date.now() - rpcStartedAt,
+    result_count: Array.isArray(data) ? data.length : 0,
+    fallback_used: fallbackUsed,
+  });
   if (data) {
     if (data.length > 0) {
       return new Response(

--- a/supabase/functions/process_hybrid_search/index.ts
+++ b/supabase/functions/process_hybrid_search/index.ts
@@ -5,6 +5,7 @@ import { InvokeEndpointCommand, SageMakerRuntimeClient } from '@aws-sdk/client-s
 import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
 import {
+  buildHybridFulltextQueryString,
   HYBRID_SYNONYM_RULES,
   hybridQuerySchema,
   HybridSearchQuery,
@@ -228,26 +229,67 @@ ${HYBRID_SYNONYM_RULES}`,
     throw new Error('OpenAI structured output missing semantic_query_en');
   }
 
-  const combinedFulltextQueries = [...fulltextQueryZh, ...fulltextQueryEn].map(
-    (query) => `(${query})`,
-  );
-  const queryFulltextString = combinedFulltextQueries.join(' OR ');
+  const queryFulltextString = buildHybridFulltextQueryString(normalizedRes);
 
   const embedding = await generateEmbedding(semanticQueryEn);
   const vectorStr = `[${embedding.join(',')}]`;
 
-  const { data, error } = await supabase.rpc(
-    'hybrid_search_processes',
-    buildHybridSearchRpcRequest(queryFulltextString, vectorStr, parsedRequest.rpcOptions),
+  const requestBody = buildHybridSearchRpcRequest(
+    queryFulltextString,
+    vectorStr,
+    parsedRequest.rpcOptions,
   );
 
+  const rpcLogBase = {
+    function: 'process_hybrid_search',
+    entity_kind: 'process',
+    query_raw: parsedRequest.queryText,
+    semantic_query_en: semanticQueryEn,
+    fulltext_query_en: fulltextQueryEn,
+    fulltext_query_zh: fulltextQueryZh,
+    query_fulltext_string: queryFulltextString,
+    match_threshold: requestBody.match_threshold,
+    data_source: requestBody.data_source,
+  };
+  const rpcStartedAt = Date.now();
+  console.log('[hybrid_search]', { ...rpcLogBase, stage: 'rpc_start' });
+
+  let { data, error } = await supabase.rpc('hybrid_search_processes', requestBody);
+  let fallbackUsed = false;
+
+  if (!error && Array.isArray(data) && data.length === 0 && requestBody.match_threshold > 0) {
+    fallbackUsed = true;
+    const fallbackRequestBody = { ...requestBody, match_threshold: 0 };
+    console.log('[hybrid_search]', {
+      ...rpcLogBase,
+      stage: 'rpc_empty_fallback',
+      match_threshold: fallbackRequestBody.match_threshold,
+      duration_ms: Date.now() - rpcStartedAt,
+    });
+    ({ data, error } = await supabase.rpc('hybrid_search_processes', fallbackRequestBody));
+  }
+
   if (error) {
-    console.error('Hybrid search error:', error);
+    console.error('[hybrid_search]', {
+      ...rpcLogBase,
+      stage: 'rpc_error',
+      duration_ms: Date.now() - rpcStartedAt,
+      error_code: error.code ?? 'HYBRID_SEARCH_RPC_ERROR',
+      error_message: error.message,
+      fallback_used: fallbackUsed,
+    });
     return new Response(JSON.stringify({ error: error.message }), {
       headers: { 'Content-Type': 'application/json' },
       status: 500,
     });
   }
+  console.log('[hybrid_search]', {
+    ...rpcLogBase,
+    stage: 'rpc_success',
+    duration_ms: Date.now() - rpcStartedAt,
+    result_count: Array.isArray(data) ? data.length : 0,
+    fallback_used: fallbackUsed,
+  });
   if (data) {
     if (data.length > 0) {
       return new Response(

--- a/test/dataset_extraction_worker_test.ts
+++ b/test/dataset_extraction_worker_test.ts
@@ -139,7 +139,7 @@ function buildFlowJob(
 }
 
 Deno.test(
-  'processDatasetExtractionJobs updates flow markdown/text jobs and acks successes',
+  'processDatasetExtractionJobs updates flow markdown jobs and acks successes',
   async () => {
     const supabase = new FakeSupabase();
     supabase.flows.push({
@@ -147,21 +147,20 @@ Deno.test(
       version: '01.00.000',
       json_ordered: FLOW_JSON,
     });
-    supabase.claimedJobs = [buildFlowJob(1, 'extracted_md'), buildFlowJob(2, 'extracted_text')];
+    supabase.claimedJobs = [buildFlowJob(1, 'extracted_md')];
 
     const result = await processDatasetExtractionJobs({
       supabase: supabase as unknown as SupabaseClient,
       markdownGenerator: () => '# Test flow',
-      textGenerator: async () => 'Test flow summary.',
     });
 
-    assertEquals(result.claimed, 2);
-    assertEquals(result.acked, 2);
+    assertEquals(result.claimed, 1);
+    assertEquals(result.acked, 1);
     assertEquals(supabase.flows[0].extracted_md, '# Test flow');
-    assertEquals(supabase.flows[0].extracted_text, 'Test flow summary.');
+    assertEquals('extracted_text' in supabase.flows[0], false);
     assertEquals(supabase.rpcCalls.at(-1), {
       fn: 'cmd_dataset_extraction_ack',
-      args: { p_msg_ids: [1, 2] },
+      args: { p_msg_ids: [1] },
     });
   },
 );
@@ -173,12 +172,12 @@ Deno.test('processDatasetExtractionJobs leaves transient failures unacked for re
     version: '01.00.000',
     json_ordered: FLOW_JSON,
   });
-  supabase.claimedJobs = [buildFlowJob(3, 'extracted_text', 1)];
+  supabase.claimedJobs = [buildFlowJob(3, 'extracted_md', 1)];
 
   const result = await processDatasetExtractionJobs({
     supabase: supabase as unknown as SupabaseClient,
-    textGenerator: async () => {
-      throw new Error('temporary OpenAI failure');
+    markdownGenerator: () => {
+      throw new Error('temporary markdown failure');
     },
   });
 
@@ -201,18 +200,32 @@ Deno.test('processDatasetExtractionJobs records terminal retry failures', async 
     version: '01.00.000',
     json_ordered: FLOW_JSON,
   });
-  supabase.claimedJobs = [buildFlowJob(4, 'extracted_text', 5)];
+  supabase.claimedJobs = [buildFlowJob(4, 'extracted_md', 5)];
 
   const result = await processDatasetExtractionJobs({
     supabase: supabase as unknown as SupabaseClient,
     maxReadCount: 5,
-    textGenerator: async () => {
-      throw new Error('terminal OpenAI failure');
+    markdownGenerator: () => {
+      throw new Error('terminal markdown failure');
     },
   });
 
   assertEquals(result.acked, 0);
   assertEquals(result.results[0].status, 'failed');
+  assertEquals(supabase.rpcCalls.at(-1)?.fn, 'cmd_dataset_extraction_record_failure');
+});
+
+Deno.test('processDatasetExtractionJobs records extracted_text jobs as unsupported', async () => {
+  const supabase = new FakeSupabase();
+  supabase.claimedJobs = [buildFlowJob(6, 'extracted_text', 1)];
+
+  const result = await processDatasetExtractionJobs({
+    supabase: supabase as unknown as SupabaseClient,
+  });
+
+  assertEquals(result.acked, 0);
+  assertEquals(result.results[0].status, 'unsupported');
+  assertEquals(result.results[0].error_code, 'UNSUPPORTED_EXTRACTION_KIND');
   assertEquals(supabase.rpcCalls.at(-1)?.fn, 'cmd_dataset_extraction_record_failure');
 });
 

--- a/test/hybrid_query_utils_test.ts
+++ b/test/hybrid_query_utils_test.ts
@@ -1,0 +1,74 @@
+import { assertEquals } from 'jsr:@std/assert';
+
+import {
+  buildHybridFulltextQueryString,
+  sanitizeHybridQueryOutput,
+} from '../supabase/functions/_shared/hybrid_query_utils.ts';
+
+Deno.test('sanitizeHybridQueryOutput preserves raw English query as fulltext fallback', () => {
+  const sanitized = sanitizeHybridQueryOutput(
+    {
+      semantic_query_en: 'alternating current',
+      fulltext_query_en: ['AC power', 'alternating current'],
+      fulltext_query_zh: ['交流电'],
+    },
+    'electricity',
+  );
+
+  assertEquals(sanitized.semantic_query_en, 'alternating current');
+  assertEquals(sanitized.fulltext_query_en.includes('electricity'), true);
+  assertEquals(sanitized.fulltext_query_en[0], 'alternating current');
+  assertEquals(sanitized.fulltext_query_en[1], 'electricity');
+});
+
+Deno.test('sanitizeHybridQueryOutput preserves raw Chinese query as fulltext fallback', () => {
+  const sanitized = sanitizeHybridQueryOutput(
+    {
+      semantic_query_en: 'alternating current',
+      fulltext_query_en: ['electricity'],
+      fulltext_query_zh: ['电力'],
+    },
+    '交流电',
+  );
+
+  assertEquals(sanitized.fulltext_query_zh[0], '交流电');
+  assertEquals(sanitized.fulltext_query_zh.includes('电力'), true);
+});
+
+Deno.test('sanitizeHybridQueryOutput keeps raw query within capped fulltext aliases', () => {
+  const sanitized = sanitizeHybridQueryOutput(
+    {
+      semantic_query_en: 'alternating current',
+      fulltext_query_en: [
+        'AC power',
+        'electric power',
+        'grid power',
+        'mains electricity',
+        'power supply',
+        'utility electricity',
+        'voltage supply',
+      ],
+      fulltext_query_zh: [],
+    },
+    'electricity',
+  );
+
+  assertEquals(sanitized.fulltext_query_en.length, 6);
+  assertEquals(sanitized.fulltext_query_en.includes('electricity'), true);
+});
+
+Deno.test('buildHybridFulltextQueryString preserves raw-query aliases in RPC query text', () => {
+  const sanitized = sanitizeHybridQueryOutput(
+    {
+      semantic_query_en: 'alternating current',
+      fulltext_query_en: ['AC power'],
+      fulltext_query_zh: ['交流电'],
+    },
+    'electricity',
+  );
+
+  assertEquals(
+    buildHybridFulltextQueryString(sanitized),
+    '(交流电) OR (alternating current) OR (electricity) OR (AC power)',
+  );
+});


### PR DESCRIPTION
Closes #131

## Summary
- Pins the raw user query into hybrid fulltext aliases so LLM rewrite cannot remove the user's search term.
- Adds empty-result match_threshold=0 fallback and structured hybrid RPC logs for flow, process, and lifecyclemodel hybrid search.
- Stops the dataset extraction worker from writing extracted_text and records legacy extracted_text jobs as unsupported terminal jobs.

## Key Decisions
- Edge no longer treats extracted_text as an LLM-generated field; database-engine owns that contract.

## Validation
- npm run lint
- npm run check
- deno test --config supabase/functions/deno.json test/hybrid_query_utils_test.ts test/dataset_extraction_worker_test.ts

## Risks / Rollback
- Hybrid fallback only retries with match_threshold=0 after an empty initial result; database searchable-text correctness still depends on tiangong-lca/database-engine#88.

## Workspace Integration
- Requires dev Edge deployment after merge, then hybrid smoke/performance validation with the database-engine dev migration.