### PR TITLE
fix: expose queued TIDAS export worker jobs

### DIFF
--- a/supabase/functions/_shared/tidas_package.ts
+++ b/supabase/functions/_shared/tidas_package.ts
@@ -72,6 +72,15 @@ type ExportRequestCacheRow = {
   hit_count: number;
 };
 
+type ExportRequestCacheLookupRow = ExportRequestCacheRow & {
+  request_key: string | null;
+  error_code: string | null;
+  error_message: string | null;
+  last_accessed_at: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
 export type ExportCacheAction = 'cache_hit' | 'in_progress' | 'retry';
 
 type PackageArtifactResponse = {
@@ -740,20 +749,22 @@ export async function lookupTidasPackageJob(
     throw new TidasPackageError(400, 'INVALID_JOB_ID', 'Invalid job identifier');
   }
 
-  const legacyJob = await fetchOwnedPackageJobIfExists(supabase, userId, jobId);
+  const requestCacheRow = await fetchOwnedExportRequestCacheByLookupId(supabase, userId, jobId);
+  const effectiveJobId = requestCacheRow?.job_id ?? jobId;
+  const legacyJob = await fetchOwnedPackageJobIfExists(supabase, userId, effectiveJobId);
   const { data: artifactRows, error: artifactError } = await supabase
     .from('lca_package_artifacts')
     .select(
       'id,worker_job_id,artifact_kind,status,artifact_url,artifact_sha256,artifact_byte_size,artifact_format,content_type,metadata,expires_at,is_pinned,created_at,updated_at',
     )
-    .eq('job_id', jobId)
+    .eq('job_id', effectiveJobId)
     .order('created_at', { ascending: true });
 
   if (artifactError) {
     console.error('query lca_package_artifacts failed', {
       error: artifactError.message,
       code: artifactError.code,
-      job_id: jobId,
+      job_id: effectiveJobId,
       user_id: userId,
     });
     throw new TidasPackageError(500, 'ARTIFACT_LOOKUP_FAILED', 'Failed to query package artifacts');
@@ -763,47 +774,43 @@ export async function lookupTidasPackageJob(
   const hasOwnedArtifact = artifactDomainRows.some(
     (artifact) => normalizeNullableString(artifact.metadata.requested_by) === userId,
   );
-  if (!legacyJob && !hasOwnedArtifact) {
+  const requestCacheWorkerJob = requestCacheRow?.worker_job_id
+    ? await fetchOwnedWorkerPackageJobIfExists(
+        supabase,
+        userId,
+        requestCacheRow.worker_job_id,
+        'tidas.export_package',
+      )
+    : null;
+  const lookupWorkerJob =
+    !requestCacheWorkerJob && jobId !== effectiveJobId
+      ? await fetchOwnedWorkerPackageJobIfExists(supabase, userId, jobId, 'tidas.export_package')
+      : null;
+  const artifactWorkerJob = await fetchWorkerPackageJobForArtifacts(
+    supabase,
+    userId,
+    artifactDomainRows,
+  );
+  const workerJob = requestCacheWorkerJob ?? lookupWorkerJob ?? artifactWorkerJob;
+
+  if (!legacyJob && !hasOwnedArtifact && !requestCacheRow && !workerJob) {
     throw new TidasPackageError(404, 'JOB_NOT_FOUND', 'Package job not found');
   }
 
-  const workerJob = await fetchWorkerPackageJobForArtifacts(supabase, userId, artifactDomainRows);
   const job =
-    legacyJob ?? buildPackageJobRowFromWorkerOrArtifacts(jobId, workerJob, artifactDomainRows);
+    legacyJob ??
+    buildPackageJobRowFromWorkerOrArtifacts(effectiveJobId, workerJob, artifactDomainRows);
 
   const artifacts = await Promise.all(
     (artifactRows ?? []).map((row) => toArtifactResponse(supabase, row)),
   );
 
-  const { data: cacheRow } = await supabase
-    .from('lca_package_request_cache')
-    .select(
-      'id,status,error_code,error_message,hit_count,last_accessed_at,created_at,updated_at,export_artifact_id,report_artifact_id',
-    )
-    .eq('job_id', jobId)
-    .maybeSingle();
-
   const artifactsByKind = Object.fromEntries(
     artifacts.map((artifact) => [artifact.artifact_kind, artifact]),
   );
 
-  const requestCache: PackageRequestCacheResponse | null = cacheRow
-    ? {
-        id: String(cacheRow.id),
-        status: String(cacheRow.status),
-        error_code: cacheRow.error_code ? String(cacheRow.error_code) : null,
-        error_message: cacheRow.error_message ? String(cacheRow.error_message) : null,
-        hit_count: Number(cacheRow.hit_count ?? 0),
-        last_accessed_at: cacheRow.last_accessed_at ?? null,
-        created_at: cacheRow.created_at ?? null,
-        updated_at: cacheRow.updated_at ?? null,
-        export_artifact_id: cacheRow.export_artifact_id
-          ? String(cacheRow.export_artifact_id)
-          : null,
-        report_artifact_id: cacheRow.report_artifact_id
-          ? String(cacheRow.report_artifact_id)
-          : null,
-      }
+  const requestCache: PackageRequestCacheResponse | null = requestCacheRow
+    ? toPackageRequestCacheResponse(requestCacheRow)
     : null;
   const diagnosticsSummary = buildPackageJobDiagnosticsSummary({
     status: job.status,
@@ -1100,6 +1107,89 @@ async function fetchExportRequestCache(
     export_artifact_id: data.export_artifact_id ? String(data.export_artifact_id) : null,
     report_artifact_id: data.report_artifact_id ? String(data.report_artifact_id) : null,
     hit_count: Number(data.hit_count ?? 0),
+  };
+}
+
+async function fetchOwnedExportRequestCacheByLookupId(
+  supabase: SupabaseClient,
+  userId: string,
+  lookupId: string,
+): Promise<ExportRequestCacheLookupRow | null> {
+  const byCompatibilityJobId = await fetchOwnedExportRequestCacheByField(
+    supabase,
+    userId,
+    'job_id',
+    lookupId,
+  );
+  if (byCompatibilityJobId) {
+    return byCompatibilityJobId;
+  }
+
+  return await fetchOwnedExportRequestCacheByField(supabase, userId, 'worker_job_id', lookupId);
+}
+
+async function fetchOwnedExportRequestCacheByField(
+  supabase: SupabaseClient,
+  userId: string,
+  field: 'job_id' | 'worker_job_id',
+  value: string,
+): Promise<ExportRequestCacheLookupRow | null> {
+  const { data, error } = await supabase
+    .from('lca_package_request_cache')
+    .select(
+      'id,status,request_key,job_id,worker_job_id,error_code,error_message,hit_count,last_accessed_at,created_at,updated_at,export_artifact_id,report_artifact_id',
+    )
+    .eq('requested_by', userId)
+    .eq('operation', 'export_package')
+    .eq(field, value)
+    .maybeSingle();
+
+  if (error) {
+    console.error('query lca_package_request_cache by job id failed', {
+      error: error.message,
+      code: error.code,
+      user_id: userId,
+      lookup_field: field,
+      lookup_id: value,
+    });
+    throw new TidasPackageError(500, 'REQUEST_CACHE_LOOKUP_FAILED', 'Failed to query export cache');
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return {
+    id: String(data.id),
+    status: String(data.status),
+    request_key: data.request_key ? String(data.request_key) : null,
+    job_id: data.job_id ? String(data.job_id) : null,
+    worker_job_id: data.worker_job_id ? String(data.worker_job_id) : null,
+    error_code: data.error_code ? String(data.error_code) : null,
+    error_message: data.error_message ? String(data.error_message) : null,
+    hit_count: Number(data.hit_count ?? 0),
+    last_accessed_at: data.last_accessed_at ? String(data.last_accessed_at) : null,
+    created_at: data.created_at ? String(data.created_at) : null,
+    updated_at: data.updated_at ? String(data.updated_at) : null,
+    export_artifact_id: data.export_artifact_id ? String(data.export_artifact_id) : null,
+    report_artifact_id: data.report_artifact_id ? String(data.report_artifact_id) : null,
+  };
+}
+
+function toPackageRequestCacheResponse(
+  row: ExportRequestCacheLookupRow,
+): PackageRequestCacheResponse {
+  return {
+    id: row.id,
+    status: row.status,
+    error_code: row.error_code,
+    error_message: row.error_message,
+    hit_count: row.hit_count,
+    last_accessed_at: row.last_accessed_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    export_artifact_id: row.export_artifact_id,
+    report_artifact_id: row.report_artifact_id,
   };
 }
 
@@ -1530,6 +1620,10 @@ async function fetchOwnedPackageJobIfExists(
     .maybeSingle();
 
   if (error) {
+    if (isMissingLegacyPackageJobTableError(error)) {
+      return null;
+    }
+
     console.error('query lca_package_jobs failed during cache reconciliation', {
       error: error.message,
       code: error.code,
@@ -1567,6 +1661,10 @@ async function fetchOwnedPackageJob(
     .maybeSingle();
 
   if (error) {
+    if (isMissingLegacyPackageJobTableError(error)) {
+      throw new TidasPackageError(404, 'JOB_NOT_FOUND', 'Package job not found');
+    }
+
     console.error('query lca_package_jobs failed', {
       error: error.message,
       code: error.code,
@@ -1586,6 +1684,28 @@ async function fetchOwnedPackageJob(
   }
 
   return row;
+}
+
+function isMissingLegacyPackageJobTableError(error: {
+  code?: unknown;
+  message?: unknown;
+  details?: unknown;
+  hint?: unknown;
+}): boolean {
+  const code = normalizeString(error.code);
+  const message = normalizeString(error.message).toLowerCase();
+  const details = normalizeString(error.details).toLowerCase();
+  const hint = normalizeString(error.hint).toLowerCase();
+  const combined = `${message} ${details} ${hint}`;
+
+  return (
+    code === '42P01' ||
+    code === 'PGRST205' ||
+    (combined.includes('lca_package_jobs') &&
+      (combined.includes('schema cache') ||
+        combined.includes('does not exist') ||
+        combined.includes('not found')))
+  );
 }
 
 function toPackageJobRow(data: Record<string, unknown>): PackageJobRow {

--- a/test/tidas_package_api_test.ts
+++ b/test/tidas_package_api_test.ts
@@ -1,7 +1,7 @@
 import { assert, assertEquals, assertMatch } from 'jsr:@std/assert';
 import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
 
-import { type AuthResult, AuthMethod } from '../supabase/functions/_shared/auth.ts';
+import { AuthMethod, type AuthResult } from '../supabase/functions/_shared/auth.ts';
 
 type JsonRecord = Record<string, unknown>;
 type Filter = {
@@ -13,6 +13,7 @@ type TableName =
   | 'lca_package_artifacts'
   | 'lca_package_jobs'
   | 'lca_package_request_cache'
+  | 'roles'
   | 'worker_jobs';
 
 const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
@@ -30,10 +31,12 @@ class FakeSupabase {
     lca_package_jobs: [],
     lca_package_artifacts: [],
     lca_package_request_cache: [],
+    roles: [],
     worker_jobs: [],
   };
   rpcCalls: Array<{ fn: string; args: unknown }> = [];
   rpcResults = new Map<string, { data: unknown; error: unknown }>();
+  missingTables = new Set<TableName>();
   signedUploadCalls: Array<{ bucket: string; objectPath: string }> = [];
   signedDownloadCalls: Array<{ bucket: string; objectPath: string; expiresIn: number }> = [];
   signedDownloadErrors = new Map<string, JsonRecord>();
@@ -107,7 +110,9 @@ class FakeSupabase {
 
         return {
           data: {
-            signedUrl: `https://download.example/${bucket}/${encodePath(objectPath)}?expires=${expiresIn}`,
+            signedUrl: `https://download.example/${bucket}/${encodePath(
+              objectPath,
+            )}?expires=${expiresIn}`,
           },
           error: null,
         };
@@ -125,7 +130,10 @@ class FakeSupabase {
       if (this.isDuplicate(table, row)) {
         return Promise.resolve({
           data: null,
-          error: { code: '23505', message: 'duplicate key value violates unique constraint' },
+          error: {
+            code: '23505',
+            message: 'duplicate key value violates unique constraint',
+          },
         });
       }
     }
@@ -135,6 +143,16 @@ class FakeSupabase {
   }
 
   executeSelect(query: FakeQueryBuilder) {
+    if (this.missingTables.has(query.table)) {
+      return {
+        data: null,
+        error: {
+          code: 'PGRST205',
+          message: `Could not find the table 'public.${query.table}' in the schema cache`,
+        },
+      };
+    }
+
     let rows = this.filterRows(query.table, query.filters);
 
     if (query.orderField) {
@@ -160,6 +178,13 @@ class FakeSupabase {
 
   executeMaybeSingle(query: FakeQueryBuilder) {
     const { data, error } = this.executeSelect(query);
+    if (error || !Array.isArray(data)) {
+      return Promise.resolve({
+        data: null,
+        error,
+      });
+    }
+
     return Promise.resolve({
       data: data[0] ?? null,
       error,
@@ -167,6 +192,16 @@ class FakeSupabase {
   }
 
   executeUpdate(query: FakeQueryBuilder) {
+    if (this.missingTables.has(query.table)) {
+      return {
+        data: null,
+        error: {
+          code: 'PGRST205',
+          message: `Could not find the table 'public.${query.table}' in the schema cache`,
+        },
+      };
+    }
+
     const rows = this.filterRows(query.table, query.filters);
     for (const row of rows) {
       Object.assign(row, structuredClone(query.updateValues));
@@ -339,22 +374,28 @@ function createAuthResult(userId = TEST_USER_ID): AuthResult {
 }
 
 type TidasHandlersModule = {
+  createExportTidasPackageHandler: typeof import('../supabase/functions/export_tidas_package/handler.ts').createExportTidasPackageHandler;
   createImportTidasPackageHandler: typeof import('../supabase/functions/import_tidas_package/handler.ts').createImportTidasPackageHandler;
   createTidasPackageJobsHandler: typeof import('../supabase/functions/tidas_package_jobs/handler.ts').createTidasPackageJobsHandler;
+  queueExportTidasPackage: typeof import('../supabase/functions/_shared/tidas_package.ts').queueExportTidasPackage;
 };
 
 let handlersModulePromise: Promise<TidasHandlersModule> | undefined;
 
 async function loadTidasHandlers(): Promise<TidasHandlersModule> {
   handlersModulePromise ??= (async () => {
-    const [importModule, jobsModule] = await Promise.all([
+    const [exportModule, importModule, jobsModule, packageModule] = await Promise.all([
+      import('../supabase/functions/export_tidas_package/handler.ts'),
       import('../supabase/functions/import_tidas_package/handler.ts'),
       import('../supabase/functions/tidas_package_jobs/handler.ts'),
+      import('../supabase/functions/_shared/tidas_package.ts'),
     ]);
 
     return {
+      createExportTidasPackageHandler: exportModule.createExportTidasPackageHandler,
       createImportTidasPackageHandler: importModule.createImportTidasPackageHandler,
       createTidasPackageJobsHandler: jobsModule.createTidasPackageJobsHandler,
+      queueExportTidasPackage: packageModule.queueExportTidasPackage,
     };
   })();
 
@@ -397,11 +438,133 @@ function restoreEnvVar(name: string, value: string | undefined): void {
   Deno.env.set(name, value);
 }
 
+Deno.test('export_tidas_package API exposes queued worker job before artifacts exist', async () => {
+  await withPackageStorageEnv(async () => {
+    const {
+      createExportTidasPackageHandler,
+      createTidasPackageJobsHandler,
+      queueExportTidasPackage,
+    } = await loadTidasHandlers();
+    const supabase = new FakeSupabase();
+    supabase.missingTables.add('lca_package_jobs');
+    const exportAuthCalls: AuthMethod[][] = [];
+    const jobsAuthCalls: AuthMethod[][] = [];
+    let jobsRedisCalls = 0;
+
+    const exportHandler = createExportTidasPackageHandler({
+      authClient: {} as SupabaseClient,
+      supabase: supabase as unknown as SupabaseClient,
+      authenticateRequest: async (_req, config) => {
+        exportAuthCalls.push([...config.allowedMethods]);
+        return createAuthResult();
+      },
+      queueExportTidasPackage,
+    });
+
+    const jobsHandler = createTidasPackageJobsHandler({
+      authClient: {} as SupabaseClient,
+      supabase: supabase as unknown as SupabaseClient,
+      authenticateRequest: async (_req, config) => {
+        jobsAuthCalls.push([...config.allowedMethods]);
+        return createAuthResult();
+      },
+      getRedisClient: async () => {
+        jobsRedisCalls += 1;
+        return undefined;
+      },
+    });
+
+    const exportResponse = await exportHandler(
+      new Request('https://example.com/functions/v1/export_tidas_package', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${TEST_JWT}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ scope: 'current_user' }),
+      }),
+    );
+
+    assertEquals(exportResponse.status, 202);
+    const queued = await exportResponse.json();
+    assertEquals(queued.ok, true);
+    assertEquals(queued.mode, 'queued');
+    assertMatch(
+      queued.job_id,
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+    assertEquals(queued.worker_job_id, TEST_WORKER_JOB_ID);
+    assertEquals(queued.scope, 'current_user');
+    assertEquals(queued.root_count, 0);
+    assertEquals(exportAuthCalls, [[AuthMethod.JWT]]);
+
+    assertEquals(supabase.getRows('lca_package_jobs').length, 0);
+    assertEquals(supabase.getRows('lca_package_artifacts').length, 0);
+
+    const cacheRow = supabase.getRows('lca_package_request_cache')[0];
+    assertEquals(cacheRow.status, 'pending');
+    assertEquals(cacheRow.job_id, queued.job_id);
+    assertEquals(cacheRow.worker_job_id, TEST_WORKER_JOB_ID);
+
+    const workerJobRow = supabase.getRows('worker_jobs')[0];
+    assertEquals(workerJobRow.status, 'queued');
+    assertEquals(workerJobRow.job_kind, 'tidas.export_package');
+    assertEquals(workerJobRow.requested_by, TEST_USER_ID);
+    assertEquals((workerJobRow.payload_json as JsonRecord).job_id, queued.job_id);
+    assertEquals((workerJobRow.payload_json as JsonRecord).scope, 'current_user');
+    assertEquals(supabase.rpcCalls.length, 1);
+    assertEquals(supabase.rpcCalls[0].fn, 'worker_enqueue_job');
+
+    const lookupResponse = await jobsHandler(
+      new Request(`https://example.com/functions/v1/tidas_package_jobs/${queued.job_id}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${TEST_JWT}`,
+        },
+      }),
+    );
+    assertEquals(lookupResponse.status, 200);
+
+    const jobLookup = await lookupResponse.json();
+    assertEquals(jobLookup.ok, true);
+    assertEquals(jobLookup.job_id, queued.job_id);
+    assertEquals(jobLookup.job_type, 'export_package');
+    assertEquals(jobLookup.status, 'queued');
+    assertEquals(jobLookup.scope, 'current_user');
+    assertEquals(jobLookup.root_count, 0);
+    assertEquals(jobLookup.request_key, workerJobRow.request_hash);
+    assertEquals(jobLookup.request_cache.status, 'pending');
+    assertEquals(jobLookup.request_cache.export_artifact_id, null);
+    assertEquals(jobLookup.request_cache.report_artifact_id, null);
+    assertEquals(jobLookup.artifacts.length, 0);
+    assertEquals(jobsRedisCalls, 1);
+    assertEquals(jobsAuthCalls, [[AuthMethod.JWT, AuthMethod.USER_API_KEY]]);
+
+    const workerIdLookupResponse = await jobsHandler(
+      new Request('https://example.com/functions/v1/tidas_package_jobs', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${TEST_JWT}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ job_id: TEST_WORKER_JOB_ID }),
+      }),
+    );
+    assertEquals(workerIdLookupResponse.status, 200);
+
+    const workerIdLookup = await workerIdLookupResponse.json();
+    assertEquals(workerIdLookup.ok, true);
+    assertEquals(workerIdLookup.job_id, queued.job_id);
+    assertEquals(workerIdLookup.status, 'queued');
+  });
+});
+
 Deno.test('import_tidas_package API completes prepare, enqueue, and job lookup flow', async () => {
   await withPackageStorageEnv(async () => {
     const { createImportTidasPackageHandler, createTidasPackageJobsHandler } =
       await loadTidasHandlers();
     const supabase = new FakeSupabase();
+    supabase.missingTables.add('lca_package_jobs');
     const importAuthCalls: AuthMethod[][] = [];
     const jobsAuthCalls: AuthMethod[][] = [];
     let importRedisCalls = 0;


### PR DESCRIPTION
## Summary

- Fix `tidas_package_jobs` lookup for newly queued TIDAS export worker jobs before artifacts exist.
- Resolve export request cache by compatibility `job_id` or `worker_job_id`, then build the response from the owned `worker_jobs` row when no legacy `lca_package_jobs` row exists.
- Treat missing retained `lca_package_jobs` table/schema-cache entries as "no legacy job" so the worker_jobs path keeps working after legacy-table retirement.
- Keep request-cache details in the response and keep lookup scoped by `requested_by` + `operation`.
- Add regression coverage for the queued export state with no legacy job row, no artifacts, and no available legacy package table.

Closes #172

## Validation

- `deno test --allow-env --config supabase/functions/deno.json test/tidas_package_api_test.ts`
- `deno test --allow-env --config supabase/functions/deno.json test/tidas_package_test.ts test/tidas_package_api_test.ts`
- `npm run check`
- `npx prettier --check supabase/functions/_shared/tidas_package.ts test/tidas_package_api_test.ts`

Note: full `npm run lint` currently fails on pre-existing `.docpact/config.yaml` formatting; this PR does not modify that file.

## Rollout

After merge, deploy `tidas_package_jobs` to main. Because this is a main hotfix for an M2 repo, follow up with `main -> dev` back-merge.
