### PR TITLE
fix: preserve hybrid search user context

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "75a658e8aa1b448a170b30190b8ab2d8243bfc61"
+lastReviewedAt: '2026-05-28'
+lastReviewedCommit: '75a658e8aa1b448a170b30190b8ab2d8243bfc61'
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/supabase/functions/_shared/hybrid_search_rpc_context.ts
+++ b/supabase/functions/_shared/hybrid_search_rpc_context.ts
@@ -1,0 +1,86 @@
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+
+import {
+  createRequestSupabaseClient,
+  supabaseClient as supabaseServiceClient,
+} from './supabase_client.ts';
+
+export type HybridSearchRpcUserContextKind = 'jwt' | 'service';
+
+export type HybridSearchRpcContext =
+  | {
+      bearerToken: string;
+      userContextKind: 'jwt';
+    }
+  | {
+      bearerToken?: undefined;
+      userContextKind: 'service';
+    };
+
+export type HybridSearchRpcClientContext = HybridSearchRpcContext & {
+  client: SupabaseClient;
+};
+
+export class HybridSearchRpcContextError extends Error {
+  code = 'HYBRID_SEARCH_USER_CONTEXT_REQUIRED';
+  status = 403;
+
+  constructor(dataSource: string) {
+    super(`data_source ${dataSource} requires a Supabase JWT user context`);
+    this.name = 'HybridSearchRpcContextError';
+  }
+}
+
+const JWT_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+const USER_SCOPED_DATA_SOURCES = new Set(['my', 'te']);
+
+function extractBearerToken(authHeader: string | null): string | undefined {
+  if (!authHeader) {
+    return undefined;
+  }
+
+  const token = authHeader.replace(/^Bearer\s+/i, '').trim();
+  return token.length > 0 ? token : undefined;
+}
+
+function isJwtLikeToken(token: string): boolean {
+  return JWT_PATTERN.test(token);
+}
+
+export function resolveHybridSearchRpcContext(
+  authHeader: string | null,
+  dataSource: string,
+): HybridSearchRpcContext {
+  const bearerToken = extractBearerToken(authHeader);
+
+  if (bearerToken && isJwtLikeToken(bearerToken)) {
+    return {
+      bearerToken,
+      userContextKind: 'jwt',
+    };
+  }
+
+  if (USER_SCOPED_DATA_SOURCES.has(dataSource)) {
+    throw new HybridSearchRpcContextError(dataSource);
+  }
+
+  return {
+    userContextKind: 'service',
+  };
+}
+
+export function createHybridSearchRpcClient(
+  authHeader: string | null,
+  dataSource: string,
+): HybridSearchRpcClientContext {
+  const context = resolveHybridSearchRpcContext(authHeader, dataSource);
+  const client =
+    context.userContextKind === 'jwt'
+      ? createRequestSupabaseClient(context.bearerToken)
+      : supabaseServiceClient;
+
+  return {
+    ...context,
+    client,
+  };
+}

--- a/supabase/functions/flow_hybrid_search/index.ts
+++ b/supabase/functions/flow_hybrid_search/index.ts
@@ -14,9 +14,14 @@ import {
   buildHybridSearchRpcRequest,
   parseHybridSearchClientRequest,
 } from '../_shared/hybrid_search_request.ts';
+import {
+  createHybridSearchRpcClient,
+  HybridSearchRpcContextError,
+  type HybridSearchRpcClientContext,
+} from '../_shared/hybrid_search_rpc_context.ts';
 import { openaiStructuredOutput } from '../_shared/openai_structured.ts';
 import { getRedisClient } from '../_shared/redis_client.ts';
-import { supabaseClient as supabase, supabaseAuthClient } from '../_shared/supabase_client.ts';
+import { supabaseAuthClient } from '../_shared/supabase_client.ts';
 const openai_chat_model = Deno.env.get('OPENAI_CHAT_MODEL') ?? 'gpt-4.1-mini';
 const SAGEMAKER_ENDPOINT_NAME = Deno.env.get('SAGEMAKER_ENDPOINT_NAME');
 const AWS_REGION = 'us-east-1';
@@ -236,6 +241,22 @@ ${HYBRID_SYNONYM_RULES}`,
     vectorStr,
     parsedRequest.rpcOptions,
   );
+  let rpcClientContext: HybridSearchRpcClientContext;
+  try {
+    rpcClientContext = createHybridSearchRpcClient(
+      req.headers.get('Authorization'),
+      requestBody.data_source,
+    );
+  } catch (error) {
+    if (error instanceof HybridSearchRpcContextError) {
+      return new Response(JSON.stringify({ error: error.message, code: error.code }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: error.status,
+      });
+    }
+
+    throw error;
+  }
 
   const rpcLogBase = {
     function: 'flow_hybrid_search',
@@ -247,11 +268,12 @@ ${HYBRID_SYNONYM_RULES}`,
     query_fulltext_string: queryFulltextString,
     match_threshold: requestBody.match_threshold,
     data_source: requestBody.data_source,
+    user_context_kind: rpcClientContext.userContextKind,
   };
   const rpcStartedAt = Date.now();
   console.log('[hybrid_search]', { ...rpcLogBase, stage: 'rpc_start' });
 
