### PR TITLE
Fix docpact gate review feedback

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "24477a12803208e21207b4b5341d71f7a5add76b"
+lastReviewedCommit: "4a5b1ee1a39aadf83c68770ccad5a0b6af0a667a"
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "4a5b1ee1a39aadf83c68770ccad5a0b6af0a667a"
+lastReviewedCommit: "75a658e8aa1b448a170b30190b8ab2d8243bfc61"
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-05-28'
-lastReviewedCommit: '19494ace404155b3ad29b49a3b6553072ab63b7b'
+lastReviewedAt: "2026-05-28"
+lastReviewedCommit: "24477a12803208e21207b4b5341d71f7a5add76b"
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -31,4 +31,6 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: scripts/docpact-gate.sh --base "$BASE_REF"

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -2,6 +2,11 @@ name: ai-doc-lint
 
 on:
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Base ref for the manual docpact comparison.
+        required: false
+        default: origin/dev
 
 permissions:
   contents: read
@@ -16,8 +21,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch main
-        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+      - name: Fetch branches
+        run: git fetch --force origin '+refs/heads/*:refs/remotes/origin/*'
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -26,4 +31,4 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base origin/main
+        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 4a5b1ee1a39aadf83c68770ccad5a0b6af0a667a
+lastReviewedCommit: 75a658e8aa1b448a170b30190b8ab2d8243bfc61
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 24477a12803208e21207b4b5341d71f7a5add76b
+lastReviewedCommit: 4a5b1ee1a39aadf83c68770ccad5a0b6af0a667a
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 1e3474675a0d1aa1271d337e2f6ce2aa704f9f34
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 24477a12803208e21207b4b5341d71f7a5add76b
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 19494ace404155b3ad29b49a3b6553072ab63b7b
+lastReviewedCommit: 4a5b1ee1a39aadf83c68770ccad5a0b6af0a667a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 4a5b1ee1a39aadf83c68770ccad5a0b6af0a667a
+lastReviewedCommit: 75a658e8aa1b448a170b30190b8ab2d8243bfc61
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-27
-lastReviewedCommit: 1e3474675a0d1aa1271d337e2f6ce2aa704f9f34
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 24477a12803208e21207b4b5341d71f7a5add76b
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 4a5b1ee1a39aadf83c68770ccad5a0b6af0a667a
+lastReviewedCommit: 75a658e8aa1b448a170b30190b8ab2d8243bfc61
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 24477a12803208e21207b4b5341d71f7a5add76b
+lastReviewedCommit: 4a5b1ee1a39aadf83c68770ccad5a0b6af0a667a
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- address Codex review feedback from the ai-doc local-gate rollout
- make manual ai-doc/docpact fallback workflows accept an explicit base_ref and fetch remote branches
- make release tag docpact gates compare the tag commit against its parent instead of a base that can collapse to the tag commit
- refresh governance review evidence for the touched workflow guidance docs

## Validation
- YAML workflow parse passed from the workspace root
- local docpact/ai-doc gate passed for this branch

Refs tiangong-lca/workspace#183