### PR TITLE
Backmerge main for ai-doc local gate

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-05-28'
-lastReviewedCommit: '6c681bb20ef9bfd382a0bb6d52b0d68c57479906'
+lastReviewedCommit: '19494ace404155b3ad29b49a3b6553072ab63b7b'
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,7 +1,7 @@
 name: ai-doc-lint
 
 on:
-  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,16 +16,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch main
+        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
         run: cargo install docpact --version 0.1.9 --force
 
-      - name: Validate docpact config
-        run: scripts/docpact validate-config --root . --strict
-
-      - name: Run docpact lint
-        run: >
-          scripts/docpact lint --root . --base "${{ github.event.pull_request.base.sha }}" --head "${{ github.event.pull_request.head.sha }}" --mode enforce
-
+      - name: Run local docpact gate
+        run: scripts/docpact-gate.sh --base origin/main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Do not start from repo landing prose or raw function inventories when the core c
 - stable path groups and hotspot families live in `docs/agents/repo-architecture.md`
 - human setup and request-example guidance stay in `README.md`
 - `test.example.http` is a supporting request collection for concrete payloads, not a governed source doc
-- repo-local documentation maintenance is enforced by `.github/workflows/ai-doc-lint.yml` with `docpact lint`
+- repo-local documentation maintenance is enforced locally by the pre-push docpact gate; `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback
 - the main routing intents are `function-runtime`, `auth-runtime`, `command-runtime`, `review-submit-gate`, `search-and-embedding`, `lca-runtime`, `tidas-package`, `deploy-auth-drift`, `proof`, `repo-docs`, and `root-integration`
 
 ## Minimal Execution Facts

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 1e3474675a0d1aa1271d337e2f6ce2aa704f9f34
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 19494ace404155b3ad29b49a3b6553072ab63b7b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -101,7 +101,7 @@ The repo's machine-readable governance source is `.docpact/config.yaml`.
 That means:
 
 - governed-doc rules, routing intents, ownership boundaries, and freshness live in `.docpact/config.yaml`
-- `.github/workflows/ai-doc-lint.yml` should validate config and run `docpact lint`
+- `.github/workflows/ai-doc-lint.yml` is manual-dispatch fallback and should delegate to the same local docpact gate
 - retained explanatory docs stay in `AGENTS.md`, this file, `repo-architecture.md`, `README.md`, and the PR templates
 
 Do not recreate deleted `ai/*` files under a new name. Keep deterministic facts in config and explanatory material in retained source docs.


### PR DESCRIPTION
## Summary
- backmerge main into dev after the ai-doc local gate change landed on main
- keeps dev aligned with the release/main workflow gating updates

## Validation
- local pre-push/docpact gate ran during push
- main PR: https://github.com/linancn/tiangong-lca-edge-functions/pull/141

Refs #140