-  let { data, error } = await supabase.rpc('hybrid_search_flows', requestBody);
+  let { data, error } = await rpcClientContext.client.rpc('hybrid_search_flows', requestBody);
   let fallbackUsed = false;
 
   if (!error && Array.isArray(data) && data.length === 0 && requestBody.match_threshold > 0) {
@@ -263,7 +285,10 @@ ${HYBRID_SYNONYM_RULES}`,
       match_threshold: fallbackRequestBody.match_threshold,
       duration_ms: Date.now() - rpcStartedAt,
     });
-    ({ data, error } = await supabase.rpc('hybrid_search_flows', fallbackRequestBody));
+    ({ data, error } = await rpcClientContext.client.rpc(
+      'hybrid_search_flows',
+      fallbackRequestBody,
+    ));
   }
 
   if (error) {

--- a/supabase/functions/lifecyclemodel_hybrid_search/index.ts
+++ b/supabase/functions/lifecyclemodel_hybrid_search/index.ts
@@ -14,9 +14,14 @@ import {
   buildHybridSearchRpcRequest,
   parseHybridSearchClientRequest,
 } from '../_shared/hybrid_search_request.ts';
+import {
+  createHybridSearchRpcClient,
+  HybridSearchRpcContextError,
+  type HybridSearchRpcClientContext,
+} from '../_shared/hybrid_search_rpc_context.ts';
 import { openaiStructuredOutput } from '../_shared/openai_structured.ts';
 import { getRedisClient } from '../_shared/redis_client.ts';
-import { supabaseClient as supabase, supabaseAuthClient } from '../_shared/supabase_client.ts';
+import { supabaseAuthClient } from '../_shared/supabase_client.ts';
 const openai_chat_model = Deno.env.get('OPENAI_CHAT_MODEL') ?? 'gpt-4.1-mini';
 const SAGEMAKER_ENDPOINT_NAME = Deno.env.get('SAGEMAKER_ENDPOINT_NAME');
 const AWS_REGION = 'us-east-1';
@@ -236,6 +241,22 @@ ${HYBRID_SYNONYM_RULES}`,
     vectorStr,
     parsedRequest.rpcOptions,
   );
+  let rpcClientContext: HybridSearchRpcClientContext;
+  try {
+    rpcClientContext = createHybridSearchRpcClient(
+      req.headers.get('Authorization'),
+      requestBody.data_source,
+    );
+  } catch (error) {
+    if (error instanceof HybridSearchRpcContextError) {
+      return new Response(JSON.stringify({ error: error.message, code: error.code }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: error.status,
+      });
+    }
+
+    throw error;
+  }
 
   const rpcLogBase = {
     function: 'lifecyclemodel_hybrid_search',
@@ -247,11 +268,15 @@ ${HYBRID_SYNONYM_RULES}`,
     query_fulltext_string: queryFulltextString,
     match_threshold: requestBody.match_threshold,
     data_source: requestBody.data_source,
+    user_context_kind: rpcClientContext.userContextKind,
   };
   const rpcStartedAt = Date.now();
   console.log('[hybrid_search]', { ...rpcLogBase, stage: 'rpc_start' });
 
-  let { data, error } = await supabase.rpc('hybrid_search_lifecyclemodels', requestBody);
+  let { data, error } = await rpcClientContext.client.rpc(
+    'hybrid_search_lifecyclemodels',
+    requestBody,
+  );
   let fallbackUsed = false;
 
   if (!error && Array.isArray(data) && data.length === 0 && requestBody.match_threshold > 0) {
@@ -263,7 +288,10 @@ ${HYBRID_SYNONYM_RULES}`,
       match_threshold: fallbackRequestBody.match_threshold,
       duration_ms: Date.now() - rpcStartedAt,
     });
-    ({ data, error } = await supabase.rpc('hybrid_search_lifecyclemodels', fallbackRequestBody));
+    ({ data, error } = await rpcClientContext.client.rpc(
+      'hybrid_search_lifecyclemodels',
+      fallbackRequestBody,
+    ));
   }
 
   if (error) {

--- a/supabase/functions/process_hybrid_search/index.ts
+++ b/supabase/functions/process_hybrid_search/index.ts
@@ -15,9 +15,14 @@ import {
   buildHybridSearchRpcRequest,
   parseHybridSearchClientRequest,
 } from '../_shared/hybrid_search_request.ts';
+import {
+  createHybridSearchRpcClient,
+  HybridSearchRpcContextError,
+  type HybridSearchRpcClientContext,
+} from '../_shared/hybrid_search_rpc_context.ts';
 import { openaiStructuredOutput } from '../_shared/openai_structured.ts';
 import { getRedisClient } from '../_shared/redis_client.ts';
-import { supabaseClient as supabase, supabaseAuthClient } from '../_shared/supabase_client.ts';
+import { supabaseAuthClient } from '../_shared/supabase_client.ts';
 
 const openai_chat_model = Deno.env.get('OPENAI_CHAT_MODEL') ?? 'gpt-4.1-mini';
 const SAGEMAKER_ENDPOINT_NAME = Deno.env.get('SAGEMAKER_ENDPOINT_NAME');
@@ -239,6 +244,22 @@ ${HYBRID_SYNONYM_RULES}`,
     vectorStr,
     parsedRequest.rpcOptions,
   );
+  let rpcClientContext: HybridSearchRpcClientContext;
+  try {
+    rpcClientContext = createHybridSearchRpcClient(
+      req.headers.get('Authorization'),
+      requestBody.data_source,
+    );
+  } catch (error) {
+    if (error instanceof HybridSearchRpcContextError) {
+      return new Response(JSON.stringify({ error: error.message, code: error.code }), {
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: error.status,
+      });
+    }
+
+    throw error;
+  }
 
   const rpcLogBase = {
     function: 'process_hybrid_search',
@@ -250,11 +271,12 @@ ${HYBRID_SYNONYM_RULES}`,
     query_fulltext_string: queryFulltextString,
     match_threshold: requestBody.match_threshold,
     data_source: requestBody.data_source,
+    user_context_kind: rpcClientContext.userContextKind,
   };
   const rpcStartedAt = Date.now();
   console.log('[hybrid_search]', { ...rpcLogBase, stage: 'rpc_start' });
 
