### PR TITLE
promote: no-legacy worker job enqueue to main

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-06-02'
-lastReviewedCommit: '445104e77a69ebc3418f541fe5f260940144cb15'
+lastReviewedCommit: '0ae67565bbd681e9f3027ab982fb5bfacd8e4d35'
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 445104e77a69ebc3418f541fe5f260940144cb15
+lastReviewedCommit: 0ae67565bbd681e9f3027ab982fb5bfacd8e4d35
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ LCA solve/snapshot/contribution path, TIDAS package import/export, and review-su
 - `public.worker_list_jobs(...)`
 - `public.worker_cancel_job(...)`
 
-Retained domain tables such as `lca_jobs`, `lca_result_cache`, `lca_package_jobs`, `lca_package_artifacts`, and `dataset_review_submit_jobs` still carry result/cache/artifact/history metadata, but they are not the user-facing task fact. Legacy `lca_enqueue_job` / `lca_package_enqueue_job` must not be used as enqueue fallback. If `LCA_WORKER_JOBS_ENABLED=false`, `TIDAS_PACKAGE_WORKER_JOBS_ENABLED=false`, or `WORKER_JOBS_CUTOVER_ENABLED=false`, new worker-owned submissions fail closed with `legacy_queue_disabled` / `LEGACY_QUEUE_DISABLED` instead of writing to the legacy queue path.
+Retained domain tables such as `lca_jobs`, `lca_result_cache`, `lca_package_jobs`, `lca_package_artifacts`, and `dataset_review_submit_jobs` still carry result/cache/artifact/history metadata, but they are not the user-facing task fact. New LCA solve/snapshot/contribution and TIDAS package import/export submissions enqueue `worker_jobs` directly; the legacy job ids returned by those APIs are compatibility ids carried in worker payloads, not newly inserted `lca_jobs` / `lca_package_jobs` rows. Legacy `lca_enqueue_job` / `lca_package_enqueue_job` must not be used as enqueue fallback. If `LCA_WORKER_JOBS_ENABLED=false`, `TIDAS_PACKAGE_WORKER_JOBS_ENABLED=false`, or `WORKER_JOBS_CUTOVER_ENABLED=false`, new worker-owned submissions fail closed with `legacy_queue_disabled` / `LEGACY_QUEUE_DISABLED` instead of writing to the legacy queue path.
 
 ## Review-submit Gate Function Call Pattern
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 445104e77a69ebc3418f541fe5f260940144cb15
+lastReviewedCommit: 0ae67565bbd681e9f3027ab982fb5bfacd8e4d35
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -153,7 +153,7 @@ Shared scope logic lives in:
 - `supabase/functions/_shared/lca_process_scope.ts`
 - `supabase/functions/_shared/lca_snapshot_scope.ts`
 
-`supabase/functions/_shared/worker_jobs_cutover.ts` owns the handoff from retained domain rows/cache to database-owned `worker_jobs`. The default path keeps existing `lca_jobs` / `lca_result_cache` domain metadata, enqueues `lca.solve_one`, `lca.solve_all_unit`, `lca.build_snapshot`, and `lca.contribution_path` through `worker_enqueue_job`, and marks retained rows failed when canonical enqueue fails. Setting `LCA_WORKER_JOBS_ENABLED=false` or `WORKER_JOBS_CUTOVER_ENABLED=false` disables new LCA worker submissions and fails closed with `legacy_queue_disabled`; it must not fall back to legacy `lca_enqueue_job`. Edge still owns auth and request normalization only; `tiangong-lca-worker` owns execution.
+`supabase/functions/_shared/worker_jobs_cutover.ts` owns the handoff from Edge runtime requests to database-owned `worker_jobs`, and `supabase/functions/_shared/lca_snapshot_build_queue.ts` owns shared snapshot-build enqueue/reuse. The default path enqueues `lca.solve_one`, `lca.solve_all_unit`, `lca.build_snapshot`, and `lca.contribution_path` through `worker_enqueue_job` without creating new `lca_jobs` rows. `lca_result_cache` remains retained result/cache metadata and stores both compatibility `job_id` and canonical `worker_job_id` where applicable. Setting `LCA_WORKER_JOBS_ENABLED=false` or `WORKER_JOBS_CUTOVER_ENABLED=false` disables new LCA worker submissions and fails closed with `legacy_queue_disabled`; it must not fall back to legacy `lca_enqueue_job`. Edge still owns auth and request normalization only; `tiangong-lca-worker` owns execution.
 
 ### TIDAS package flows
 
@@ -168,7 +168,7 @@ Shared behavior lives in:
 - `supabase/functions/_shared/tidas_package.ts`
 - `supabase/functions/_shared/redis_client.ts`
 
