### PR TITLE
fix: queue all-unit solve for LCIA result queries

### DIFF
--- a/supabase/functions/_shared/lca_all_unit_solve_queue.ts
+++ b/supabase/functions/_shared/lca_all_unit_solve_queue.ts
@@ -1,0 +1,335 @@
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+
+import {
+  enqueueCalculatorWorkerJob,
+  isWorkerJobsCutoverEnabled,
+  lcaWorkerJobKindForJobType,
+  workerJobPayloadSchemaVersion,
+  workerJobPayloadStringFromRpcData,
+} from './worker_jobs_cutover.ts';
+
+const REQUEST_VERSION = 'lca_solve_v2';
+
+type EnvReader = (key: string) => string | undefined;
+
+type ResultCacheRow = {
+  id: string;
+  status: string;
+  job_id: string | null;
+  worker_job_id: string | null;
+  result_id: string | null;
+  hit_count: number;
+};
+
+type AllUnitSolvePayload = {
+  type: 'solve_all_unit';
+  job_id: string;
+  snapshot_id: string;
+  solve: { return_x: false; return_g: false; return_h: true };
+  print_level: number;
+};
+
+type AllUnitSolveNormalizedRequest = {
+  version: string;
+  scope: string;
+  snapshot_id: string;
+  demand_mode: 'all_unit';
+  solve: { return_x: false; return_g: false; return_h: true };
+  print_level: number;
+};
+
+export type LcaAllUnitSolveQueueResult =
+  | {
+      ok: true;
+      mode: 'queued' | 'in_progress';
+      snapshot_id: string;
+      cache_key: string;
+      job_id: string;
+      worker_job_id: string | null;
+    }
+  | { ok: false; error: string; status: number; details?: unknown };
+
+export async function ensureLcaAllUnitSolveQueued(
+  supabase: SupabaseClient,
+  args: {
+    scope: string;
+    snapshotId: string;
+    userId: string;
+    readEnv?: EnvReader;
+  },
+): Promise<LcaAllUnitSolveQueueResult> {
+  const solve = { return_x: false, return_g: false, return_h: true } as const;
+  const normalizedRequest: AllUnitSolveNormalizedRequest = {
+    version: REQUEST_VERSION,
+    scope: args.scope,
+    snapshot_id: args.snapshotId,
+    demand_mode: 'all_unit',
+    solve,
+    print_level: 0,
+  };
+  const requestKey = await sha256Hex(JSON.stringify(normalizedRequest));
+  const nowIso = new Date().toISOString();
+
+  const existingCache = await fetchResultCache(supabase, args.scope, args.snapshotId, requestKey);
+  if (!existingCache.ok) {
+    return { ok: false, error: 'cache_lookup_failed', status: 500 };
+  }
+
+  if (existingCache.row) {
+    await touchResultCache(supabase, existingCache.row, {
+      updated_at: nowIso,
+      last_accessed_at: nowIso,
+      hit_count: existingCache.row.hit_count + 1,
+    });
+
+    if (
+      (existingCache.row.status === 'pending' || existingCache.row.status === 'running') &&
+      (existingCache.row.worker_job_id || existingCache.row.job_id)
+    ) {
+      return {
+        ok: true,
+        mode: 'in_progress',
+        snapshot_id: args.snapshotId,
+        cache_key: requestKey,
+        job_id: existingCache.row.job_id ?? existingCache.row.worker_job_id ?? '',
+        worker_job_id: existingCache.row.worker_job_id,
+      };
+    }
+  }
+
+  if (!isWorkerJobsCutoverEnabled('LCA_WORKER_JOBS_ENABLED', args.readEnv)) {
+    console.error('legacy lca queue fallback is disabled before all-unit worker job enqueue', {
+      request_key: requestKey,
+      snapshot_id: args.snapshotId,
+    });
+    return { ok: false, error: 'legacy_queue_disabled', status: 503 };
+  }
+
+  const jobType = 'solve_all_unit';
+  const jobKind = lcaWorkerJobKindForJobType(jobType);
+  if (!jobKind) {
+    return { ok: false, error: 'worker_job_kind_unsupported', status: 500 };
+  }
+
+  const newJobId = crypto.randomUUID();
+  const payload: AllUnitSolvePayload = {
+    type: jobType,
+    job_id: newJobId,
+    snapshot_id: args.snapshotId,
+    solve,
+    print_level: 0,
+  };
+  const workerJob = await enqueueCalculatorWorkerJob(supabase, {
+    jobKind,
+    payload,
+    payloadSchemaVersion: workerJobPayloadSchemaVersion(jobKind),
+    subjectType: 'lca_job',
+    subjectId: newJobId,
+    subjectVersion: args.snapshotId,
+    requestedBy: args.userId,
+    requesterType: 'user',
+    idempotencyKey: `${args.userId}:${requestKey}`,
+    requestHash: requestKey,
+    queueKey: args.snapshotId,
+    visibility: 'user',
+  });
+  if (!workerJob.ok) {
+    console.error('enqueue all-unit lca worker_jobs job failed', {
+      error: workerJob.error,
+      status: workerJob.status,
+      details: workerJob.details,
+      lca_job_id: newJobId,
+      snapshot_id: args.snapshotId,
+    });
+    return {
+      ok: false,
+      error: 'worker_jobs_enqueue_failed',
+      status: workerJob.status,
+      details: workerJob.error,
+    };
+  }
+
+  const finalJobId = workerJobPayloadStringFromRpcData(workerJob.data, 'job_id') ?? newJobId;
+  const finalWorkerJobId = workerJob.workerJobId;
+
+  if (existingCache.row) {
+    const updated = await updateResultCacheForPending(supabase, existingCache.row, {
+      normalizedRequest,
+      nowIso,
+      finalJobId,
+      finalWorkerJobId,
+    });
+    if (!updated.ok) {
+      return updated;
+    }
+  } else {
+    const inserted = await insertResultCacheForPending(supabase, {
+      scope: args.scope,
+      snapshotId: args.snapshotId,
+      requestKey,
+      normalizedRequest,
+      nowIso,
+      finalJobId,
+      finalWorkerJobId,
+    });
+    if (!inserted.ok) {
+      return inserted;
+    }
+  }
+
+  return {
+    ok: true,
+    mode: 'queued',
+    snapshot_id: args.snapshotId,
+    cache_key: requestKey,
+    job_id: finalJobId,
+    worker_job_id: finalWorkerJobId,
+  };
+}
+
+async function fetchResultCache(
+  supabase: SupabaseClient,
+  scope: string,
+  snapshotId: string,
+  requestKey: string,
+): Promise<{ ok: true; row: ResultCacheRow | null } | { ok: false }> {
+  const { data, error } = await supabase
+    .from('lca_result_cache')
+    .select('id,status,job_id,worker_job_id,result_id,hit_count')
+    .eq('scope', scope)
+    .eq('snapshot_id', snapshotId)
+    .eq('request_key', requestKey)
+    .maybeSingle();
+
+  if (error) {
+    console.error('fetch all-unit lca_result_cache failed', {
+      error: error.message,
+      code: error.code,
+      snapshot_id: snapshotId,
+    });
+    return { ok: false };
+  }
+
+  if (!data) {
+    return { ok: true, row: null };
+  }
+
+  return {
+    ok: true,
+    row: {
+      id: String(data.id),
+      status: String(data.status),
+      job_id: data.job_id ? String(data.job_id) : null,
+      worker_job_id: data.worker_job_id ? String(data.worker_job_id) : null,
+      result_id: data.result_id ? String(data.result_id) : null,
+      hit_count: Number(data.hit_count ?? 0),
+    },
+  };
+}
+
+async function touchResultCache(
+  supabase: SupabaseClient,
+  row: ResultCacheRow,
+  patch: {
+    updated_at: string;
+    last_accessed_at: string;
+    hit_count: number;
+  },
+): Promise<void> {
+  const { error } = await supabase
+    .from('lca_result_cache')
+    .update({
+      updated_at: patch.updated_at,
+      last_accessed_at: patch.last_accessed_at,
+      hit_count: patch.hit_count,
+    })
+    .eq('id', row.id);
+
+  if (error) {
+    console.warn('touch all-unit lca_result_cache failed', {
+      error: error.message,
+      code: error.code,
+      row_id: row.id,
+    });
+  }
+}
+
+async function updateResultCacheForPending(
+  supabase: SupabaseClient,
+  row: ResultCacheRow,
+  args: {
+    normalizedRequest: AllUnitSolveNormalizedRequest;
+    nowIso: string;
+    finalJobId: string;
+    finalWorkerJobId: string | null;
+  },
+): Promise<{ ok: true } | { ok: false; error: string; status: number }> {
+  const { error } = await supabase
+    .from('lca_result_cache')
+    .update({
+      status: 'pending',
+      job_id: args.finalJobId,
+      worker_job_id: args.finalWorkerJobId,
+      request_payload: args.normalizedRequest,
+      hit_count: row.hit_count + 1,
+      last_accessed_at: args.nowIso,
+      updated_at: args.nowIso,
+    })
+    .eq('id', row.id);
+
+  if (error) {
+    console.error('update all-unit lca_result_cache failed', {
+      error: error.message,
+      code: error.code,
+      row_id: row.id,
+    });
+    return { ok: false, error: 'cache_update_failed', status: 500 };
+  }
+
+  return { ok: true };
+}
+
+async function insertResultCacheForPending(
+  supabase: SupabaseClient,
+  args: {
+    scope: string;
+    snapshotId: string;
+    requestKey: string;
+    normalizedRequest: AllUnitSolveNormalizedRequest;
+    nowIso: string;
+    finalJobId: string;
+    finalWorkerJobId: string | null;
+  },
+): Promise<{ ok: true } | { ok: false; error: string; status: number }> {
+  const { error } = await supabase.from('lca_result_cache').insert({
+    scope: args.scope,
+    snapshot_id: args.snapshotId,
+    request_key: args.requestKey,
+    request_payload: args.normalizedRequest,
+    status: 'pending',
+    job_id: args.finalJobId,
+    worker_job_id: args.finalWorkerJobId,
+    hit_count: 1,
+    last_accessed_at: args.nowIso,
+    created_at: args.nowIso,
+    updated_at: args.nowIso,
+  });
+
+  if (error && error.code !== '23505') {
+    console.error('insert all-unit lca_result_cache failed', {
+      error: error.message,
+      code: error.code,
+      snapshot_id: args.snapshotId,
+    });
+    return { ok: false, error: 'cache_insert_failed', status: 500 };
+  }
+
+  return { ok: true };
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/supabase/functions/lca_query_results/index.ts
+++ b/supabase/functions/lca_query_results/index.ts
@@ -3,6 +3,7 @@ import '@supabase/functions-js/edge-runtime.d.ts';
 
 import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
+import { ensureLcaAllUnitSolveQueued } from '../_shared/lca_all_unit_solve_queue.ts';
 import {
   fetchProcessScopeLookup,
   matchesProcessDataScope,
@@ -215,10 +216,26 @@ Deno.serve(async (req) => {
     return json({ error: latestAllUnit.error }, latestAllUnit.status);
   }
   if (!latestAllUnit.row) {
-    if (allowFallback) {
-      return json({ error: 'fallback_not_implemented_yet' }, 501);
+    const queued = await ensureLcaAllUnitSolveQueued(supabaseClient, {
+      scope,
+      snapshotId,
+      userId,
+    });
+    if (!queued.ok) {
+      return json({ error: queued.error, details: queued.details ?? null }, queued.status);
     }
-    return json({ error: 'all_unit_result_not_ready' }, 409);
+    return json(
+      {
+        error: 'all_unit_result_queued',
+        mode: queued.mode,
+        snapshot_id: queued.snapshot_id,
+        cache_key: queued.cache_key,
+        solve_job_id: queued.job_id,
+        solve_worker_job_id: queued.worker_job_id,
+        fallback_requested: allowFallback,
+      },
+      409,
+    );
   }
 
   const queryArtifact = await fetchArtifactJson<AllUnitQueryEnvelope>(

--- a/test/lca_all_unit_solve_queue_test.ts
+++ b/test/lca_all_unit_solve_queue_test.ts
@@ -1,0 +1,205 @@
+import { assert, assertEquals } from 'jsr:@std/assert';
+
+import { ensureLcaAllUnitSolveQueued } from '../supabase/functions/_shared/lca_all_unit_solve_queue.ts';
+
+type MockError = { code: string; message: string };
+type MockCacheRow = {
+  id: string;
+  status: string;
+  job_id: string | null;
+  worker_job_id: string | null;
+  result_id: string | null;
+  hit_count: number;
+};
+
+type MockState = {
+  cacheRow: MockCacheRow | null;
+  selectError: MockError | null;
+  updateError: MockError | null;
+  insertError: MockError | null;
+  rpcData: unknown;
+  rpcError: MockError | null;
+  rpcCalls: Array<{ fn: string; args: Record<string, unknown> }>;
+  updateCalls: Array<{ table: string; patch: Record<string, unknown> }>;
+  insertCalls: Array<{ table: string; row: Record<string, unknown> }>;
+};
+
+function createMockState(overrides: Partial<MockState> = {}): MockState {
+  return {
+    cacheRow: null,
+    selectError: null,
+    updateError: null,
+    insertError: null,
+    rpcData: {
+      ok: true,
+      data: {
+        id: 'worker-job-1',
+        payload: {
+          job_id: 'lca-job-1',
+          snapshot_id: 'snapshot-1',
+        },
+      },
+    },
+    rpcError: null,
+    rpcCalls: [],
+    updateCalls: [],
+    insertCalls: [],
+    ...overrides,
+  };
+}
+
+function createSupabaseMock(state: MockState) {
+  return {
+    from(table: string) {
+      return createTableBuilder(state, table);
+    },
+    rpc(fn: string, args: Record<string, unknown>) {
+      state.rpcCalls.push({ fn, args });
+      return Promise.resolve({ data: state.rpcData, error: state.rpcError });
+    },
+  };
+}
+
+function createTableBuilder(state: MockState, table: string) {
+  return {
+    select(_columns: string) {
+      return this;
+    },
+    eq(_column: string, _value: unknown) {
+      return this;
+    },
+    maybeSingle() {
+      return Promise.resolve({ data: state.cacheRow, error: state.selectError });
+    },
+    update(patch: Record<string, unknown>) {
+      state.updateCalls.push({ table, patch });
+      return {
+        eq: (_column: string, _value: unknown) =>
+          Promise.resolve({ data: null, error: state.updateError }),
+      };
+    },
+    insert(row: Record<string, unknown>) {
+      state.insertCalls.push({ table, row });
+      return Promise.resolve({ data: null, error: state.insertError });
+    },
+  };
+}
+
+Deno.test('ensureLcaAllUnitSolveQueued reuses pending cache worker job', async () => {
+  const state = createMockState({
+    cacheRow: {
+      id: 'cache-1',
+      status: 'running',
+      job_id: 'lca-job-active',
+      worker_job_id: 'worker-job-active',
+      result_id: null,
+      hit_count: 2,
+    },
+  });
+
+  const result = await ensureLcaAllUnitSolveQueued(createSupabaseMock(state) as never, {
+    scope: 'dev-v1',
+    snapshotId: 'snapshot-1',
+    userId: 'user-1',
+  });
+
+  assert(result.ok);
+  assertEquals(result.mode, 'in_progress');
+  assertEquals(result.job_id, 'lca-job-active');
+  assertEquals(result.worker_job_id, 'worker-job-active');
+  assertEquals(state.rpcCalls.length, 0);
+  assertEquals(state.insertCalls.length, 0);
+  assertEquals(state.updateCalls.length, 1);
+  assertEquals(state.updateCalls[0].patch.hit_count, 3);
+});
+
+Deno.test(
+  'ensureLcaAllUnitSolveQueued enqueues all-unit solve and inserts pending cache',
+  async () => {
+    const state = createMockState();
+
+    const result = await ensureLcaAllUnitSolveQueued(createSupabaseMock(state) as never, {
+      scope: 'dev-v1',
+      snapshotId: 'snapshot-1',
+      userId: 'user-1',
+    });
+
+    assert(result.ok);
+    assertEquals(result.mode, 'queued');
+    assertEquals(result.job_id, 'lca-job-1');
+    assertEquals(result.worker_job_id, 'worker-job-1');
+    assertEquals(state.rpcCalls.length, 1);
+    assertEquals(state.insertCalls.length, 1);
+
+    const rpcArgs = state.rpcCalls[0].args;
+    assertEquals(rpcArgs.p_job_kind, 'lca.solve_all_unit');
+    assertEquals(rpcArgs.p_payload_schema_version, 'lca.solve_all_unit.request.v1');
+    assertEquals(rpcArgs.p_subject_type, 'lca_job');
+    assertEquals(rpcArgs.p_subject_version, 'snapshot-1');
+    assertEquals(rpcArgs.p_requested_by, 'user-1');
+    assertEquals(rpcArgs.p_queue_key, 'snapshot-1');
+    assertEquals(rpcArgs.p_request_hash, result.cache_key);
+
+    const payload = rpcArgs.p_payload_json as Record<string, unknown>;
+    assertEquals(payload.type, 'solve_all_unit');
+    assertEquals(payload.snapshot_id, 'snapshot-1');
+    assertEquals(payload.solve, { return_x: false, return_g: false, return_h: true });
+
+    const inserted = state.insertCalls[0].row;
+    assertEquals(inserted.scope, 'dev-v1');
+    assertEquals(inserted.snapshot_id, 'snapshot-1');
+    assertEquals(inserted.request_key, result.cache_key);
+    assertEquals(inserted.status, 'pending');
+    assertEquals(inserted.job_id, 'lca-job-1');
+    assertEquals(inserted.worker_job_id, 'worker-job-1');
+  },
+);
+
+Deno.test(
+  'ensureLcaAllUnitSolveQueued requeues ready cache when latest query pointer is missing',
+  async () => {
+    const state = createMockState({
+      cacheRow: {
+        id: 'cache-ready',
+        status: 'ready',
+        job_id: 'old-lca-job',
+        worker_job_id: 'old-worker-job',
+        result_id: 'old-result',
+        hit_count: 4,
+      },
+    });
+
+    const result = await ensureLcaAllUnitSolveQueued(createSupabaseMock(state) as never, {
+      scope: 'dev-v1',
+      snapshotId: 'snapshot-1',
+      userId: 'user-1',
+    });
+
+    assert(result.ok);
+    assertEquals(result.mode, 'queued');
+    assertEquals(state.rpcCalls.length, 1);
+    assertEquals(state.insertCalls.length, 0);
+    assertEquals(state.updateCalls.length, 2);
+    assertEquals(state.updateCalls[1].patch.status, 'pending');
+    assertEquals(state.updateCalls[1].patch.job_id, 'lca-job-1');
+    assertEquals(state.updateCalls[1].patch.worker_job_id, 'worker-job-1');
+  },
+);
+
+Deno.test(
+  'ensureLcaAllUnitSolveQueued fails closed when worker jobs cutover is disabled',
+  async () => {
+    const state = createMockState();
+
+    const result = await ensureLcaAllUnitSolveQueued(createSupabaseMock(state) as never, {
+      scope: 'dev-v1',
+      snapshotId: 'snapshot-1',
+      userId: 'user-1',
+      readEnv: (key) => (key === 'LCA_WORKER_JOBS_ENABLED' ? 'false' : undefined),
+    });
+
+    assertEquals(result, { ok: false, error: 'legacy_queue_disabled', status: 503 });
+    assertEquals(state.rpcCalls.length, 0);
+    assertEquals(state.insertCalls.length, 0);
+  },
+);


### PR DESCRIPTION
## Summary
- Queue or reuse `lca.solve_all_unit` from `lca_query_results` when a ready snapshot exists but the latest all-unit query artifact is missing.
- Return a structured `all_unit_result_queued` 409 response with `snapshot_id`, `cache_key`, `solve_job_id`, and `solve_worker_job_id` so callers can show pending state and retry.
- Add a shared helper that reuses the `lca_solve_v2` all-unit request key/cache semantics and keeps worker_jobs as the only primary task lifecycle path.

## Validation
- `deno check --config supabase/functions/deno.json supabase/functions/lca_query_results/index.ts supabase/functions/_shared/lca_all_unit_solve_queue.ts test/lca_all_unit_solve_queue_test.ts`
- `deno test --allow-env --config supabase/functions/deno.json test/lca_all_unit_solve_queue_test.ts`
- `npm run lint`
- `npm run check`

Closes #169
Related: tiangong-lca/workspace#242