-  let { data, error } = await supabase.rpc('hybrid_search_processes', requestBody);
+  let { data, error } = await rpcClientContext.client.rpc('hybrid_search_processes', requestBody);
   let fallbackUsed = false;
 
   if (!error && Array.isArray(data) && data.length === 0 && requestBody.match_threshold > 0) {
@@ -266,7 +288,10 @@ ${HYBRID_SYNONYM_RULES}`,
       match_threshold: fallbackRequestBody.match_threshold,
       duration_ms: Date.now() - rpcStartedAt,
     });
-    ({ data, error } = await supabase.rpc('hybrid_search_processes', fallbackRequestBody));
+    ({ data, error } = await rpcClientContext.client.rpc(
+      'hybrid_search_processes',
+      fallbackRequestBody,
+    ));
   }
 
   if (error) {

--- a/test/hybrid_search_rpc_context_test.ts
+++ b/test/hybrid_search_rpc_context_test.ts
@@ -1,0 +1,58 @@
+import { assertEquals, assertInstanceOf, assertThrows } from 'jsr:@std/assert';
+
+import {
+  HybridSearchRpcContextError,
+  resolveHybridSearchRpcContext,
+} from '../supabase/functions/_shared/hybrid_search_rpc_context.ts';
+
+const TEST_JWT = 'header.payload.signature';
+
+Deno.test('resolveHybridSearchRpcContext uses request JWT context for user-scoped sources', () => {
+  const context = resolveHybridSearchRpcContext(`Bearer ${TEST_JWT}`, 'my');
+
+  assertEquals(context, {
+    bearerToken: TEST_JWT,
+    userContextKind: 'jwt',
+  });
+});
+
+Deno.test('resolveHybridSearchRpcContext also keeps JWT context for public sources', () => {
+  const context = resolveHybridSearchRpcContext(`Bearer ${TEST_JWT}`, 'tg');
+
+  assertEquals(context, {
+    bearerToken: TEST_JWT,
+    userContextKind: 'jwt',
+  });
+});
+
+Deno.test(
+  'resolveHybridSearchRpcContext allows service context for non-user-scoped sources',
+  () => {
+    const context = resolveHybridSearchRpcContext(null, 'tg');
+
+    assertEquals(context, {
+      userContextKind: 'service',
+    });
+  },
+);
+
+Deno.test('resolveHybridSearchRpcContext rejects my data without a Supabase JWT context', () => {
+  const error = assertThrows(
+    () => resolveHybridSearchRpcContext('Bearer user-api-key-token', 'my'),
+    HybridSearchRpcContextError,
+  );
+
+  assertInstanceOf(error, HybridSearchRpcContextError);
+  assertEquals(error.status, 403);
+  assertEquals(error.code, 'HYBRID_SEARCH_USER_CONTEXT_REQUIRED');
+  assertEquals(error.message, 'data_source my requires a Supabase JWT user context');
+});
+
+Deno.test('resolveHybridSearchRpcContext rejects team data without a Supabase JWT context', () => {
+  const error = assertThrows(
+    () => resolveHybridSearchRpcContext(null, 'te'),
+    HybridSearchRpcContextError,
+  );
+
+  assertEquals(error.message, 'data_source te requires a Supabase JWT user context');
+});


### PR DESCRIPTION
## Summary\n- Route hybrid search RPC calls through a request-scoped Supabase client when the request carries a Supabase JWT, so database RPCs can see auth.uid() for my/team data.\n- Keep service-role RPC context only for non-JWT service calls, and return an explicit 403 for my/te hybrid search without a Supabase JWT instead of silently returning empty results.\n- Add shared context resolution tests and format the existing docpact config so repo lint passes.\n\nCloses #145\n\n## Validation\n- deno test --config supabase/functions/deno.json test/hybrid_search_request_test.ts test/hybrid_search_rpc_context_test.ts\n- npm run check\n- npm run lint