-The default TIDAS package path enqueues `tidas.import_package` and `tidas.export_package` through `worker_enqueue_job`; setting `TIDAS_PACKAGE_WORKER_JOBS_ENABLED=false` or `WORKER_JOBS_CUTOVER_ENABLED=false` disables new package worker submissions and fails closed with `LEGACY_QUEUE_DISABLED`; it must not fall back to legacy `lca_package_enqueue_job`. The package domain rows, request cache, artifacts, and lookup APIs remain retained domain metadata; `worker_jobs` is the canonical task lifecycle projection and worker delivery mechanism.
+The default TIDAS package path enqueues `tidas.import_package` and `tidas.export_package` through `worker_enqueue_job` without creating new `lca_package_jobs` rows. Import prepare creates an `import_source` artifact row for upload coordination; import enqueue links that artifact to the canonical `worker_jobs` row. Export request cache stores both compatibility `job_id` and canonical `worker_job_id` where applicable. Setting `TIDAS_PACKAGE_WORKER_JOBS_ENABLED=false` or `WORKER_JOBS_CUTOVER_ENABLED=false` disables new package worker submissions and fails closed with `LEGACY_QUEUE_DISABLED`; it must not fall back to legacy `lca_package_enqueue_job`. Existing package domain rows, request cache, artifacts, and lookup APIs remain retained compatibility metadata; `worker_jobs` is the canonical task lifecycle projection and worker delivery mechanism.
 
 ## Database Boundary
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-02
-lastReviewedCommit: 445104e77a69ebc3418f541fe5f260940144cb15
+lastReviewedCommit: 0ae67565bbd681e9f3027ab982fb5bfacd8e4d35
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/functions/_shared/lca_snapshot_build_queue.ts
+++ b/supabase/functions/_shared/lca_snapshot_build_queue.ts
@@ -1,0 +1,232 @@
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+
+import {
+  buildSnapshotBuildPayloadFields,
+  buildSnapshotProcessFilter,
+  type LcaDataScope,
+} from './lca_snapshot_scope.ts';
+import {
+  enqueueCalculatorWorkerJob,
+  isWorkerJobsCutoverEnabled,
+  workerJobPayloadStringFromRpcData,
+} from './worker_jobs_cutover.ts';
+
+export type LcaSnapshotBuildQueueResult =
+  | { ok: true; job_id: string; snapshot_id: string; worker_job_id?: string | null }
+  | { ok: false; error: string; status: number };
+
+const SNAPSHOT_BUILD_REQUEST_VERSION = 'lca_snapshot_build_v1';
+const ACTIVE_BUILD_MAX_QUEUED_MS = 10 * 60 * 1000;
+const ACTIVE_BUILD_MAX_RUNNING_MS = 2 * 60 * 60 * 1000;
+const ACTIVE_WORKER_STATUSES = ['queued', 'running', 'waiting', 'blocked'];
+
+export async function ensureLcaSnapshotBuildQueued(
+  supabase: SupabaseClient,
+  args: {
+    scope: string;
+    dataScope: LcaDataScope;
+    userId: string;
+  },
+): Promise<LcaSnapshotBuildQueueResult> {
+  const processFilter = buildSnapshotProcessFilter(args.dataScope, args.userId);
+  const buildPayloadFields = {
+    scope: args.scope,
+    ...buildSnapshotBuildPayloadFields(processFilter),
+    reference_normalization_mode: 'lenient',
+    allocation_fraction_mode: 'lenient',
+    self_loop_cutoff: 0.999999,
+    singular_eps: 1e-12,
+    no_lcia: false,
+  };
+  const requestKey = await sha256Hex(
+    JSON.stringify({
+      version: SNAPSHOT_BUILD_REQUEST_VERSION,
+      scope: args.scope,
+      process_filter: processFilter,
+      payload: buildPayloadFields,
+    }),
+  );
+  const concurrencyKey = `lca.build_snapshot:${args.scope}:${requestKey}`;
+
+  const activeBuild = await findActiveSnapshotBuildWorkerJob(supabase, concurrencyKey);
+  if (!activeBuild.ok) {
+    return activeBuild;
+  }
+  if (activeBuild.job_id && activeBuild.snapshot_id) {
+    return {
+      ok: true,
+      job_id: activeBuild.job_id,
+      snapshot_id: activeBuild.snapshot_id,
+      worker_job_id: activeBuild.worker_job_id,
+    };
+  }
+
+  if (!isWorkerJobsCutoverEnabled('LCA_WORKER_JOBS_ENABLED')) {
+    console.error('legacy lca snapshot queue fallback is disabled before worker job enqueue', {
+      request_key: requestKey,
+      scope: args.scope,
+    });
+    return { ok: false, error: 'legacy_queue_disabled', status: 503 };
+  }
+
+  const snapshotId = crypto.randomUUID();
+  const jobId = crypto.randomUUID();
+  const payload = {
+    type: 'build_snapshot',
+    job_id: jobId,
+    snapshot_id: snapshotId,
+    ...buildPayloadFields,
+  };
+
+  const { error: snapshotInsertError } = await supabase.from('lca_network_snapshots').insert({
+    id: snapshotId,
+    scope: 'full_library',
+    process_filter: processFilter,
+    status: 'draft',
+    created_by: args.userId,
+  });
+  if (snapshotInsertError && snapshotInsertError.code !== '23505') {
+    console.error('insert lca_network_snapshots failed', {
+      error: snapshotInsertError.message,
+      code: snapshotInsertError.code,
+      snapshot_id: snapshotId,
+    });
+    return { ok: false, error: 'snapshot_build_seed_failed', status: 500 };
+  }
+
+  const workerJob = await enqueueCalculatorWorkerJob(supabase, {
+    jobKind: 'lca.build_snapshot',
+    payload,
+    payloadSchemaVersion: 'lca.build_snapshot.request.v1',
+    subjectType: 'lca_job',
+    subjectId: jobId,
+    subjectVersion: snapshotId,
+    requestedBy: args.userId,
+    requesterType: 'user',
+    idempotencyKey: `${args.userId}:${requestKey}`,
+    requestHash: requestKey,
+    concurrencyKey,
+    queueKey: args.scope,
+    visibility: 'user',
+  });
+  if (!workerJob.ok) {
+    if (workerJob.error === 'WORKER_JOB_CONCURRENCY_CONFLICT') {
+      const activeAfterConflict = await findActiveSnapshotBuildWorkerJob(supabase, concurrencyKey);
+      if (activeAfterConflict.ok && activeAfterConflict.job_id && activeAfterConflict.snapshot_id) {
+        return {
+          ok: true,
+          job_id: activeAfterConflict.job_id,
+          snapshot_id: activeAfterConflict.snapshot_id,
+          worker_job_id: activeAfterConflict.worker_job_id,
+        };
+      }
+    }
+
+    console.error('enqueue build snapshot worker_jobs job failed', {
+      error: workerJob.error,
+      status: workerJob.status,
+      details: workerJob.details,
+      lca_job_id: jobId,
+      snapshot_id: snapshotId,
+    });
+    return {
+      ok: false,
+      error: 'snapshot_build_worker_jobs_enqueue_failed',
+      status: workerJob.status,
+    };
+  }
+
+  return {
+    ok: true,
+    job_id: workerJobPayloadStringFromRpcData(workerJob.data, 'job_id') ?? jobId,
+    snapshot_id: workerJobPayloadStringFromRpcData(workerJob.data, 'snapshot_id') ?? snapshotId,
+    worker_job_id: workerJob.workerJobId,
+  };
+}
+
+async function findActiveSnapshotBuildWorkerJob(
+  supabase: SupabaseClient,
+  concurrencyKey: string,
+): Promise<
+  | { ok: true; job_id: string | null; snapshot_id: string | null; worker_job_id: string | null }
+  | { ok: false; error: string; status: number }
+> {
+  const { data: rows, error } = await supabase
+    .from('worker_jobs')
+    .select('id,payload_json,status,created_at,started_at')
+    .eq('job_kind', 'lca.build_snapshot')
+    .eq('concurrency_key', concurrencyKey)
+    .in('status', ACTIVE_WORKER_STATUSES)
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  if (error) {
+    console.error('read active build worker_jobs failed', {
+      error: error.message,
+      code: error.code,
+      concurrency_key: concurrencyKey,
+    });
+    return { ok: false, error: 'snapshot_build_job_lookup_failed', status: 500 };
+  }
+
+  for (const row of rows ?? []) {
+    const status = String((row as { status?: unknown }).status ?? '');
+    if (isExpiredActiveStatus(status, row)) {
+      continue;
+    }
+
+    const payload = (row as { payload_json?: unknown }).payload_json;
+    const jobId = payloadString(payload, 'job_id');
+    const snapshotId = payloadString(payload, 'snapshot_id');
+    const workerJobId = String((row as { id?: unknown }).id ?? '').trim();
+    if (jobId && snapshotId && workerJobId) {
+      return {
+        ok: true,
+        job_id: jobId,
+        snapshot_id: snapshotId,
+        worker_job_id: workerJobId,
+      };
+    }
+  }
+
+  return { ok: true, job_id: null, snapshot_id: null, worker_job_id: null };
+}
+
+function isExpiredActiveStatus(status: string, row: unknown): boolean {
+  const nowMs = Date.now();
+  const createdAtMs = dateMs((row as { created_at?: unknown }).created_at);
+  if (
+    status === 'queued' &&
+    Number.isFinite(createdAtMs) &&
+    nowMs - createdAtMs > ACTIVE_BUILD_MAX_QUEUED_MS
+  ) {
+    return true;
+  }
+
+  const startedAtMs = dateMs((row as { started_at?: unknown }).started_at);
+  return (
+    status === 'running' &&
+    Number.isFinite(startedAtMs) &&
+    nowMs - startedAtMs > ACTIVE_BUILD_MAX_RUNNING_MS
+  );
+}
+
+function payloadString(payload: unknown, field: string): string | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+
+  const value = (payload as Record<string, unknown>)[field];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function dateMs(value: unknown): number {
+  return value === null || value === undefined ? Number.NaN : Date.parse(String(value));
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/supabase/functions/_shared/tidas_package.ts
+++ b/supabase/functions/_shared/tidas_package.ts
@@ -1,6 +1,10 @@
 import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 import { corsHeaders } from './cors.ts';
-import { enqueueCalculatorWorkerJob, isWorkerJobsCutoverEnabled } from './worker_jobs_cutover.ts';
+import {
+  enqueueCalculatorWorkerJob,
+  isWorkerJobsCutoverEnabled,
+  workerJobPayloadStringFromRpcData,
+} from './worker_jobs_cutover.ts';
 
 export const SUPPORTED_TIDAS_TABLES = [
   'contacts',
@@ -62,6 +66,7 @@ type ExportRequestCacheRow = {
   id: string;
   status: string;
   job_id: string | null;
+  worker_job_id?: string | null;
   export_artifact_id: string | null;
   report_artifact_id: string | null;
   hit_count: number;
@@ -147,8 +152,25 @@ type PackageJobRow = {
   updated_at: string | null;
 };
 
+type WorkerPackageJobRow = {
+  id: string;
+  job_kind: string;
+  status: string;
+  requested_by: string | null;
+  request_hash: string | null;
+  payload: JsonRecord;
+  diagnostics: unknown;
+  error_code: string | null;
+  error_message: string | null;
+  created_at: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+  updated_at: string | null;
+};
+
 type PackageArtifactRow = {
   id: string;
+  worker_job_id: string | null;
   artifact_kind: TidasPackageArtifactKind;
   status: string;
   artifact_url: string;
@@ -328,9 +350,21 @@ export async function queueExportTidasPackage(
   if (existingCache) {
     await touchExportRequestCache(supabase, existingCache, nowIso);
 
-    const existingJob = existingCache.job_id
-      ? await fetchOwnedPackageJobIfExists(supabase, userId, existingCache.job_id, 'export_package')
-      : null;
+    const existingJob = existingCache.worker_job_id
+      ? await fetchOwnedWorkerPackageJobIfExists(
+          supabase,
+          userId,
+          existingCache.worker_job_id,
+          'tidas.export_package',
+        )
+      : existingCache.job_id
+        ? await fetchOwnedPackageJobIfExists(
+            supabase,
+            userId,
+            existingCache.job_id,
+            'export_package',
+          )
+        : null;
     const cacheAction = resolveExportCacheAction(existingCache, existingJob);
 
     if (cacheAction === 'cache_hit' && existingCache.job_id) {
@@ -338,6 +372,7 @@ export async function queueExportTidasPackage(
         ok: true,
         mode: 'cache_hit' as const,
         job_id: existingCache.job_id,
+        ...(existingCache.worker_job_id ? { worker_job_id: existingCache.worker_job_id } : {}),
         scope: normalized.scope,
         root_count: normalized.roots.length,
       };
@@ -348,6 +383,7 @@ export async function queueExportTidasPackage(
         ok: true,
         mode: 'in_progress' as const,
         job_id: existingCache.job_id,
+        ...(existingCache.worker_job_id ? { worker_job_id: existingCache.worker_job_id } : {}),
         scope: normalized.scope,
         root_count: normalized.roots.length,
       };
@@ -382,81 +418,42 @@ export async function queueExportTidasPackage(
     );
   }
 
-  const { error: insertJobError } = await supabase.from('lca_package_jobs').insert({
-    id: newJobId,
-    job_type: 'export_package',
-    status: 'queued',
+  const workerJob = await enqueueCalculatorWorkerJob(supabase, {
+    jobKind: 'tidas.export_package',
     payload,
-    diagnostics: {},
-    requested_by: userId,
-    scope: normalized.scope,
-    root_count: normalized.roots.length,
-    request_key: requestKey,
-    idempotency_key: idempotencyKey,
-    created_at: nowIso,
-    updated_at: nowIso,
+    payloadSchemaVersion: 'tidas.export_package.request.v1',
+    subjectType: 'lca_package_job',
+    subjectId: newJobId,
+    subjectVersion: normalized.scope,
+    requestedBy: userId,
+    requesterType: 'user',
+    idempotencyKey,
+    requestHash: requestKey,
+    queueKey: normalized.scope,
+    visibility: 'user',
   });
-
-  if (insertJobError && !isDuplicateKey(insertJobError.code)) {
-    console.error('insert lca_package_jobs failed', {
-      error: insertJobError.message,
-      code: insertJobError.code,
-      idempotency_key: idempotencyKey,
-      user_id: userId,
+  if (!workerJob.ok) {
+    console.error('enqueue tidas export worker_jobs job failed', {
+      error: workerJob.error,
+      status: workerJob.status,
+      details: workerJob.details,
+      job_id: newJobId,
     });
-    throw new TidasPackageError(500, 'JOB_INSERT_FAILED', 'Failed to create export job');
+    throw new TidasPackageError(
+      workerJob.status,
+      'WORKER_JOBS_ENQUEUE_FAILED',
+      'Failed to enqueue export worker job',
+    );
   }
-
-  const finalJobId = await readJobIdByIdempotencyKey(supabase, idempotencyKey, userId);
-  let finalWorkerJobId: string | null = null;
-
-  if (finalJobId === newJobId) {
-    const workerJob = await enqueueCalculatorWorkerJob(supabase, {
-      jobKind: 'tidas.export_package',
-      payload: {
-        ...payload,
-        job_id: finalJobId,
-      },
-      payloadSchemaVersion: 'tidas.export_package.request.v1',
-      subjectType: 'lca_package_job',
-      subjectId: finalJobId,
-      subjectVersion: normalized.scope,
-      requestedBy: userId,
-      requesterType: 'user',
-      idempotencyKey,
-      requestHash: requestKey,
-      queueKey: normalized.scope,
-      visibility: 'user',
-    });
-    if (!workerJob.ok) {
-      console.error('enqueue tidas export worker_jobs job failed', {
-        error: workerJob.error,
-        status: workerJob.status,
-        details: workerJob.details,
-        job_id: finalJobId,
-      });
-      await markPackageJobWorkerEnqueueFailed(supabase, {
-        jobId: finalJobId,
-        userId,
-        nowIso,
-        errorCode: workerJob.error,
-        errorMessage: 'Failed to enqueue export worker job',
-        details: workerJob.details,
-      });
-      throw new TidasPackageError(
-        workerJob.status,
-        'WORKER_JOBS_ENQUEUE_FAILED',
-        'Failed to enqueue export worker job',
-      );
-    }
-    finalWorkerJobId = workerJob.workerJobId;
-  }
+  const finalJobId = workerJobPayloadStringFromRpcData(workerJob.data, 'job_id') ?? newJobId;
+  const finalWorkerJobId = workerJob.workerJobId;
 
   await upsertExportRequestCache(supabase, {
     requested_by: userId,
     request_key: requestKey,
     request_payload: normalized.request_payload,
     job_id: finalJobId,
+    worker_job_id: finalWorkerJobId,
     hit_count: existingCache ? existingCache.hit_count + 1 : 1,
     nowIso,
   });
@@ -486,37 +483,10 @@ export async function prepareImportTidasPackageUpload(
   let objectPath = buildImportSourceObjectPath(jobId);
   let artifactUrl = buildStorageObjectUrl(resolveStorageBucket(), objectPath);
 
-  const payload = {
-    type: 'import_package',
-    job_id: jobId,
-    requested_by: userId,
-    source_artifact_id: sourceArtifactId,
-    upload_state: 'prepared',
-  };
-
-  const { error: insertJobError } = await supabase.from('lca_package_jobs').insert({
-    id: jobId,
-    job_type: 'import_package',
-    status: 'stale',
-    payload,
-    diagnostics: { phase: 'prepare_upload' },
-    requested_by: userId,
-    idempotency_key: idempotencyKey,
-    created_at: nowIso,
-    updated_at: nowIso,
-  });
-
-  if (insertJobError) {
-    if (!idempotencyKey || !isDuplicateKey(insertJobError.code)) {
-      console.error('insert import prepare job failed', {
-        error: insertJobError.message,
-        code: insertJobError.code,
-        user_id: userId,
-      });
-      throw new TidasPackageError(500, 'JOB_INSERT_FAILED', 'Failed to prepare import upload');
-    }
-
-    const existing = await fetchPreparedImportJob(supabase, userId, idempotencyKey);
+  const existing = idempotencyKey
+    ? await fetchPreparedImportArtifactByIdempotencyKey(supabase, userId, idempotencyKey)
+    : null;
+  if (existing) {
     jobId = existing.job_id;
     sourceArtifactId = existing.source_artifact_id;
     objectPath = existing.object_path;
@@ -525,6 +495,7 @@ export async function prepareImportTidasPackageUpload(
     const { error: insertArtifactError } = await supabase.from('lca_package_artifacts').insert({
       id: sourceArtifactId,
       job_id: jobId,
+      worker_job_id: null,
       artifact_kind: 'import_source',
       status: 'pending',
       artifact_url: artifactUrl,
@@ -534,6 +505,8 @@ export async function prepareImportTidasPackageUpload(
         filename: parsed.filename,
         original_filename: parsed.filename,
         upload_state: 'prepared',
+        requested_by: userId,
+        import_prepare_idempotency_key: idempotencyKey,
       },
       created_at: nowIso,
       updated_at: nowIso,
@@ -583,8 +556,20 @@ export async function enqueueImportTidasPackage(
 ) {
   const parsed = parseEnqueueImportRequest(body);
   const nowIso = new Date().toISOString();
-  const job = await fetchOwnedPackageJob(supabase, userId, parsed.job_id, 'import_package');
-  const sourceArtifact = await fetchPackageArtifact(supabase, parsed.source_artifact_id, job.id);
+  const legacyJob = await fetchOwnedPackageJobIfExists(
+    supabase,
+    userId,
+    parsed.job_id,
+    'import_package',
+  );
+  const sourceArtifact = await fetchPackageArtifact(
+    supabase,
+    parsed.source_artifact_id,
+    parsed.job_id,
+  );
+  if (!legacyJob) {
+    assertPackageArtifactOwnedBy(sourceArtifact, userId);
+  }
   assertPackageArtifactUsable(sourceArtifact);
 
   if (sourceArtifact.artifact_kind !== 'import_source') {
@@ -595,34 +580,61 @@ export async function enqueueImportTidasPackage(
     );
   }
 
-  if (job.status === 'completed') {
+  if (legacyJob?.status === 'completed') {
     return {
       ok: true,
       mode: 'completed' as const,
-      job_id: job.id,
+      job_id: legacyJob.id,
       source_artifact_id: sourceArtifact.id,
     };
   }
 
-  if (job.status === 'queued' || job.status === 'running') {
+  if (legacyJob?.status === 'queued' || legacyJob?.status === 'running') {
     return {
       ok: true,
       mode: 'in_progress' as const,
-      job_id: job.id,
+      job_id: legacyJob.id,
       source_artifact_id: sourceArtifact.id,
     };
+  }
+
+  if (sourceArtifact.worker_job_id) {
+    const existingWorkerJob = await fetchOwnedWorkerPackageJobIfExists(
+      supabase,
+      userId,
+      sourceArtifact.worker_job_id,
+      'tidas.import_package',
+    );
+    if (existingWorkerJob?.status === 'completed') {
+      return {
+        ok: true,
+        mode: 'completed' as const,
+        job_id: parsed.job_id,
+        worker_job_id: existingWorkerJob.id,
+        source_artifact_id: sourceArtifact.id,
+      };
+    }
+    if (existingWorkerJob && isActiveWorkerJobStatus(existingWorkerJob.status)) {
+      return {
+        ok: true,
+        mode: 'in_progress' as const,
+        job_id: parsed.job_id,
+        worker_job_id: existingWorkerJob.id,
+        source_artifact_id: sourceArtifact.id,
+      };
+    }
   }
 
   const payload = {
     type: 'import_package',
-    job_id: job.id,
+    job_id: parsed.job_id,
     requested_by: userId,
     source_artifact_id: sourceArtifact.id,
   };
 
   if (!isWorkerJobsCutoverEnabled('TIDAS_PACKAGE_WORKER_JOBS_ENABLED')) {
     console.error('legacy package queue fallback is disabled before import job enqueue', {
-      job_id: job.id,
+      job_id: parsed.job_id,
       source_artifact_id: sourceArtifact.id,
       user_id: userId,
     });
@@ -639,6 +651,7 @@ export async function enqueueImportTidasPackage(
     original_filename:
       parsed.filename ?? sourceArtifact.metadata.original_filename ?? IMPORT_SOURCE_FILENAME,
     upload_state: 'uploaded',
+    requested_by: sourceArtifact.metadata.requested_by ?? userId,
   };
 
   const { error: artifactUpdateError } = await supabase
@@ -652,13 +665,13 @@ export async function enqueueImportTidasPackage(
       updated_at: nowIso,
     })
     .eq('id', sourceArtifact.id)
-    .eq('job_id', job.id);
+    .eq('job_id', parsed.job_id);
 
   if (artifactUpdateError) {
     console.error('update import source artifact failed', {
       error: artifactUpdateError.message,
       code: artifactUpdateError.code,
-      job_id: job.id,
+      job_id: parsed.job_id,
       artifact_id: sourceArtifact.id,
     });
     throw new TidasPackageError(
@@ -668,38 +681,17 @@ export async function enqueueImportTidasPackage(
     );
   }
 
-  const { error: jobUpdateError } = await supabase
-    .from('lca_package_jobs')
-    .update({
-      status: 'queued',
-      payload,
-      diagnostics: { phase: 'enqueue_import', source_artifact_id: sourceArtifact.id },
-      request_key: parsed.artifact_sha256 ?? sourceArtifact.id,
-      updated_at: nowIso,
-    })
-    .eq('id', job.id)
-    .eq('requested_by', userId);
-
-  if (jobUpdateError) {
-    console.error('update import job failed', {
-      error: jobUpdateError.message,
-      code: jobUpdateError.code,
-      job_id: job.id,
-    });
-    throw new TidasPackageError(500, 'JOB_UPDATE_FAILED', 'Failed to enqueue import job');
-  }
-
   let workerJobId: string | null = null;
   const workerJob = await enqueueCalculatorWorkerJob(supabase, {
     jobKind: 'tidas.import_package',
     payload,
     payloadSchemaVersion: 'tidas.import_package.request.v1',
     subjectType: 'lca_package_job',
-    subjectId: job.id,
+    subjectId: parsed.job_id,
     subjectVersion: sourceArtifact.id,
     requestedBy: userId,
     requesterType: 'user',
-    idempotencyKey: `${userId}:import_package:${job.id}`,
+    idempotencyKey: `${userId}:import_package:${parsed.job_id}`,
     requestHash: parsed.artifact_sha256 ?? sourceArtifact.id,
     queueKey: sourceArtifact.id,
     visibility: 'user',
@@ -709,15 +701,7 @@ export async function enqueueImportTidasPackage(
       error: workerJob.error,
       status: workerJob.status,
       details: workerJob.details,
-      job_id: job.id,
-    });
-    await markPackageJobWorkerEnqueueFailed(supabase, {
-      jobId: job.id,
-      userId,
-      nowIso,
-      errorCode: workerJob.error,
-      errorMessage: 'Failed to enqueue import worker job',
-      details: workerJob.details,
+      job_id: parsed.job_id,
     });
     throw new TidasPackageError(
       workerJob.status,
@@ -727,10 +711,21 @@ export async function enqueueImportTidasPackage(
   }
   workerJobId = workerJob.workerJobId;
 
+  await linkPackageArtifactWorkerJob(supabase, {
+    artifactId: sourceArtifact.id,
+    jobId: parsed.job_id,
+    workerJobId,
+    nowIso,
+    metadata: {
+      ...metadata,
+      phase: 'enqueue_import',
+    },
+  });
+
   return {
     ok: true,
     mode: 'queued' as const,
-    job_id: job.id,
+    job_id: parsed.job_id,
     ...(workerJobId ? { worker_job_id: workerJobId } : {}),
     source_artifact_id: sourceArtifact.id,
   };
@@ -745,11 +740,11 @@ export async function lookupTidasPackageJob(
     throw new TidasPackageError(400, 'INVALID_JOB_ID', 'Invalid job identifier');
   }
 
-  const job = await fetchOwnedPackageJob(supabase, userId, jobId);
+  const legacyJob = await fetchOwnedPackageJobIfExists(supabase, userId, jobId);
   const { data: artifactRows, error: artifactError } = await supabase
     .from('lca_package_artifacts')
     .select(
-      'id,artifact_kind,status,artifact_url,artifact_sha256,artifact_byte_size,artifact_format,content_type,metadata,expires_at,is_pinned,created_at,updated_at',
+      'id,worker_job_id,artifact_kind,status,artifact_url,artifact_sha256,artifact_byte_size,artifact_format,content_type,metadata,expires_at,is_pinned,created_at,updated_at',
     )
     .eq('job_id', jobId)
     .order('created_at', { ascending: true });
@@ -763,6 +758,18 @@ export async function lookupTidasPackageJob(
     });
     throw new TidasPackageError(500, 'ARTIFACT_LOOKUP_FAILED', 'Failed to query package artifacts');
   }
+
+  const artifactDomainRows = (artifactRows ?? []).map((row) => toPackageArtifactRow(row));
+  const hasOwnedArtifact = artifactDomainRows.some(
+    (artifact) => normalizeNullableString(artifact.metadata.requested_by) === userId,
+  );
+  if (!legacyJob && !hasOwnedArtifact) {
+    throw new TidasPackageError(404, 'JOB_NOT_FOUND', 'Package job not found');
+  }
+
+  const workerJob = await fetchWorkerPackageJobForArtifacts(supabase, userId, artifactDomainRows);
+  const job =
+    legacyJob ?? buildPackageJobRowFromWorkerOrArtifacts(jobId, workerJob, artifactDomainRows);
 
   const artifacts = await Promise.all(
     (artifactRows ?? []).map((row) => toArtifactResponse(supabase, row)),
@@ -1066,7 +1073,7 @@ async function fetchExportRequestCache(
 ): Promise<ExportRequestCacheRow | null> {
   const { data, error } = await supabase
     .from('lca_package_request_cache')
-    .select('id,status,job_id,export_artifact_id,report_artifact_id,hit_count')
+    .select('id,status,job_id,worker_job_id,export_artifact_id,report_artifact_id,hit_count')
     .eq('requested_by', userId)
     .eq('operation', 'export_package')
     .eq('request_key', requestKey)
@@ -1089,6 +1096,7 @@ async function fetchExportRequestCache(
     id: String(data.id),
     status: String(data.status),
     job_id: data.job_id ? String(data.job_id) : null,
+    worker_job_id: data.worker_job_id ? String(data.worker_job_id) : null,
     export_artifact_id: data.export_artifact_id ? String(data.export_artifact_id) : null,
     report_artifact_id: data.report_artifact_id ? String(data.report_artifact_id) : null,
     hit_count: Number(data.hit_count ?? 0),
@@ -1126,6 +1134,7 @@ async function upsertExportRequestCache(
     request_key: string;
     request_payload: unknown;
     job_id: string;
+    worker_job_id: string | null;
     hit_count: number;
     nowIso: string;
   },
@@ -1138,6 +1147,7 @@ async function upsertExportRequestCache(
       .update({
         status: 'pending',
         job_id: args.job_id,
+        worker_job_id: args.worker_job_id,
         request_payload: args.request_payload,
         export_artifact_id: null,
         report_artifact_id: null,
@@ -1172,6 +1182,7 @@ async function upsertExportRequestCache(
     request_payload: args.request_payload,
     status: 'pending',
     job_id: args.job_id,
+    worker_job_id: args.worker_job_id,
     hit_count: args.hit_count,
     last_accessed_at: args.nowIso,
     created_at: args.nowIso,
@@ -1193,70 +1204,238 @@ async function upsertExportRequestCache(
   }
 }
 
-async function markPackageJobWorkerEnqueueFailed(
+async function linkPackageArtifactWorkerJob(
   supabase: SupabaseClient,
   args: {
+    artifactId: string;
     jobId: string;
-    userId: string;
+    workerJobId: string | null;
     nowIso: string;
-    errorCode: string;
-    errorMessage: string;
-    details?: unknown;
+    metadata: JsonRecord;
   },
 ): Promise<void> {
-  const diagnostics = {
-    phase: 'worker_jobs_enqueue_failed',
-    error_code: args.errorCode,
-    error_message: args.errorMessage,
-    details: args.details ?? null,
-  };
-
   const { error } = await supabase
-    .from('lca_package_jobs')
+    .from('lca_package_artifacts')
     .update({
-      status: 'failed',
-      diagnostics,
-      finished_at: args.nowIso,
+      worker_job_id: args.workerJobId,
+      metadata: args.metadata,
       updated_at: args.nowIso,
     })
-    .eq('id', args.jobId)
-    .eq('requested_by', args.userId);
+    .eq('id', args.artifactId)
+    .eq('job_id', args.jobId);
 
   if (error) {
-    console.error('mark package job worker_jobs enqueue failure failed', {
+    console.error('link package artifact worker job failed', {
       error: error.message,
       code: error.code,
+      artifact_id: args.artifactId,
       job_id: args.jobId,
-      user_id: args.userId,
+      worker_job_id: args.workerJobId,
     });
+    throw new TidasPackageError(
+      500,
+      'ARTIFACT_WORKER_JOB_LINK_FAILED',
+      'Failed to link package artifact to worker job',
+    );
   }
 }
 
-async function readJobIdByIdempotencyKey(
+async function fetchPreparedImportArtifactByIdempotencyKey(
   supabase: SupabaseClient,
-  idempotencyKey: string,
   userId: string,
-): Promise<string> {
+  idempotencyKey: string,
+): Promise<{
+  job_id: string;
+  source_artifact_id: string;
+  object_path: string;
+  artifact_url: string;
+} | null> {
   const { data, error } = await supabase
-    .from('lca_package_jobs')
-    .select('id')
-    .eq('idempotency_key', idempotencyKey)
-    .eq('requested_by', userId)
+    .from('lca_package_artifacts')
+    .select(
+      'id,worker_job_id,job_id,artifact_kind,status,artifact_url,artifact_sha256,artifact_byte_size,artifact_format,content_type,metadata,expires_at,is_pinned,created_at,updated_at',
+    )
+    .eq('artifact_kind', 'import_source')
+    .contains('metadata', {
+      requested_by: userId,
+      import_prepare_idempotency_key: idempotencyKey,
+    })
     .order('created_at', { ascending: false })
     .limit(1)
     .maybeSingle();
 
-  if (error || !data?.id) {
-    console.error('read lca_package_jobs by idempotency_key failed', {
-      error: error?.message,
-      code: error?.code,
-      idempotency_key: idempotencyKey,
+  if (error) {
+    console.error('query prepared import artifact by idempotency key failed', {
+      error: error.message,
+      code: error.code,
       user_id: userId,
     });
-    throw new TidasPackageError(500, 'JOB_LOOKUP_FAILED', 'Failed to read package job');
+    throw new TidasPackageError(500, 'JOB_LOOKUP_FAILED', 'Failed to read prepared import upload');
   }
 
-  return String(data.id);
+  if (!data) {
+    return null;
+  }
+
+  const artifact = toPackageArtifactRow(data);
+  const storagePath = parseStoragePathFromArtifactUrl(artifact.artifact_url);
+  if (!storagePath) {
+    throw new TidasPackageError(
+      500,
+      'IMPORT_ARTIFACT_STORAGE_PATH_INVALID',
+      'Prepared import artifact has an invalid storage path',
+    );
+  }
+
+  return {
+    job_id: String((data as { job_id?: unknown }).job_id),
+    source_artifact_id: artifact.id,
+    object_path: storagePath.objectPath,
+    artifact_url: artifact.artifact_url,
+  };
+}
+
+async function fetchOwnedWorkerPackageJobIfExists(
+  supabase: SupabaseClient,
+  userId: string,
+  workerJobId: string,
+  expectedJobKind?: string,
+): Promise<WorkerPackageJobRow | null> {
+  const { data, error } = await supabase
+    .from('worker_jobs')
+    .select(
+      'id,job_kind,status,requested_by,request_hash,payload_json,diagnostics,error_code,error_message,created_at,started_at,finished_at,updated_at',
+    )
+    .eq('id', workerJobId)
+    .eq('requested_by', userId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('query worker package job failed', {
+      error: error.message,
+      code: error.code,
+      worker_job_id: workerJobId,
+      user_id: userId,
+    });
+    throw new TidasPackageError(500, 'JOB_LOOKUP_FAILED', 'Failed to query package worker job');
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const row = toWorkerPackageJobRow(data);
+  if (expectedJobKind && row.job_kind !== expectedJobKind) {
+    return null;
+  }
+
+  return row;
+}
+
+async function fetchWorkerPackageJobForArtifacts(
+  supabase: SupabaseClient,
+  userId: string,
+  artifacts: PackageArtifactRow[],
+): Promise<WorkerPackageJobRow | null> {
+  const workerJobId = artifacts.find((artifact) => artifact.worker_job_id)?.worker_job_id;
+  if (!workerJobId) {
+    return null;
+  }
+
+  return await fetchOwnedWorkerPackageJobIfExists(supabase, userId, workerJobId);
+}
+
+function buildPackageJobRowFromWorkerOrArtifacts(
+  jobId: string,
+  workerJob: WorkerPackageJobRow | null,
+  artifacts: PackageArtifactRow[],
+): PackageJobRow {
+  const importSource = artifacts.find((artifact) => artifact.artifact_kind === 'import_source');
+  const payload = workerJob?.payload ?? {
+    type: 'import_package',
+    job_id: jobId,
+    source_artifact_id: importSource?.id,
+  };
+  const jobType = packageJobTypeFromPayload(payload);
+  const workerDiagnostics = isJsonRecord(workerJob?.diagnostics) ? workerJob?.diagnostics : null;
+  const diagnostics =
+    workerDiagnostics && Object.keys(workerDiagnostics).length > 0
+      ? workerDiagnostics
+      : {
+          phase: importSource?.metadata.phase ?? importSource?.metadata.upload_state ?? 'prepared',
+          worker_job_id: workerJob?.id ?? null,
+        };
+
+  return {
+    id: jobId,
+    job_type: jobType,
+    status: workerJob ? workerStatusToPackageStatus(workerJob.status) : 'stale',
+    scope: normalizeNullableString(payload.scope),
+    root_count: Array.isArray(payload.roots) ? payload.roots.length : 0,
+    request_key: workerJob?.request_hash ?? null,
+    payload,
+    diagnostics,
+    created_at: workerJob?.created_at ?? importSource?.created_at ?? null,
+    started_at: workerJob?.started_at ?? null,
+    finished_at: workerJob?.finished_at ?? null,
+    updated_at: workerJob?.updated_at ?? importSource?.updated_at ?? null,
+  };
+}
+
+function toWorkerPackageJobRow(data: Record<string, unknown>): WorkerPackageJobRow {
+  return {
+    id: String(data.id),
+    job_kind: String(data.job_kind),
+    status: String(data.status),
+    requested_by: data.requested_by ? String(data.requested_by) : null,
+    request_hash: data.request_hash ? String(data.request_hash) : null,
+    payload: isJsonRecord(data.payload_json) ? data.payload_json : {},
+    diagnostics: data.diagnostics ?? {},
+    error_code: data.error_code ? String(data.error_code) : null,
+    error_message: data.error_message ? String(data.error_message) : null,
+    created_at: data.created_at ? String(data.created_at) : null,
+    started_at: data.started_at ? String(data.started_at) : null,
+    finished_at: data.finished_at ? String(data.finished_at) : null,
+    updated_at: data.updated_at ? String(data.updated_at) : null,
+  };
+}
+
+function packageJobTypeFromPayload(payload: JsonRecord): TidasPackageJobType {
+  return payload.type === 'export_package' ? 'export_package' : 'import_package';
+}
+
+function workerStatusToPackageStatus(status: string): TidasPackageJobStatus {
+  switch (status) {
+    case 'completed':
+      return 'completed';
+    case 'failed':
+    case 'cancelled':
+      return 'failed';
+    case 'stale':
+      return 'stale';
+    case 'queued':
+    case 'waiting':
+    case 'blocked':
+      return 'queued';
+    case 'running':
+      return 'running';
+    default:
+      return 'stale';
+  }
+}
+
+function isActiveWorkerJobStatus(status: string): boolean {
+  return (
+    status === 'queued' || status === 'running' || status === 'waiting' || status === 'blocked'
+  );
+}
+
+function assertPackageArtifactOwnedBy(artifact: PackageArtifactRow, userId: string): void {
+  if (normalizeNullableString(artifact.metadata.requested_by) === userId) {
+    return;
+  }
+
+  throw new TidasPackageError(404, 'JOB_NOT_FOUND', 'Package job not found');
 }
 
 function buildRetryIdempotencyKey(
@@ -1269,7 +1448,7 @@ function buildRetryIdempotencyKey(
 
 export function resolveExportCacheAction(
   cacheRow: ExportRequestCacheRow,
-  jobRow: Pick<PackageJobRow, 'status'> | null,
+  jobRow: { status: string } | null,
 ): ExportCacheAction {
   if (!cacheRow.job_id || !jobRow) {
     return 'retry';
@@ -1333,69 +1512,6 @@ function parseEnqueueImportRequest(body: unknown): NormalizedEnqueueImportReques
     filename,
     content_type: contentType,
   };
-}
-
-async function fetchPreparedImportJob(
-  supabase: SupabaseClient,
-  userId: string,
-  idempotencyKey: string,
-): Promise<{
-  job_id: string;
-  source_artifact_id: string;
-  object_path: string;
-  artifact_url: string;
-}> {
-  const job = await fetchOwnedPackageJobByIdempotencyKey(supabase, userId, idempotencyKey);
-  const artifact = await fetchPackageArtifactByKind(supabase, job.id, 'import_source');
-  const storagePath = parseStoragePathFromArtifactUrl(artifact.artifact_url);
-
-  if (!storagePath) {
-    throw new TidasPackageError(
-      500,
-      'IMPORT_ARTIFACT_STORAGE_PATH_INVALID',
-      'Prepared import artifact has an invalid storage path',
-    );
-  }
-
-  return {
-    job_id: job.id,
-    source_artifact_id: artifact.id,
-    object_path: storagePath.objectPath,
-    artifact_url: artifact.artifact_url,
-  };
-}
-
-async function fetchOwnedPackageJobByIdempotencyKey(
-  supabase: SupabaseClient,
-  userId: string,
-  idempotencyKey: string,
-): Promise<PackageJobRow> {
-  const { data, error } = await supabase
-    .from('lca_package_jobs')
-    .select(
-      'id,job_type,status,scope,root_count,request_key,payload,diagnostics,created_at,started_at,finished_at,updated_at',
-    )
-    .eq('requested_by', userId)
-    .eq('idempotency_key', idempotencyKey)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  if (error) {
-    console.error('query lca_package_jobs by idempotency_key failed', {
-      error: error.message,
-      code: error.code,
-      idempotency_key: idempotencyKey,
-      user_id: userId,
-    });
-    throw new TidasPackageError(500, 'JOB_LOOKUP_FAILED', 'Failed to query package job');
-  }
-
-  if (!data) {
-    throw new TidasPackageError(404, 'JOB_NOT_FOUND', 'Package job not found');
-  }
-
-  return toPackageJobRow(data);
 }
 
 async function fetchOwnedPackageJobIfExists(
@@ -1497,7 +1613,7 @@ async function fetchPackageArtifact(
   const { data, error } = await supabase
     .from('lca_package_artifacts')
     .select(
-      'id,artifact_kind,status,artifact_url,artifact_sha256,artifact_byte_size,artifact_format,content_type,metadata,expires_at,is_pinned,created_at,updated_at',
+      'id,worker_job_id,artifact_kind,status,artifact_url,artifact_sha256,artifact_byte_size,artifact_format,content_type,metadata,expires_at,is_pinned,created_at,updated_at',
     )
     .eq('id', artifactId)
     .eq('job_id', jobId)
@@ -1553,7 +1669,7 @@ async function fetchPackageArtifactByKind(
   const { data, error } = await supabase
     .from('lca_package_artifacts')
     .select(
-      'id,artifact_kind,status,artifact_url,artifact_sha256,artifact_byte_size,artifact_format,content_type,metadata,expires_at,is_pinned,created_at,updated_at',
+      'id,worker_job_id,artifact_kind,status,artifact_url,artifact_sha256,artifact_byte_size,artifact_format,content_type,metadata,expires_at,is_pinned,created_at,updated_at',
     )
     .eq('job_id', jobId)
     .eq('artifact_kind', artifactKind)
@@ -1579,6 +1695,7 @@ async function fetchPackageArtifactByKind(
 function toPackageArtifactRow(data: Record<string, unknown>): PackageArtifactRow {
   return {
     id: String(data.id),
+    worker_job_id: data.worker_job_id ? String(data.worker_job_id) : null,
     artifact_kind: String(data.artifact_kind) as TidasPackageArtifactKind,
     status: String(data.status),
     artifact_url: String(data.artifact_url),

--- a/supabase/functions/_shared/worker_jobs_cutover.ts
+++ b/supabase/functions/_shared/worker_jobs_cutover.ts
@@ -47,6 +47,25 @@ export function workerJobIdFromRpcData(data: unknown): string | null {
   return typeof id === 'string' && id.length > 0 ? id : null;
 }
 
+function workerJobPayloadFromRpcData(data: unknown): Record<string, unknown> | null {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return null;
+  }
+
+  const payload = (data as { payload?: unknown }).payload;
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+
+  return payload as Record<string, unknown>;
+}
+
+export function workerJobPayloadStringFromRpcData(data: unknown, field: string): string | null {
+  const payload = workerJobPayloadFromRpcData(data);
+  const value = payload?.[field];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
 export async function enqueueCalculatorWorkerJob(
   supabase: SupabaseClient,
   request: WorkerJobEnqueueRequest,

--- a/supabase/functions/lca_contribution_path/index.ts
+++ b/supabase/functions/lca_contribution_path/index.ts
@@ -4,8 +4,8 @@ import '@supabase/functions-js/edge-runtime.d.ts';
 import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
 import { validateProcessEntriesInDataScope } from '../_shared/lca_process_scope.ts';
+import { ensureLcaSnapshotBuildQueued } from '../_shared/lca_snapshot_build_queue.ts';
 import {
-  buildSnapshotBuildPayloadFields,
   buildSnapshotContainsFilter,
   buildSnapshotProcessFilter,
   matchesSnapshotProcessFilter,
@@ -14,14 +14,13 @@ import {
   shouldAutoBuildSnapshot,
   type LcaDataScope,
   type ParsedSnapshotProcessFilter,
-  type SnapshotProcessFilter,
 } from '../_shared/lca_snapshot_scope.ts';
 import { getRedisClient } from '../_shared/redis_client.ts';
 import { supabaseAuthClient, supabaseClient } from '../_shared/supabase_client.ts';
 import {
   enqueueCalculatorWorkerJob,
   isWorkerJobsCutoverEnabled,
-  markRetainedLcaJobWorkerEnqueueFailed,
+  workerJobPayloadStringFromRpcData,
 } from '../_shared/worker_jobs_cutover.ts';
 
 type ContributionPathRequest = {
@@ -89,14 +88,11 @@ type ScopedSnapshotResolution =
   | { kind: 'stale'; snapshot_id: string }
   | { kind: 'none' };
 
-type BuildQueueResult =
-  | { ok: true; job_id: string; snapshot_id: string; worker_job_id?: string | null }
-  | { ok: false; error: string; status: number };
-
 type ResultCacheRow = {
   id: string;
   status: string;
   job_id: string | null;
+  worker_job_id: string | null;
   result_id: string | null;
   hit_count: number;
 };
@@ -118,9 +114,6 @@ type ContributionPathOptions = {
 };
 
 const REQUEST_VERSION = 'lca_contribution_path_v1';
-const SNAPSHOT_BUILD_REQUEST_VERSION = 'lca_snapshot_build_v1';
-const ACTIVE_BUILD_MAX_QUEUED_MS = 10 * 60 * 1000;
-const ACTIVE_BUILD_MAX_RUNNING_MS = 2 * 60 * 60 * 1000;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 Deno.serve(async (req) => {
@@ -194,7 +187,11 @@ Deno.serve(async (req) => {
       (snapshotMeta.error === 'no_ready_snapshot' ||
         snapshotMeta.error === 'snapshot_stale_rebuild_required');
     if (shouldQueueBuild) {
-      const queued = await ensureSnapshotBuildQueued(scope, userId, dataScope);
+      const queued = await ensureLcaSnapshotBuildQueued(supabaseClient, {
+        scope,
+        dataScope,
+        userId,
+      });
       if (!queued.ok) {
         return json({ error: queued.error }, queued.status);
       }
@@ -298,9 +295,9 @@ Deno.serve(async (req) => {
 
     if (
       (existingCache.row.status === 'pending' || existingCache.row.status === 'running') &&
-      existingCache.row.job_id
+      (existingCache.row.worker_job_id || existingCache.row.job_id)
     ) {
-      const cacheJobState = await fetchCacheJobState(existingCache.row.job_id);
+      const cacheJobState = await fetchCacheJobState(existingCache.row);
       if (cacheJobState.ok) {
         if (
           (cacheJobState.data.status === 'ready' || cacheJobState.data.status === 'completed') &&
@@ -322,12 +319,18 @@ Deno.serve(async (req) => {
           return json(cacheHit, 200);
         }
 
-        if (cacheJobState.data.status === 'queued' || cacheJobState.data.status === 'running') {
+        if (
+          cacheJobState.data.status === 'queued' ||
+          cacheJobState.data.status === 'running' ||
+          cacheJobState.data.status === 'waiting' ||
+          cacheJobState.data.status === 'blocked'
+        ) {
           const inProgress: ContributionPathResponse = {
             mode: 'in_progress',
             snapshot_id: snapshotId,
             cache_key: requestKey,
-            job_id: existingCache.row.job_id,
+            job_id: existingCache.row.job_id ?? undefined,
+            worker_job_id: existingCache.row.worker_job_id,
           };
           return json(inProgress, 200);
         }
@@ -346,7 +349,8 @@ Deno.serve(async (req) => {
           mode: 'in_progress',
           snapshot_id: snapshotId,
           cache_key: requestKey,
-          job_id: existingCache.row.job_id,
+          job_id: existingCache.row.job_id ?? undefined,
+          worker_job_id: existingCache.row.worker_job_id,
         };
         return json(inProgress, 200);
       }
@@ -380,88 +384,34 @@ Deno.serve(async (req) => {
     return json({ error: 'legacy_queue_disabled' }, 503);
   }
 
-  const { error: insertJobError } = await supabaseClient.from('lca_jobs').insert({
-    id: newJobId,
-    job_type: 'analyze_contribution_path',
-    snapshot_id: snapshotId,
-    status: 'queued',
+  const workerJob = await enqueueCalculatorWorkerJob(supabaseClient, {
+    jobKind: 'lca.contribution_path',
     payload,
-    diagnostics: {},
-    requested_by: userId,
-    request_key: requestKey,
-    idempotency_key: idempotencyKey,
-    created_at: nowIso,
-    updated_at: nowIso,
+    payloadSchemaVersion: 'lca.contribution_path.request.v1',
+    subjectType: 'lca_job',
+    subjectId: newJobId,
+    subjectVersion: snapshotId,
+    requestedBy: userId,
+    requesterType: 'user',
+    idempotencyKey,
+    requestHash: requestKey,
+    queueKey: snapshotId,
+    visibility: 'user',
   });
-
-  if (insertJobError && !isDuplicateKey(insertJobError.code)) {
-    console.error('insert lca_jobs failed', {
-      error: insertJobError.message,
-      code: insertJobError.code,
-      idempotency_key: idempotencyKey,
+  if (!workerJob.ok) {
+    console.error('enqueue contribution path worker_jobs job failed', {
+      error: workerJob.error,
+      status: workerJob.status,
+      details: workerJob.details,
+      lca_job_id: newJobId,
     });
-    return json({ error: 'job_insert_failed' }, 500);
+    return json(
+      { error: 'worker_jobs_enqueue_failed', details: workerJob.error },
+      workerJob.status,
+    );
   }
-
-  const { data: jobRow, error: jobReadError } = await supabaseClient
-    .from('lca_jobs')
-    .select('id')
-    .eq('idempotency_key', idempotencyKey)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  if (jobReadError || !jobRow?.id) {
-    console.error('read lca_jobs by idempotency_key failed', {
-      error: jobReadError?.message,
-      code: jobReadError?.code,
-      idempotency_key: idempotencyKey,
-    });
-    return json({ error: 'job_lookup_failed' }, 500);
-  }
-
-  const finalJobId = String(jobRow.id);
-  let finalWorkerJobId: string | null = null;
-  if (finalJobId === newJobId) {
-    const workerJob = await enqueueCalculatorWorkerJob(supabaseClient, {
-      jobKind: 'lca.contribution_path',
-      payload: {
-        ...payload,
-        job_id: finalJobId,
-      },
-      payloadSchemaVersion: 'lca.contribution_path.request.v1',
-      subjectType: 'lca_job',
-      subjectId: finalJobId,
-      subjectVersion: snapshotId,
-      requestedBy: userId,
-      requesterType: 'user',
-      idempotencyKey,
-      requestHash: requestKey,
-      queueKey: snapshotId,
-      visibility: 'user',
-    });
-    if (!workerJob.ok) {
-      console.error('enqueue contribution path worker_jobs job failed', {
-        error: workerJob.error,
-        status: workerJob.status,
-        details: workerJob.details,
-        lca_job_id: finalJobId,
-      });
-      await markRetainedLcaJobWorkerEnqueueFailed(supabaseClient, {
-        jobId: finalJobId,
-        userId,
-        nowIso,
-        errorCode: workerJob.error,
-        errorMessage: 'Failed to enqueue contribution path worker job',
-        details: workerJob.details,
-      });
-      return json(
-        { error: 'worker_jobs_enqueue_failed', details: workerJob.error },
-        workerJob.status,
-      );
-    }
-    finalWorkerJobId = workerJob.workerJobId;
-  }
+  const finalJobId = workerJobPayloadStringFromRpcData(workerJob.data, 'job_id') ?? newJobId;
+  const finalWorkerJobId = workerJob.workerJobId;
 
   if (existingCache.row) {
     const { error: cacheUpdateError } = await supabaseClient
@@ -469,6 +419,7 @@ Deno.serve(async (req) => {
       .update({
         status: 'pending',
         job_id: finalJobId,
+        worker_job_id: finalWorkerJobId,
         request_payload: normalizedRequest,
         hit_count: existingCache.row.hit_count + 1,
         last_accessed_at: nowIso,
@@ -491,6 +442,7 @@ Deno.serve(async (req) => {
       request_payload: normalizedRequest,
       status: 'pending',
       job_id: finalJobId,
+      worker_job_id: finalWorkerJobId,
       hit_count: 1,
       last_accessed_at: nowIso,
       created_at: nowIso,
@@ -555,7 +507,7 @@ async function fetchResultCache(
 ): Promise<{ ok: true; row: ResultCacheRow | null } | { ok: false }> {
   const { data, error } = await supabaseClient
     .from('lca_result_cache')
-    .select('id,status,job_id,result_id,hit_count')
+    .select('id,status,job_id,worker_job_id,result_id,hit_count')
     .eq('scope', scope)
     .eq('snapshot_id', snapshotId)
     .eq('request_key', requestKey)
@@ -581,6 +533,7 @@ async function fetchResultCache(
       id: String(data.id),
       status: String(data.status),
       job_id: data.job_id ? String(data.job_id) : null,
+      worker_job_id: data.worker_job_id ? String(data.worker_job_id) : null,
       result_id: data.result_id ? String(data.result_id) : null,
       hit_count: Number(data.hit_count ?? 0),
     },
@@ -647,6 +600,70 @@ async function updateResultCacheState(
 }
 
 async function fetchCacheJobState(
+  row: ResultCacheRow,
+): Promise<{ ok: true; data: CacheJobState } | { ok: false }> {
+  if (row.worker_job_id) {
+    return await fetchWorkerCacheJobState(row.worker_job_id);
+  }
+
+  if (!row.job_id) {
+    return { ok: false };
+  }
+
+  return await fetchLegacyCacheJobState(row.job_id);
+}
+
+async function fetchWorkerCacheJobState(
+  workerJobId: string,
+): Promise<{ ok: true; data: CacheJobState } | { ok: false }> {
+  const { data: jobData, error: jobError } = await supabaseClient
+    .from('worker_jobs')
+    .select('id,status')
+    .eq('id', workerJobId)
+    .maybeSingle();
+
+  if (jobError) {
+    console.warn('fetch worker cache job state failed', {
+      error: jobError.message,
+      worker_job_id: workerJobId,
+    });
+    return { ok: false };
+  }
+
+  if (!jobData) {
+    return { ok: false };
+  }
+
+  let resultId: string | null = null;
+  if (jobData.status === 'completed') {
+    const { data: resultData, error: resultError } = await supabaseClient
+      .from('lca_results')
+      .select('id')
+      .eq('worker_job_id', workerJobId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (resultError) {
+      console.warn('fetch contribution path result by worker_job_id failed', {
+        error: resultError.message,
+        worker_job_id: workerJobId,
+      });
+      return { ok: false };
+    }
+    resultId = resultData?.id ? String(resultData.id) : null;
+  }
+
+  return {
+    ok: true,
+    data: {
+      status: String(jobData.status),
+      result_id: resultId,
+    },
+  };
+}
+
+async function fetchLegacyCacheJobState(
   jobId: string,
 ): Promise<{ ok: true; data: CacheJobState } | { ok: false }> {
   const { data: jobData, error: jobError } = await supabaseClient
@@ -908,241 +925,6 @@ async function fetchTableMaxModifiedAt(
     return null;
   }
   return data?.modified_at ? String(data.modified_at) : null;
-}
-
-async function ensureSnapshotBuildQueued(
-  scope: string,
-  userId: string,
-  dataScope: LcaDataScope = 'current_user',
-): Promise<BuildQueueResult> {
-  const processFilter = buildSnapshotProcessFilter(dataScope, userId);
-  const activeBuild = await findActiveBuildJob(scope, processFilter);
-  if (!activeBuild.ok) {
-    return activeBuild;
-  }
-  if (activeBuild.job_id && activeBuild.snapshot_id) {
-    return { ok: true, job_id: activeBuild.job_id, snapshot_id: activeBuild.snapshot_id };
-  }
-
-  const snapshotId = crypto.randomUUID();
-  const jobId = crypto.randomUUID();
-  const buildPayload = {
-    type: 'build_snapshot',
-    job_id: jobId,
-    snapshot_id: snapshotId,
-    scope,
-    ...buildSnapshotBuildPayloadFields(processFilter),
-    reference_normalization_mode: 'lenient',
-    allocation_fraction_mode: 'lenient',
-    self_loop_cutoff: 0.999999,
-    singular_eps: 1e-12,
-    no_lcia: false,
-  };
-  const requestKey = await sha256Hex(
-    JSON.stringify({
-      version: SNAPSHOT_BUILD_REQUEST_VERSION,
-      scope,
-      process_filter: processFilter,
-      payload: buildPayload,
-    }),
-  );
-
-  const { error: snapshotInsertError } = await supabaseClient.from('lca_network_snapshots').insert({
-    id: snapshotId,
-    scope: 'full_library',
-    process_filter: processFilter,
-    status: 'draft',
-    created_by: userId,
-  });
-  if (snapshotInsertError && !isDuplicateKey(snapshotInsertError.code)) {
-    console.error('insert lca_network_snapshots failed', {
-      error: snapshotInsertError.message,
-      code: snapshotInsertError.code,
-      snapshot_id: snapshotId,
-    });
-    return { ok: false, error: 'snapshot_build_seed_failed', status: 500 };
-  }
-
-  if (!isWorkerJobsCutoverEnabled('LCA_WORKER_JOBS_ENABLED')) {
-    console.error('legacy lca snapshot queue fallback is disabled before job insert', {
-      request_key: requestKey,
-      snapshot_id: snapshotId,
-    });
-    return { ok: false, error: 'legacy_queue_disabled', status: 503 };
-  }
-
-  const nowIso = new Date().toISOString();
-  const { error: jobInsertError } = await supabaseClient.from('lca_jobs').insert({
-    id: jobId,
-    job_type: 'build_snapshot',
-    snapshot_id: snapshotId,
-    status: 'queued',
-    payload: buildPayload,
-    diagnostics: {},
-    requested_by: userId,
-    request_key: requestKey,
-    idempotency_key: `${userId}:${requestKey}`,
-    created_at: nowIso,
-    updated_at: nowIso,
-  });
-  if (jobInsertError && !isDuplicateKey(jobInsertError.code)) {
-    console.error('insert build lca_jobs failed', {
-      error: jobInsertError.message,
-      code: jobInsertError.code,
-      job_id: jobId,
-    });
-    return { ok: false, error: 'snapshot_build_job_insert_failed', status: 500 };
-  }
-
-  const { data: jobRow, error: jobReadError } = await supabaseClient
-    .from('lca_jobs')
-    .select('id,snapshot_id')
-    .eq('request_key', requestKey)
-    .eq('job_type', 'build_snapshot')
-    .eq('requested_by', userId)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
-  if (jobReadError || !jobRow?.id || !jobRow?.snapshot_id) {
-    console.error('read build lca_jobs failed', {
-      error: jobReadError?.message,
-      code: jobReadError?.code,
-      request_key: requestKey,
-    });
-    return { ok: false, error: 'snapshot_build_job_lookup_failed', status: 500 };
-  }
-
-  const finalJobId = String(jobRow.id);
-  const finalSnapshotId = String(jobRow.snapshot_id);
-  let finalWorkerJobId: string | null = null;
-  if (finalJobId === jobId) {
-    const workerJob = await enqueueCalculatorWorkerJob(supabaseClient, {
-      jobKind: 'lca.build_snapshot',
-      payload: {
-        ...buildPayload,
-        job_id: finalJobId,
-        snapshot_id: finalSnapshotId,
-      },
-      payloadSchemaVersion: 'lca.build_snapshot.request.v1',
-      subjectType: 'lca_job',
-      subjectId: finalJobId,
-      subjectVersion: finalSnapshotId,
-      requestedBy: userId,
-      requesterType: 'user',
-      idempotencyKey: `${userId}:${requestKey}`,
-      requestHash: requestKey,
-      concurrencyKey: `lca.build_snapshot:${scope}:${requestKey}`,
-      queueKey: scope,
-      visibility: 'user',
-    });
-    if (!workerJob.ok) {
-      console.error('enqueue build snapshot worker_jobs job failed', {
-        error: workerJob.error,
-        status: workerJob.status,
-        details: workerJob.details,
-        lca_job_id: finalJobId,
-        snapshot_id: finalSnapshotId,
-      });
-      await markRetainedLcaJobWorkerEnqueueFailed(supabaseClient, {
-        jobId: finalJobId,
-        userId,
-        nowIso,
-        errorCode: workerJob.error,
-        errorMessage: 'Failed to enqueue snapshot build worker job',
-        details: workerJob.details,
-      });
-      return {
-        ok: false,
-        error: 'snapshot_build_worker_jobs_enqueue_failed',
-        status: workerJob.status,
-      };
-    }
-    finalWorkerJobId = workerJob.workerJobId;
-  }
-
-  return {
-    ok: true,
-    job_id: finalJobId,
-    snapshot_id: finalSnapshotId,
-    worker_job_id: finalWorkerJobId,
-  };
-}
-
-async function findActiveBuildJob(
-  scope: string,
-  expectedProcessFilter: SnapshotProcessFilter,
-): Promise<
-  | { ok: true; job_id: string | null; snapshot_id: string | null }
-  | { ok: false; error: string; status: number }
-> {
-  const { data: rows, error } = await supabaseClient
-    .from('lca_jobs')
-    .select('id,snapshot_id,payload,status,created_at,started_at')
-    .eq('job_type', 'build_snapshot')
-    .in('status', ['queued', 'running'])
-    .order('created_at', { ascending: false })
-    .limit(100);
-
-  if (error) {
-    console.error('read active build lca_jobs failed', {
-      error: error.message,
-      code: error.code,
-    });
-    return { ok: false, error: 'snapshot_build_job_lookup_failed', status: 500 };
-  }
-
-  for (const row of rows ?? []) {
-    const status = String((row as { status?: unknown }).status ?? '');
-    const nowMs = Date.now();
-    const createdAtRaw = (row as { created_at?: unknown }).created_at;
-    const createdAtMs =
-      createdAtRaw === null || createdAtRaw === undefined
-        ? Number.NaN
-        : Date.parse(String(createdAtRaw));
-    const startedAtRaw = (row as { started_at?: unknown }).started_at;
-    const startedAtMs =
-      startedAtRaw === null || startedAtRaw === undefined
-        ? Number.NaN
-        : Date.parse(String(startedAtRaw));
-    if (
-      status === 'queued' &&
-      Number.isFinite(createdAtMs) &&
-      nowMs - createdAtMs > ACTIVE_BUILD_MAX_QUEUED_MS
-    ) {
-      continue;
-    }
-    if (
-      status === 'running' &&
-      Number.isFinite(startedAtMs) &&
-      nowMs - startedAtMs > ACTIVE_BUILD_MAX_RUNNING_MS
-    ) {
-      continue;
-    }
-
-    const payload = (row as { payload?: unknown }).payload as { scope?: unknown } | undefined;
-    if ((payload?.scope ?? '') !== scope) {
-      continue;
-    }
-    const jobId = String((row as { id?: unknown }).id ?? '').trim();
-    const snapshotId = String((row as { snapshot_id?: unknown }).snapshot_id ?? '').trim();
-    if (!jobId || !snapshotId) {
-      continue;
-    }
-    const { data: snap, error: snapErr } = await supabaseClient
-      .from('lca_network_snapshots')
-      .select('process_filter')
-      .eq('id', snapshotId)
-      .maybeSingle();
-    if (snapErr || !snap) {
-      continue;
-    }
-    const filter = (snap as { process_filter?: unknown }).process_filter;
-    if (matchesSnapshotProcessFilter(filter, expectedProcessFilter)) {
-      return { ok: true, job_id: jobId, snapshot_id: snapshotId };
-    }
-  }
-
-  return { ok: true, job_id: null, snapshot_id: null };
 }
 
 async function fetchSnapshotArtifactMeta(

--- a/supabase/functions/lca_query_results/index.ts
+++ b/supabase/functions/lca_query_results/index.ts
@@ -9,8 +9,8 @@ import {
   processScopeLookupKey,
   validateProcessEntriesInDataScope,
 } from '../_shared/lca_process_scope.ts';
+import { ensureLcaSnapshotBuildQueued } from '../_shared/lca_snapshot_build_queue.ts';
 import {
-  buildSnapshotBuildPayloadFields,
   buildSnapshotContainsFilter,
   buildSnapshotProcessFilter,
   matchesSnapshotProcessFilter,
@@ -19,21 +19,12 @@ import {
   shouldAutoBuildSnapshot,
   type LcaDataScope,
   type ParsedSnapshotProcessFilter,
-  type SnapshotProcessFilter,
 } from '../_shared/lca_snapshot_scope.ts';
 import { getRedisClient } from '../_shared/redis_client.ts';
 import { supabaseAuthClient, supabaseClient } from '../_shared/supabase_client.ts';
-import {
-  enqueueCalculatorWorkerJob,
-  isWorkerJobsCutoverEnabled,
-  markRetainedLcaJobWorkerEnqueueFailed,
-} from '../_shared/worker_jobs_cutover.ts';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const ALL_UNIT_QUERY_FORMAT = 'all-unit-query:v1';
-const SNAPSHOT_BUILD_REQUEST_VERSION = 'lca_snapshot_build_v1';
-const ACTIVE_BUILD_MAX_QUEUED_MS = 10 * 60 * 1000;
-const ACTIVE_BUILD_MAX_RUNNING_MS = 2 * 60 * 60 * 1000;
 const DEFAULT_HOTSPOT_LIMIT = 20;
 const MAX_HOTSPOT_LIMIT = 200;
 
@@ -103,10 +94,6 @@ type ScopedSnapshotResolution =
   | { kind: 'fresh'; data: ReadySnapshotMeta }
   | { kind: 'stale'; snapshot_id: string }
   | { kind: 'none' };
-
-type BuildQueueResult =
-  | { ok: true; job_id: string; snapshot_id: string; worker_job_id?: string | null }
-  | { ok: false; error: string; status: number };
 
 type LatestAllUnitRow = {
   snapshot_id: string;
@@ -187,7 +174,11 @@ Deno.serve(async (req) => {
       (snapshotMeta.error === 'no_ready_snapshot' ||
         snapshotMeta.error === 'snapshot_stale_rebuild_required');
     if (shouldQueueBuild) {
-      const queued = await ensureSnapshotBuildQueued(scope, userId, dataScope);
+      const queued = await ensureLcaSnapshotBuildQueued(supabaseClient, {
+        scope,
+        dataScope,
+        userId,
+      });
       if (!queued.ok) {
         return json({ error: queued.error }, queued.status);
       }
@@ -745,241 +736,6 @@ async function fetchTableMaxModifiedAt(
   return data?.modified_at ? String(data.modified_at) : null;
 }
 
-async function ensureSnapshotBuildQueued(
-  scope: string,
-  userId: string,
-  dataScope: LcaDataScope = 'current_user',
-): Promise<BuildQueueResult> {
-  const processFilter = buildSnapshotProcessFilter(dataScope, userId);
-  const activeBuild = await findActiveBuildJob(scope, processFilter);
-  if (!activeBuild.ok) {
-    return activeBuild;
-  }
-  if (activeBuild.job_id && activeBuild.snapshot_id) {
-    return { ok: true, job_id: activeBuild.job_id, snapshot_id: activeBuild.snapshot_id };
-  }
-
-  const snapshotId = crypto.randomUUID();
-  const jobId = crypto.randomUUID();
-  const buildPayload = {
-    type: 'build_snapshot',
-    job_id: jobId,
-    snapshot_id: snapshotId,
-    scope,
-    ...buildSnapshotBuildPayloadFields(processFilter),
-    reference_normalization_mode: 'lenient',
-    allocation_fraction_mode: 'lenient',
-    self_loop_cutoff: 0.999999,
-    singular_eps: 1e-12,
-    no_lcia: false,
-  };
-  const requestKey = await sha256Hex(
-    JSON.stringify({
-      version: SNAPSHOT_BUILD_REQUEST_VERSION,
-      scope,
-      process_filter: processFilter,
-      payload: buildPayload,
-    }),
-  );
-
-  const { error: snapshotInsertError } = await supabaseClient.from('lca_network_snapshots').insert({
-    id: snapshotId,
-    scope: 'full_library',
-    process_filter: processFilter,
-    status: 'draft',
-    created_by: userId,
-  });
-  if (snapshotInsertError && !isDuplicateKey(snapshotInsertError.code)) {
-    console.error('insert lca_network_snapshots failed', {
-      error: snapshotInsertError.message,
-      code: snapshotInsertError.code,
-      snapshot_id: snapshotId,
-    });
-    return { ok: false, error: 'snapshot_build_seed_failed', status: 500 };
-  }
-
-  if (!isWorkerJobsCutoverEnabled('LCA_WORKER_JOBS_ENABLED')) {
-    console.error('legacy lca snapshot queue fallback is disabled before job insert', {
-      request_key: requestKey,
-      snapshot_id: snapshotId,
-    });
-    return { ok: false, error: 'legacy_queue_disabled', status: 503 };
-  }
-
-  const nowIso = new Date().toISOString();
-  const { error: jobInsertError } = await supabaseClient.from('lca_jobs').insert({
-    id: jobId,
-    job_type: 'build_snapshot',
-    snapshot_id: snapshotId,
-    status: 'queued',
-    payload: buildPayload,
-    diagnostics: {},
-    requested_by: userId,
-    request_key: requestKey,
-    idempotency_key: `${userId}:${requestKey}`,
-    created_at: nowIso,
-    updated_at: nowIso,
-  });
-  if (jobInsertError && !isDuplicateKey(jobInsertError.code)) {
-    console.error('insert build lca_jobs failed', {
-      error: jobInsertError.message,
-      code: jobInsertError.code,
-      job_id: jobId,
-    });
-    return { ok: false, error: 'snapshot_build_job_insert_failed', status: 500 };
-  }
-
-  const { data: jobRow, error: jobReadError } = await supabaseClient
-    .from('lca_jobs')
-    .select('id,snapshot_id')
-    .eq('request_key', requestKey)
-    .eq('job_type', 'build_snapshot')
-    .eq('requested_by', userId)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
-  if (jobReadError || !jobRow?.id || !jobRow?.snapshot_id) {
-    console.error('read build lca_jobs failed', {
-      error: jobReadError?.message,
-      code: jobReadError?.code,
-      request_key: requestKey,
-    });
-    return { ok: false, error: 'snapshot_build_job_lookup_failed', status: 500 };
-  }
-
-  const finalJobId = String(jobRow.id);
-  const finalSnapshotId = String(jobRow.snapshot_id);
-  let finalWorkerJobId: string | null = null;
-  if (finalJobId === jobId) {
-    const workerJob = await enqueueCalculatorWorkerJob(supabaseClient, {
-      jobKind: 'lca.build_snapshot',
-      payload: {
-        ...buildPayload,
-        job_id: finalJobId,
-        snapshot_id: finalSnapshotId,
-      },
-      payloadSchemaVersion: 'lca.build_snapshot.request.v1',
-      subjectType: 'lca_job',
-      subjectId: finalJobId,
-      subjectVersion: finalSnapshotId,
-      requestedBy: userId,
-      requesterType: 'user',
-      idempotencyKey: `${userId}:${requestKey}`,
-      requestHash: requestKey,
-      concurrencyKey: `lca.build_snapshot:${scope}:${requestKey}`,
-      queueKey: scope,
-      visibility: 'user',
-    });
-    if (!workerJob.ok) {
-      console.error('enqueue build snapshot worker_jobs job failed', {
-        error: workerJob.error,
-        status: workerJob.status,
-        details: workerJob.details,
-        lca_job_id: finalJobId,
-        snapshot_id: finalSnapshotId,
-      });
-      await markRetainedLcaJobWorkerEnqueueFailed(supabaseClient, {
-        jobId: finalJobId,
-        userId,
-        nowIso,
-        errorCode: workerJob.error,
-        errorMessage: 'Failed to enqueue snapshot build worker job',
-        details: workerJob.details,
-      });
-      return {
-        ok: false,
-        error: 'snapshot_build_worker_jobs_enqueue_failed',
-        status: workerJob.status,
-      };
-    }
-    finalWorkerJobId = workerJob.workerJobId;
-  }
-
-  return {
-    ok: true,
-    job_id: finalJobId,
-    snapshot_id: finalSnapshotId,
-    worker_job_id: finalWorkerJobId,
-  };
-}
-
-async function findActiveBuildJob(
-  scope: string,
-  expectedProcessFilter: SnapshotProcessFilter,
-): Promise<
-  | { ok: true; job_id: string | null; snapshot_id: string | null }
-  | { ok: false; error: string; status: number }
-> {
-  const { data: rows, error } = await supabaseClient
-    .from('lca_jobs')
-    .select('id,snapshot_id,payload,status,created_at,started_at')
-    .eq('job_type', 'build_snapshot')
-    .in('status', ['queued', 'running'])
-    .order('created_at', { ascending: false })
-    .limit(100);
-
-  if (error) {
-    console.error('read active build lca_jobs failed', {
-      error: error.message,
-      code: error.code,
-    });
-    return { ok: false, error: 'snapshot_build_job_lookup_failed', status: 500 };
-  }
-
-  for (const row of rows ?? []) {
-    const status = String((row as { status?: unknown }).status ?? '');
-    const nowMs = Date.now();
-    const createdAtRaw = (row as { created_at?: unknown }).created_at;
-    const createdAtMs =
-      createdAtRaw === null || createdAtRaw === undefined
-        ? Number.NaN
-        : Date.parse(String(createdAtRaw));
-    const startedAtRaw = (row as { started_at?: unknown }).started_at;
-    const startedAtMs =
-      startedAtRaw === null || startedAtRaw === undefined
-        ? Number.NaN
-        : Date.parse(String(startedAtRaw));
-    if (
-      status === 'queued' &&
-      Number.isFinite(createdAtMs) &&
-      nowMs - createdAtMs > ACTIVE_BUILD_MAX_QUEUED_MS
-    ) {
-      continue;
-    }
-    if (
-      status === 'running' &&
-      Number.isFinite(startedAtMs) &&
-      nowMs - startedAtMs > ACTIVE_BUILD_MAX_RUNNING_MS
-    ) {
-      continue;
-    }
-
-    const payload = (row as { payload?: unknown }).payload as { scope?: unknown } | undefined;
-    if ((payload?.scope ?? '') !== scope) {
-      continue;
-    }
-    const jobId = String((row as { id?: unknown }).id ?? '').trim();
-    const snapshotId = String((row as { snapshot_id?: unknown }).snapshot_id ?? '').trim();
-    if (!jobId || !snapshotId) {
-      continue;
-    }
-    const { data: snap, error: snapErr } = await supabaseClient
-      .from('lca_network_snapshots')
-      .select('process_filter')
-      .eq('id', snapshotId)
-      .maybeSingle();
-    if (snapErr || !snap) {
-      continue;
-    }
-    const filter = (snap as { process_filter?: unknown }).process_filter;
-    if (matchesSnapshotProcessFilter(filter, expectedProcessFilter)) {
-      return { ok: true, job_id: jobId, snapshot_id: snapshotId };
-    }
-  }
-
-  return { ok: true, job_id: null, snapshot_id: null };
-}
-
 async function fetchSnapshotArtifactMeta(
   snapshotId: string,
 ): Promise<
@@ -1150,10 +906,6 @@ function amountForProcessIndex(payload: unknown, processIndex: number): number |
     return null;
   }
   return amount;
-}
-
-function isDuplicateKey(code: string | undefined): boolean {
-  return code === '23505';
 }
 
 function processEntryForId(
@@ -1402,13 +1154,6 @@ async function fetchJsonByHttp<T>(
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : 'fetch_failed' };
   }
-}
-
-async function sha256Hex(input: string): Promise<string> {
-  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
 }
 
 function json(body: unknown, status = 200): Response {

--- a/supabase/functions/lca_solve/index.ts
+++ b/supabase/functions/lca_solve/index.ts
@@ -4,8 +4,8 @@ import '@supabase/functions-js/edge-runtime.d.ts';
 import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
 import { validateProcessEntriesInDataScope } from '../_shared/lca_process_scope.ts';
+import { ensureLcaSnapshotBuildQueued } from '../_shared/lca_snapshot_build_queue.ts';
 import {
-  buildSnapshotBuildPayloadFields,
   buildSnapshotContainsFilter,
   buildSnapshotProcessFilter,
   matchesSnapshotProcessFilter,
@@ -14,7 +14,6 @@ import {
   shouldAutoBuildSnapshot,
   type LcaDataScope,
   type ParsedSnapshotProcessFilter,
-  type SnapshotProcessFilter,
 } from '../_shared/lca_snapshot_scope.ts';
 import { getRedisClient } from '../_shared/redis_client.ts';
 import { supabaseAuthClient, supabaseClient } from '../_shared/supabase_client.ts';
@@ -22,8 +21,8 @@ import {
   enqueueCalculatorWorkerJob,
   isWorkerJobsCutoverEnabled,
   lcaWorkerJobKindForJobType,
-  markRetainedLcaJobWorkerEnqueueFailed,
   workerJobPayloadSchemaVersion,
+  workerJobPayloadStringFromRpcData,
 } from '../_shared/worker_jobs_cutover.ts';
 
 type SolveRequest = {
@@ -81,14 +80,12 @@ type ResultCacheRow = {
   id: string;
   status: string;
   job_id: string | null;
+  worker_job_id: string | null;
   result_id: string | null;
   hit_count: number;
 };
 
 const REQUEST_VERSION = 'lca_solve_v2';
-const SNAPSHOT_BUILD_REQUEST_VERSION = 'lca_snapshot_build_v1';
-const ACTIVE_BUILD_MAX_QUEUED_MS = 10 * 60 * 1000;
-const ACTIVE_BUILD_MAX_RUNNING_MS = 2 * 60 * 60 * 1000;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 Deno.serve(async (req) => {
@@ -144,7 +141,11 @@ Deno.serve(async (req) => {
       (snapshotMeta.error === 'no_ready_snapshot' ||
         snapshotMeta.error === 'snapshot_stale_rebuild_required');
     if (shouldQueueBuild) {
-      const queued = await ensureSnapshotBuildQueued(scope, dataScope, userId);
+      const queued = await ensureLcaSnapshotBuildQueued(supabaseClient, {
+        scope,
+        dataScope,
+        userId,
+      });
       if (!queued.ok) {
         return json({ error: queued.error }, queued.status);
       }
@@ -359,13 +360,14 @@ Deno.serve(async (req) => {
 
     if (
       (existingCache.row.status === 'pending' || existingCache.row.status === 'running') &&
-      existingCache.row.job_id
+      (existingCache.row.worker_job_id || existingCache.row.job_id)
     ) {
       const inProgress: SolveResponse = {
         mode: 'in_progress',
         snapshot_id: snapshotId,
         cache_key: requestKey,
-        job_id: existingCache.row.job_id,
+        job_id: existingCache.row.job_id ?? undefined,
+        worker_job_id: existingCache.row.worker_job_id,
       };
       return json(inProgress, 200);
     }
@@ -380,94 +382,39 @@ Deno.serve(async (req) => {
     return json({ error: 'legacy_queue_disabled' }, 503);
   }
 
-  const { error: insertJobError } = await supabaseClient.from('lca_jobs').insert({
-    id: newJobId,
-    job_type: jobType,
-    snapshot_id: snapshotId,
-    status: 'queued',
+  const jobKind = lcaWorkerJobKindForJobType(jobType);
+  if (!jobKind) {
+    return json({ error: 'worker_job_kind_unsupported' }, 500);
+  }
+
+  const workerJob = await enqueueCalculatorWorkerJob(supabaseClient, {
+    jobKind,
     payload,
-    diagnostics: {},
-    requested_by: userId,
-    request_key: requestKey,
-    idempotency_key: idempotencyKey,
-    created_at: nowIso,
-    updated_at: nowIso,
+    payloadSchemaVersion: workerJobPayloadSchemaVersion(jobKind),
+    subjectType: 'lca_job',
+    subjectId: newJobId,
+    subjectVersion: snapshotId,
+    requestedBy: userId,
+    requesterType: 'user',
+    idempotencyKey,
+    requestHash: requestKey,
+    queueKey: snapshotId,
+    visibility: 'user',
   });
-
-  if (insertJobError && !isDuplicateKey(insertJobError.code)) {
-    console.error('insert lca_jobs failed', {
-      error: insertJobError.message,
-      code: insertJobError.code,
-      idempotency_key: idempotencyKey,
+  if (!workerJob.ok) {
+    console.error('enqueue lca worker_jobs job failed', {
+      error: workerJob.error,
+      status: workerJob.status,
+      details: workerJob.details,
+      lca_job_id: newJobId,
     });
-    return json({ error: 'job_insert_failed' }, 500);
+    return json(
+      { error: 'worker_jobs_enqueue_failed', details: workerJob.error },
+      workerJob.status,
+    );
   }
-
-  const { data: jobRow, error: jobReadError } = await supabaseClient
-    .from('lca_jobs')
-    .select('id')
-    .eq('idempotency_key', idempotencyKey)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  if (jobReadError || !jobRow?.id) {
-    console.error('read lca_jobs by idempotency_key failed', {
-      error: jobReadError?.message,
-      code: jobReadError?.code,
-      idempotency_key: idempotencyKey,
-    });
-    return json({ error: 'job_lookup_failed' }, 500);
-  }
-
-  const finalJobId = String(jobRow.id);
-  let finalWorkerJobId: string | null = null;
-
-  if (finalJobId === newJobId) {
-    const jobKind = lcaWorkerJobKindForJobType(jobType);
-    if (!jobKind) {
-      return json({ error: 'worker_job_kind_unsupported' }, 500);
-    }
-
-    const workerJob = await enqueueCalculatorWorkerJob(supabaseClient, {
-      jobKind,
-      payload: {
-        ...payload,
-        job_id: finalJobId,
-      },
-      payloadSchemaVersion: workerJobPayloadSchemaVersion(jobKind),
-      subjectType: 'lca_job',
-      subjectId: finalJobId,
-      subjectVersion: snapshotId,
-      requestedBy: userId,
-      requesterType: 'user',
-      idempotencyKey,
-      requestHash: requestKey,
-      queueKey: snapshotId,
-      visibility: 'user',
-    });
-    if (!workerJob.ok) {
-      console.error('enqueue lca worker_jobs job failed', {
-        error: workerJob.error,
-        status: workerJob.status,
-        details: workerJob.details,
-        lca_job_id: finalJobId,
-      });
-      await markRetainedLcaJobWorkerEnqueueFailed(supabaseClient, {
-        jobId: finalJobId,
-        userId,
-        nowIso,
-        errorCode: workerJob.error,
-        errorMessage: 'Failed to enqueue LCA worker job',
-        details: workerJob.details,
-      });
-      return json(
-        { error: 'worker_jobs_enqueue_failed', details: workerJob.error },
-        workerJob.status,
-      );
-    }
-    finalWorkerJobId = workerJob.workerJobId;
-  }
+  const finalJobId = workerJobPayloadStringFromRpcData(workerJob.data, 'job_id') ?? newJobId;
+  const finalWorkerJobId = workerJob.workerJobId;
 
   if (existingCache.row) {
     const { error: cacheUpdateError } = await supabaseClient
@@ -475,6 +422,7 @@ Deno.serve(async (req) => {
       .update({
         status: 'pending',
         job_id: finalJobId,
+        worker_job_id: finalWorkerJobId,
         request_payload: normalizedRequest,
         hit_count: existingCache.row.hit_count + 1,
         last_accessed_at: nowIso,
@@ -497,6 +445,7 @@ Deno.serve(async (req) => {
       request_payload: normalizedRequest,
       status: 'pending',
       job_id: finalJobId,
+      worker_job_id: finalWorkerJobId,
       hit_count: 1,
       last_accessed_at: nowIso,
       created_at: nowIso,
@@ -530,7 +479,7 @@ async function fetchResultCache(
 ): Promise<{ ok: true; row: ResultCacheRow | null } | { ok: false }> {
   const { data, error } = await supabaseClient
     .from('lca_result_cache')
-    .select('id,status,job_id,result_id,hit_count')
+    .select('id,status,job_id,worker_job_id,result_id,hit_count')
     .eq('scope', scope)
     .eq('snapshot_id', snapshotId)
     .eq('request_key', requestKey)
@@ -554,6 +503,7 @@ async function fetchResultCache(
       id: String(data.id),
       status: String(data.status),
       job_id: data.job_id ? String(data.job_id) : null,
+      worker_job_id: data.worker_job_id ? String(data.worker_job_id) : null,
       result_id: data.result_id ? String(data.result_id) : null,
       hit_count: Number(data.hit_count ?? 0),
     },
@@ -823,245 +773,6 @@ async function fetchTableMaxModifiedAt(
     return null;
   }
   return data?.modified_at ? String(data.modified_at) : null;
-}
-
-type BuildQueueResult =
-  | { ok: true; job_id: string; snapshot_id: string; worker_job_id?: string | null }
-  | { ok: false; error: string; status: number };
-
-async function ensureSnapshotBuildQueued(
-  scope: string,
-  dataScope: LcaDataScope,
-  userId: string,
-): Promise<BuildQueueResult> {
-  const processFilter = buildSnapshotProcessFilter(dataScope, userId);
-  const activeBuild = await findActiveBuildJob(scope, processFilter);
-  if (!activeBuild.ok) {
-    return activeBuild;
-  }
-  if (activeBuild.job_id && activeBuild.snapshot_id) {
-    return { ok: true, job_id: activeBuild.job_id, snapshot_id: activeBuild.snapshot_id };
-  }
-
-  const snapshotId = crypto.randomUUID();
-  const jobId = crypto.randomUUID();
-  const buildPayload = {
-    type: 'build_snapshot',
-    job_id: jobId,
-    snapshot_id: snapshotId,
-    scope,
-    ...buildSnapshotBuildPayloadFields(processFilter),
-    reference_normalization_mode: 'lenient',
-    allocation_fraction_mode: 'lenient',
-    self_loop_cutoff: 0.999999,
-    singular_eps: 1e-12,
-    no_lcia: false,
-  };
-  const requestKey = await sha256Hex(
-    JSON.stringify({
-      version: SNAPSHOT_BUILD_REQUEST_VERSION,
-      scope,
-      process_filter: processFilter,
-      payload: buildPayload,
-    }),
-  );
-
-  const { error: snapshotInsertError } = await supabaseClient.from('lca_network_snapshots').insert({
-    id: snapshotId,
-    scope: 'full_library',
-    process_filter: processFilter,
-    status: 'draft',
-    created_by: userId,
-  });
-  if (snapshotInsertError && snapshotInsertError.code !== '23505') {
-    console.error('insert lca_network_snapshots failed', {
-      error: snapshotInsertError.message,
-      code: snapshotInsertError.code,
-      snapshot_id: snapshotId,
-    });
-    return { ok: false, error: 'snapshot_build_seed_failed', status: 500 };
-  }
-
-  if (!isWorkerJobsCutoverEnabled('LCA_WORKER_JOBS_ENABLED')) {
-    console.error('legacy lca snapshot queue fallback is disabled before job insert', {
-      request_key: requestKey,
-      snapshot_id: snapshotId,
-    });
-    return { ok: false, error: 'legacy_queue_disabled', status: 503 };
-  }
-
-  const nowIso = new Date().toISOString();
-  const { error: jobInsertError } = await supabaseClient.from('lca_jobs').insert({
-    id: jobId,
-    job_type: 'build_snapshot',
-    snapshot_id: snapshotId,
-    status: 'queued',
-    payload: buildPayload,
-    diagnostics: {},
-    requested_by: userId,
-    request_key: requestKey,
-    idempotency_key: `${userId}:${requestKey}`,
-    created_at: nowIso,
-    updated_at: nowIso,
-  });
-  if (jobInsertError && jobInsertError.code !== '23505') {
-    console.error('insert build lca_jobs failed', {
-      error: jobInsertError.message,
-      code: jobInsertError.code,
-      job_id: jobId,
-    });
-    return { ok: false, error: 'snapshot_build_job_insert_failed', status: 500 };
-  }
-
-  const { data: jobRow, error: jobReadError } = await supabaseClient
-    .from('lca_jobs')
-    .select('id,snapshot_id')
-    .eq('request_key', requestKey)
-    .eq('job_type', 'build_snapshot')
-    .eq('requested_by', userId)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
-  if (jobReadError || !jobRow?.id || !jobRow?.snapshot_id) {
-    console.error('read build lca_jobs failed', {
-      error: jobReadError?.message,
-      code: jobReadError?.code,
-      request_key: requestKey,
-    });
-    return { ok: false, error: 'snapshot_build_job_lookup_failed', status: 500 };
-  }
-
-  const finalJobId = String(jobRow.id);
-  const finalSnapshotId = String(jobRow.snapshot_id);
-  let finalWorkerJobId: string | null = null;
-  if (finalJobId === jobId) {
-    const workerJob = await enqueueCalculatorWorkerJob(supabaseClient, {
-      jobKind: 'lca.build_snapshot',
-      payload: {
-        ...buildPayload,
-        job_id: finalJobId,
-        snapshot_id: finalSnapshotId,
-      },
-      payloadSchemaVersion: 'lca.build_snapshot.request.v1',
-      subjectType: 'lca_job',
-      subjectId: finalJobId,
-      subjectVersion: finalSnapshotId,
-      requestedBy: userId,
-      requesterType: 'user',
-      idempotencyKey: `${userId}:${requestKey}`,
-      requestHash: requestKey,
-      concurrencyKey: `lca.build_snapshot:${scope}:${requestKey}`,
-      queueKey: scope,
-      visibility: 'user',
-    });
-    if (!workerJob.ok) {
-      console.error('enqueue build snapshot worker_jobs job failed', {
-        error: workerJob.error,
-        status: workerJob.status,
-        details: workerJob.details,
-        lca_job_id: finalJobId,
-        snapshot_id: finalSnapshotId,
-      });
-      await markRetainedLcaJobWorkerEnqueueFailed(supabaseClient, {
-        jobId: finalJobId,
-        userId,
-        nowIso,
-        errorCode: workerJob.error,
-        errorMessage: 'Failed to enqueue snapshot build worker job',
-        details: workerJob.details,
-      });
-      return {
-        ok: false,
-        error: 'snapshot_build_worker_jobs_enqueue_failed',
-        status: workerJob.status,
-      };
-    }
-    finalWorkerJobId = workerJob.workerJobId;
-  }
-
-  return {
-    ok: true,
-    job_id: finalJobId,
-    snapshot_id: finalSnapshotId,
-    worker_job_id: finalWorkerJobId,
-  };
-}
-
-async function findActiveBuildJob(
-  scope: string,
-  expectedProcessFilter: SnapshotProcessFilter,
-): Promise<
-  | { ok: true; job_id: string | null; snapshot_id: string | null }
-  | { ok: false; error: string; status: number }
-> {
-  const { data: rows, error } = await supabaseClient
-    .from('lca_jobs')
-    .select('id,snapshot_id,payload,status,created_at,started_at')
-    .eq('job_type', 'build_snapshot')
-    .in('status', ['queued', 'running'])
-    .order('created_at', { ascending: false })
-    .limit(100);
-
-  if (error) {
-    console.error('read active build lca_jobs failed', {
-      error: error.message,
-      code: error.code,
-    });
-    return { ok: false, error: 'snapshot_build_job_lookup_failed', status: 500 };
-  }
-
-  for (const row of rows ?? []) {
-    const status = String((row as { status?: unknown }).status ?? '');
-    const nowMs = Date.now();
-    const createdAtRaw = (row as { created_at?: unknown }).created_at;
-    const createdAtMs =
-      createdAtRaw === null || createdAtRaw === undefined
-        ? Number.NaN
-        : Date.parse(String(createdAtRaw));
-    const startedAtRaw = (row as { started_at?: unknown }).started_at;
-    const startedAtMs =
-      startedAtRaw === null || startedAtRaw === undefined
-        ? Number.NaN
-        : Date.parse(String(startedAtRaw));
-    if (
-      status === 'queued' &&
-      Number.isFinite(createdAtMs) &&
-      nowMs - createdAtMs > ACTIVE_BUILD_MAX_QUEUED_MS
-    ) {
-      continue;
-    }
-    if (
-      status === 'running' &&
-      Number.isFinite(startedAtMs) &&
-      nowMs - startedAtMs > ACTIVE_BUILD_MAX_RUNNING_MS
-    ) {
-      continue;
-    }
-
-    const payload = (row as { payload?: unknown }).payload as { scope?: unknown } | undefined;
-    if ((payload?.scope ?? '') !== scope) {
-      continue;
-    }
-    const jobId = String((row as { id?: unknown }).id ?? '').trim();
-    const snapshotId = String((row as { snapshot_id?: unknown }).snapshot_id ?? '').trim();
-    if (!jobId || !snapshotId) {
-      continue;
-    }
-    const { data: snap, error: snapErr } = await supabaseClient
-      .from('lca_network_snapshots')
-      .select('process_filter')
-      .eq('id', snapshotId)
-      .maybeSingle();
-    if (snapErr || !snap) {
-      continue;
-    }
-    const filter = (snap as { process_filter?: unknown }).process_filter;
-    if (matchesSnapshotProcessFilter(filter, expectedProcessFilter)) {
-      return { ok: true, job_id: jobId, snapshot_id: snapshotId };
-    }
-  }
-
-  return { ok: true, job_id: null, snapshot_id: null };
 }
 
 async function resolveProcessIndexFromSnapshot(input: {

--- a/test/tidas_package_api_test.ts
+++ b/test/tidas_package_api_test.ts
@@ -7,9 +7,13 @@ type JsonRecord = Record<string, unknown>;
 type Filter = {
   field: string;
   value: unknown;
-  op: 'eq' | 'in';
+  op: 'eq' | 'in' | 'contains';
 };
-type TableName = 'lca_package_artifacts' | 'lca_package_jobs' | 'lca_package_request_cache';
+type TableName =
+  | 'lca_package_artifacts'
+  | 'lca_package_jobs'
+  | 'lca_package_request_cache'
+  | 'worker_jobs';
 
 const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
 const TEST_WORKER_JOB_ID = '22222222-2222-4222-8222-222222222222';
@@ -26,6 +30,7 @@ class FakeSupabase {
     lca_package_jobs: [],
     lca_package_artifacts: [],
     lca_package_request_cache: [],
+    worker_jobs: [],
   };
   rpcCalls: Array<{ fn: string; args: unknown }> = [];
   rpcResults = new Map<string, { data: unknown; error: unknown }>();
@@ -44,11 +49,31 @@ class FakeSupabase {
       return Promise.resolve(structuredClone(configured));
     }
     if (fn === 'worker_enqueue_job') {
+      const record = asJsonRecord(args);
+      const payload = asJsonRecord(record.p_payload_json);
+      const nowIso = new Date().toISOString();
+      this.tables.worker_jobs.push({
+        id: TEST_WORKER_JOB_ID,
+        job_kind: String(record.p_job_kind ?? ''),
+        status: 'queued',
+        requested_by: record.p_requested_by ?? null,
+        request_hash: record.p_request_hash ?? null,
+        payload_json: payload,
+        diagnostics: {},
+        error_code: null,
+        error_message: null,
+        created_at: nowIso,
+        started_at: null,
+        finished_at: null,
+        updated_at: nowIso,
+      });
       return Promise.resolve({
         data: {
           ok: true,
           data: {
             id: TEST_WORKER_JOB_ID,
+            payload,
+            status: 'queued',
           },
         },
         error: null,
@@ -156,6 +181,9 @@ class FakeSupabase {
         if (filter.op === 'eq') {
           return actual === filter.value;
         }
+        if (filter.op === 'contains') {
+          return jsonContains(actual, filter.value);
+        }
 
         return Array.isArray(filter.value) && filter.value.includes(actual);
       }),
@@ -220,6 +248,11 @@ class FakeQueryBuilder implements PromiseLike<{ data: unknown; error: unknown }>
     return this;
   }
 
+  contains(field: string, value: unknown): this {
+    this.filters.push({ field, value, op: 'contains' });
+    return this;
+  }
+
   order(field: string, options?: { ascending?: boolean }): this {
     this.orderField = field;
     this.orderAscending = options?.ascending ?? true;
@@ -265,6 +298,28 @@ function normalizeSortValue(value: unknown): string | number {
     return value;
   }
   return '';
+}
+
+function asJsonRecord(value: unknown): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  return value as JsonRecord;
+}
+
+function jsonContains(actual: unknown, expected: unknown): boolean {
+  const actualRecord = asJsonRecord(actual);
+  const expectedRecord = asJsonRecord(expected);
+
+  return Object.entries(expectedRecord).every(([key, expectedValue]) => {
+    const actualValue = actualRecord[key];
+    if (expectedValue && typeof expectedValue === 'object' && !Array.isArray(expectedValue)) {
+      return jsonContains(actualValue, expectedValue);
+    }
+
+    return actualValue === expectedValue;
+  });
 }
 
 async function sha256Hex(bytes: Uint8Array): Promise<string> {
@@ -417,7 +472,7 @@ Deno.test('import_tidas_package API completes prepare, enqueue, and job lookup f
     assertEquals(prepared.upload.content_type, 'application/zip');
     assertEquals(importRedisCalls, 0);
     assertEquals(importAuthCalls, [[AuthMethod.JWT]]);
-    assertEquals(supabase.getRows('lca_package_jobs').length, 1);
+    assertEquals(supabase.getRows('lca_package_jobs').length, 0);
     assertEquals(supabase.getRows('lca_package_artifacts').length, 1);
 
     const repeatedPrepareResponse = await importHandler(
@@ -441,7 +496,7 @@ Deno.test('import_tidas_package API completes prepare, enqueue, and job lookup f
     assertEquals(repeatedPrepareResponse.status, 200);
     assertEquals(repeatedPrepared.job_id, prepared.job_id);
     assertEquals(repeatedPrepared.source_artifact_id, prepared.source_artifact_id);
-    assertEquals(supabase.getRows('lca_package_jobs').length, 1);
+    assertEquals(supabase.getRows('lca_package_jobs').length, 0);
     assertEquals(supabase.getRows('lca_package_artifacts').length, 1);
 
     const artifactSha256 = await sha256Hex(EMPTY_ZIP_BYTES);
@@ -481,11 +536,19 @@ Deno.test('import_tidas_package API completes prepare, enqueue, and job lookup f
     assertEquals(artifactRow.content_type, 'application/zip');
     assertEquals((artifactRow.metadata as JsonRecord).upload_state, 'uploaded');
     assertEquals((artifactRow.metadata as JsonRecord).filename, 'Demo_Package.zip');
+    assertEquals((artifactRow.metadata as JsonRecord).phase, 'enqueue_import');
+    assertEquals(artifactRow.worker_job_id, TEST_WORKER_JOB_ID);
 
-    const jobRow = supabase.getRows('lca_package_jobs')[0];
-    assertEquals(jobRow.status, 'queued');
-    assertEquals(jobRow.request_key, artifactSha256);
-    assertEquals((jobRow.diagnostics as JsonRecord).phase, 'enqueue_import');
+    assertEquals(supabase.getRows('lca_package_jobs').length, 0);
+    const workerJobRow = supabase.getRows('worker_jobs')[0];
+    assertEquals(workerJobRow.status, 'queued');
+    assertEquals(workerJobRow.job_kind, 'tidas.import_package');
+    assertEquals(workerJobRow.request_hash, artifactSha256);
+    assertEquals((workerJobRow.payload_json as JsonRecord).job_id, prepared.job_id);
+    assertEquals(
+      (workerJobRow.payload_json as JsonRecord).source_artifact_id,
+      prepared.source_artifact_id,
+    );
     assertEquals(supabase.rpcCalls.length, 1);
     assertEquals(supabase.rpcCalls[0].fn, 'worker_enqueue_job');
 
@@ -505,6 +568,7 @@ Deno.test('import_tidas_package API completes prepare, enqueue, and job lookup f
       ok: true,
       mode: 'in_progress',
       job_id: prepared.job_id,
+      worker_job_id: TEST_WORKER_JOB_ID,
       source_artifact_id: prepared.source_artifact_id,
     });
     assertEquals(supabase.rpcCalls.length, 1);
@@ -549,72 +613,81 @@ Deno.test('import_tidas_package API completes prepare, enqueue, and job lookup f
   });
 });
 
-Deno.test('import_tidas_package marks retained job failed when worker enqueue fails', async () => {
-  await withPackageStorageEnv(async () => {
-    const { createImportTidasPackageHandler } = await loadTidasHandlers();
-    const supabase = new FakeSupabase();
-    const handler = createImportTidasPackageHandler({
-      authClient: {} as SupabaseClient,
-      supabase: supabase as unknown as SupabaseClient,
-      authenticateRequest: async () => createAuthResult(),
-      getRedisClient: async () => undefined,
-    });
+Deno.test(
+  'import_tidas_package fails without creating a legacy job row when worker enqueue fails',
+  async () => {
+    await withPackageStorageEnv(async () => {
+      const { createImportTidasPackageHandler } = await loadTidasHandlers();
+      const supabase = new FakeSupabase();
+      const handler = createImportTidasPackageHandler({
+        authClient: {} as SupabaseClient,
+        supabase: supabase as unknown as SupabaseClient,
+        authenticateRequest: async () => createAuthResult(),
+        getRedisClient: async () => undefined,
+      });
 
-    const prepareResponse = await handler(
-      new Request('https://example.com/functions/v1/import_tidas_package', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${TEST_JWT}`,
-          'Content-Type': 'application/json',
-          'x-idempotency-key': 'enqueue-fails',
-        },
-        body: JSON.stringify({
-          action: 'prepare_upload',
-          filename: 'fixtures/Demo Package.zip',
-          byte_size: EMPTY_ZIP_BYTES.byteLength,
-          content_type: 'application/zip',
+      const prepareResponse = await handler(
+        new Request('https://example.com/functions/v1/import_tidas_package', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${TEST_JWT}`,
+            'Content-Type': 'application/json',
+            'x-idempotency-key': 'enqueue-fails',
+          },
+          body: JSON.stringify({
+            action: 'prepare_upload',
+            filename: 'fixtures/Demo Package.zip',
+            byte_size: EMPTY_ZIP_BYTES.byteLength,
+            content_type: 'application/zip',
+          }),
         }),
-      }),
-    );
-    assertEquals(prepareResponse.status, 200);
-    const prepared = await prepareResponse.json();
-    const artifactSha256 = await sha256Hex(EMPTY_ZIP_BYTES);
+      );
+      assertEquals(prepareResponse.status, 200);
+      const prepared = await prepareResponse.json();
+      const artifactSha256 = await sha256Hex(EMPTY_ZIP_BYTES);
 
-    supabase.rpcResults.set('worker_enqueue_job', {
-      data: null,
-      error: {
-        code: '42501',
-        message: 'permission denied for worker_enqueue_job',
-        details: { reason: 'missing_migration' },
-      },
-    });
-
-    const enqueueResponse = await handler(
-      new Request('https://example.com/functions/v1/import_tidas_package', {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${TEST_JWT}`,
-          'Content-Type': 'application/json',
+      supabase.rpcResults.set('worker_enqueue_job', {
+        data: null,
+        error: {
+          code: '42501',
+          message: 'permission denied for worker_enqueue_job',
+          details: { reason: 'missing_migration' },
         },
-        body: JSON.stringify({
-          action: 'enqueue',
-          job_id: prepared.job_id,
-          source_artifact_id: prepared.source_artifact_id,
-          artifact_sha256: artifactSha256,
-          artifact_byte_size: EMPTY_ZIP_BYTES.byteLength,
-          filename: './uploads/Demo Package.zip',
-          content_type: 'application/zip',
-        }),
-      }),
-    );
+      });
 
-    assertEquals(enqueueResponse.status, 403);
-    const jobRow = supabase.getRows('lca_package_jobs')[0];
-    assertEquals(jobRow.status, 'failed');
-    assertEquals((jobRow.diagnostics as JsonRecord).phase, 'worker_jobs_enqueue_failed');
-    assertEquals((jobRow.diagnostics as JsonRecord).error_code, '42501');
-  });
-});
+      const enqueueResponse = await handler(
+        new Request('https://example.com/functions/v1/import_tidas_package', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${TEST_JWT}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            action: 'enqueue',
+            job_id: prepared.job_id,
+            source_artifact_id: prepared.source_artifact_id,
+            artifact_sha256: artifactSha256,
+            artifact_byte_size: EMPTY_ZIP_BYTES.byteLength,
+            filename: './uploads/Demo Package.zip',
+            content_type: 'application/zip',
+          }),
+        }),
+      );
+
+      assertEquals(enqueueResponse.status, 403);
+      assertEquals(await enqueueResponse.json(), {
+        ok: false,
+        code: 'WORKER_JOBS_ENQUEUE_FAILED',
+        message: 'Failed to enqueue import worker job',
+      });
+      assertEquals(supabase.getRows('lca_package_jobs').length, 0);
+      const artifactRow = supabase.getRows('lca_package_artifacts')[0];
+      assertEquals(artifactRow.status, 'ready');
+      assertEquals(artifactRow.worker_job_id, null);
+      assertEquals(supabase.rpcCalls.length, 1);
+    });
+  },
+);
 
 Deno.test(
   'import_tidas_package fails closed when package worker_jobs cutover is disabled',
@@ -675,9 +748,10 @@ Deno.test(
         code: 'LEGACY_QUEUE_DISABLED',
         message: 'Package worker_jobs cutover must be enabled',
       });
-      const jobRow = supabase.getRows('lca_package_jobs')[0];
-      assertEquals(jobRow.status, 'stale');
-      assertEquals((jobRow.diagnostics as JsonRecord).phase, 'prepare_upload');
+      assertEquals(supabase.getRows('lca_package_jobs').length, 0);
+      const artifactRow = supabase.getRows('lca_package_artifacts')[0];
+      assertEquals(artifactRow.status, 'pending');
+      assertEquals((artifactRow.metadata as JsonRecord).upload_state, 'prepared');
       assertEquals(supabase.rpcCalls.length, 0);
     });
   },

--- a/test/worker_jobs_cutover_test.ts
+++ b/test/worker_jobs_cutover_test.ts
@@ -6,6 +6,7 @@ import {
   lcaWorkerJobKindForJobType,
   workerJobIdFromRpcData,
   workerJobPayloadSchemaVersion,
+  workerJobPayloadStringFromRpcData,
 } from '../supabase/functions/_shared/worker_jobs_cutover.ts';
 
 Deno.test('isWorkerJobsCutoverEnabled defaults on and accepts explicit overrides', () => {
@@ -55,6 +56,25 @@ Deno.test('workerJobIdFromRpcData extracts worker job id defensively', () => {
   assertEquals(workerJobIdFromRpcData({ id: 'job-1' }), 'job-1');
   assertEquals(workerJobIdFromRpcData({ id: 1 }), null);
   assertEquals(workerJobIdFromRpcData(null), null);
+});
+
+Deno.test('workerJobPayloadStringFromRpcData extracts compatibility payload ids', () => {
+  assertEquals(
+    workerJobPayloadStringFromRpcData(
+      { id: 'worker-1', payload: { job_id: 'legacy-job-1', snapshot_id: 'snapshot-1' } },
+      'job_id',
+    ),
+    'legacy-job-1',
+  );
+  assertEquals(
+    workerJobPayloadStringFromRpcData(
+      { id: 'worker-1', payload: { job_id: 'legacy-job-1', snapshot_id: 'snapshot-1' } },
+      'snapshot_id',
+    ),
+    'snapshot-1',
+  );
+  assertEquals(workerJobPayloadStringFromRpcData({ id: 'worker-1' }, 'job_id'), null);
+  assertEquals(workerJobPayloadStringFromRpcData({ id: 'worker-1', payload: [] }, 'job_id'), null);
 });
 
 Deno.test('enqueueCalculatorWorkerJob requires canonical worker job id', async () => {


### PR DESCRIPTION
## Summary
- Promote edge-functions dev after #167 for workspace#242.
- Carries the no-new-legacy-row worker_jobs enqueue cutover into main.
- Covered LCA solve/snapshot/contribution and TIDAS import/export no longer create lca_jobs/lca_package_jobs rows for new tasks.

## Scope
- Promotes merge commit content from dev: abc1373 / source commit 013e87e.
- Related child issue: linancn/tiangong-lca-edge-functions#166.
- Parent: tiangong-lca/workspace#242.

## Validation
- Original PR #167 validation passed: npm run lint, npm run check, focused Deno tests for TIDAS/worker_jobs/LCA scope, docpact validate/lint.

## Rollout
- After merge, manually deploy the affected main Edge Functions with --no-verify-jwt and run smoke verifying new covered flows create canonical worker_jobs rows without legacy-only job rows.

Refs #166
Refs tiangong-lca/workspace#242