### PR TITLE
Promote dev to main for dataset create-version command

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-06-02'
-lastReviewedCommit: '07d218208e049d3d23e8091102e5a97b7c4dfc51'
+lastReviewedAt: '2026-06-11'
+lastReviewedCommit: '511a9e9c1019f7306e16f4ba285e86afcc1ae1cb'
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: 6653f78559db853da835348cabe04509afe1d10b
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: 511a9e9c1019f7306e16f4ba285e86afcc1ae1cb
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ checkPaths:
   - supabase/config.toml
   - supabase/.env.example
   - test.example.http
-lastReviewedAt: 2026-05-29
-lastReviewedCommit: a98c4dc89050a426f8428b46c1ad0e89dc89e8f6
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: 511a9e9c1019f7306e16f4ba285e86afcc1ae1cb
 ---
 
 # TianGong-LCA-Edge-Functions

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: 6653f78559db853da835348cabe04509afe1d10b
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: 511a9e9c1019f7306e16f4ba285e86afcc1ae1cb
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-03
-lastReviewedCommit: 6653f78559db853da835348cabe04509afe1d10b
+lastReviewedAt: 2026-06-11
+lastReviewedCommit: 511a9e9c1019f7306e16f4ba285e86afcc1ae1cb
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/functions/_shared/commands/dataset/create_version.ts
+++ b/supabase/functions/_shared/commands/dataset/create_version.ts
@@ -1,0 +1,50 @@
+import type { ActorContext } from '../../command_runtime/actor_context.ts';
+import { buildCommandAuditPayload } from '../../command_runtime/audit_log.ts';
+import { assertCreateVersionPolicy } from './policy.ts';
+import { createDatasetCommandRepository, type DatasetCommandRepository } from './repository.ts';
+import type { CreateVersionRequest, DatasetCommandExecutionResult } from './types.ts';
+import { createVersionRequestSchema, parseCreateVersionRequest } from './validation.ts';
+
+export { createVersionRequestSchema };
+
+export function parseCreateVersionCommand(body: unknown) {
+  return parseCreateVersionRequest(body);
+}
+
+export async function executeCreateVersionCommand(
+  request: CreateVersionRequest,
+  actor: ActorContext,
+  repository: DatasetCommandRepository = createDatasetCommandRepository(actor.supabase),
+): Promise<DatasetCommandExecutionResult> {
+  const policy = assertCreateVersionPolicy(request);
+  if (!policy.ok) {
+    return policy;
+  }
+
+  const audit = buildCommandAuditPayload({
+    command: 'dataset_create_version',
+    actorUserId: actor.userId,
+    targetTable: request.table,
+    targetId: request.id,
+    targetVersion: '',
+    payload: {
+      sourceVersion: request.sourceVersion,
+      ...(request.modelId ? { modelId: request.modelId } : {}),
+    },
+  });
+
+  const result = await repository.createVersion(request, audit);
+  if (!result.ok) {
+    return result;
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: 'dataset_create_version',
+      data: result.data,
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/dataset/policy.ts
+++ b/supabase/functions/_shared/commands/dataset/policy.ts
@@ -1,6 +1,7 @@
 import type {
   AssignTeamRequest,
   CreateRequest,
+  CreateVersionRequest,
   DatasetCommandFailure,
   DeleteRequest,
   PublishRequest,
@@ -35,6 +36,19 @@ export function assertCreatePolicy(request: CreateRequest): { ok: true } | Datas
     return invalidInput(
       'MODEL_ID_NOT_ALLOWED',
       'modelId is only allowed for process dataset creates',
+    );
+  }
+
+  return { ok: true };
+}
+
+export function assertCreateVersionPolicy(
+  request: CreateVersionRequest,
+): { ok: true } | DatasetCommandFailure {
+  if (request.table !== 'processes' && request.modelId) {
+    return invalidInput(
+      'MODEL_ID_NOT_ALLOWED',
+      'modelId is only allowed for process dataset version creates',
     );
   }
 

--- a/supabase/functions/_shared/commands/dataset/repository.ts
+++ b/supabase/functions/_shared/commands/dataset/repository.ts
@@ -4,6 +4,7 @@ import type { CommandAuditPayload } from '../../command_runtime/audit_log.ts';
 import {
   callDatasetAssignTeamRpc,
   callDatasetCreateRpc,
+  callDatasetCreateVersionRpc,
   callDatasetDeleteRpc,
   callDatasetPublishRpc,
   callDatasetReviewSubmitGateRpc,
@@ -17,6 +18,7 @@ import {
 import type {
   AssignTeamRequest,
   CreateRequest,
+  CreateVersionRequest,
   DeleteRequest,
   PublishRequest,
   ReviewSubmitGateRequest,
@@ -31,6 +33,10 @@ type RpcClient = Pick<SupabaseClient, 'rpc'>;
 
 export type DatasetCommandRepository = {
   create: (request: CreateRequest, audit: CommandAuditPayload) => Promise<DatasetRpcResult>;
+  createVersion: (
+    request: CreateVersionRequest,
+    audit: CommandAuditPayload,
+  ) => Promise<DatasetRpcResult>;
   delete: (request: DeleteRequest, audit: CommandAuditPayload) => Promise<DatasetRpcResult>;
   saveDraft: (request: SaveDraftRequest, audit: CommandAuditPayload) => Promise<DatasetRpcResult>;
   assignTeam: (request: AssignTeamRequest, audit: CommandAuditPayload) => Promise<DatasetRpcResult>;
@@ -66,6 +72,7 @@ export function createDatasetCommandRepository(supabase: RpcClient): DatasetComm
 
   return {
     create: (request, audit) => callDatasetCreateRpc(client, request, audit),
+    createVersion: (request, audit) => callDatasetCreateVersionRpc(client, request, audit),
     delete: (request, audit) => callDatasetDeleteRpc(client, request, audit),
     saveDraft: (request, audit) => callDatasetSaveDraftRpc(client, request, audit),
     assignTeam: (request, audit) => callDatasetAssignTeamRpc(client, request, audit),

--- a/supabase/functions/_shared/commands/dataset/types.ts
+++ b/supabase/functions/_shared/commands/dataset/types.ts
@@ -27,6 +27,15 @@ export type CreateRequest = {
   ruleVerification?: boolean | null;
 };
 
+export type CreateVersionRequest = {
+  table: DatasetTable;
+  id: string;
+  sourceVersion: string;
+  jsonOrdered: unknown;
+  modelId?: string | null;
+  ruleVerification?: boolean | null;
+};
+
 export type DeleteRequest = {
   table: DatasetTable;
   id: string;

--- a/supabase/functions/_shared/commands/dataset/validation.ts
+++ b/supabase/functions/_shared/commands/dataset/validation.ts
@@ -4,6 +4,7 @@ import type { CommandParseResult } from '../../command_runtime/command.ts';
 import {
   type AssignTeamRequest,
   type CreateRequest,
+  type CreateVersionRequest,
   DATASET_TABLES,
   type DeleteRequest,
   type PublishRequest,
@@ -46,6 +47,15 @@ export const saveDraftRequestSchema = datasetBaseRequestSchema
 
 export const createRequestSchema = datasetIdTableSchema
   .extend({
+    jsonOrdered: z.unknown(),
+    modelId: z.string().uuid().nullable().optional(),
+    ruleVerification: z.boolean().nullable().optional(),
+  })
+  .strict();
+
+export const createVersionRequestSchema = datasetIdTableSchema
+  .extend({
+    sourceVersion: versionSchema,
     jsonOrdered: z.unknown(),
     modelId: z.string().uuid().nullable().optional(),
     ruleVerification: z.boolean().nullable().optional(),
@@ -115,6 +125,18 @@ export function parseCreateRequest(body: unknown): CommandParseResult<CreateRequ
   const parsed = createRequestSchema.safeParse(body);
   if (!parsed.success) {
     return invalidPayload('Invalid dataset create payload', parsed.error);
+  }
+
+  return {
+    ok: true,
+    value: parsed.data,
+  };
+}
+
+export function parseCreateVersionRequest(body: unknown): CommandParseResult<CreateVersionRequest> {
+  const parsed = createVersionRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload('Invalid dataset create-version payload', parsed.error);
   }
 
   return {

--- a/supabase/functions/_shared/db_rpc/dataset_commands.ts
+++ b/supabase/functions/_shared/db_rpc/dataset_commands.ts
@@ -4,6 +4,7 @@ import type { CommandAuditPayload } from '../command_runtime/audit_log.ts';
 import type {
   AssignTeamRequest,
   CreateRequest,
+  CreateVersionRequest,
   DatasetCommandFailure,
   DeleteRequest,
   PublishRequest,
@@ -106,6 +107,21 @@ export function buildDatasetCreateRpcArgs(
   return {
     p_table: request.table,
     p_id: request.id,
+    p_json_ordered: request.jsonOrdered,
+    p_model_id: request.modelId ?? null,
+    p_rule_verification: request.ruleVerification ?? null,
+    p_audit: audit,
+  };
+}
+
+export function buildDatasetCreateVersionRpcArgs(
+  request: CreateVersionRequest,
+  audit: CommandAuditPayload,
+): Record<string, unknown> {
+  return {
+    p_table: request.table,
+    p_id: request.id,
+    p_source_version: request.sourceVersion,
     p_json_ordered: request.jsonOrdered,
     p_model_id: request.modelId ?? null,
     p_rule_verification: request.ruleVerification ?? null,
@@ -271,6 +287,18 @@ export function callDatasetCreateRpc(
   audit: CommandAuditPayload,
 ) {
   return callDatasetRpc(supabase, 'cmd_dataset_create', buildDatasetCreateRpcArgs(request, audit));
+}
+
+export function callDatasetCreateVersionRpc(
+  supabase: RpcClient,
+  request: CreateVersionRequest,
+  audit: CommandAuditPayload,
+) {
+  return callDatasetRpc(
+    supabase,
+    'cmd_dataset_create_version',
+    buildDatasetCreateVersionRpcArgs(request, audit),
+  );
 }
 
 export function callDatasetDeleteRpc(

--- a/supabase/functions/app_dataset_create_version/index.ts
+++ b/supabase/functions/app_dataset_create_version/index.ts
@@ -1,0 +1,27 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+
+import {
+  type CommandHandlerOptions,
+  createCommandHandler,
+} from '../_shared/command_runtime/command.ts';
+import {
+  executeCreateVersionCommand,
+  parseCreateVersionCommand,
+} from '../_shared/commands/dataset/create_version.ts';
+import type { CreateVersionRequest } from '../_shared/commands/dataset/types.ts';
+
+export function createAppDatasetCreateVersionHandler(
+  overrides: Partial<CommandHandlerOptions<CreateVersionRequest>> = {},
+) {
+  return createCommandHandler<CreateVersionRequest>({
+    parse: parseCreateVersionCommand,
+    execute: executeCreateVersionCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppDatasetCreateVersion = createAppDatasetCreateVersionHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppDatasetCreateVersion);
+}

--- a/test.example.http
+++ b/test.example.http
@@ -121,6 +121,26 @@ curl -i --location --request POST '{{$dotenv LOCAL_ENDPOINT}}/app_dataset_verify
       ]
     }'
 
+### @name Dataset_Create_Version：Local
+curl -i --location --request POST '{{$dotenv LOCAL_ENDPOINT}}/app_dataset_create_version' \
+    --header 'Content-Type: application/json' \
+    --header 'Authorization: Bearer {{$dotenv USER_JWT}}' \
+    --data '{
+      "table": "processes",
+      "id": "012fc8f6-9a30-4d98-9b03-34ddec3a6f10",
+      "sourceVersion": "01.01.002",
+      "jsonOrdered": {
+        "processDataSet": {
+          "administrativeInformation": {
+            "publicationAndOwnership": {
+              "common:dataSetVersion": "will-be-overwritten-by-server"
+            }
+          }
+        }
+      },
+      "ruleVerification": true
+    }'
+
 ### @name Dataset_Review_Submit_Gate：Local
 # Worker-owned gate reports may still contain legacy payload fields such as calculatorReport.
 curl -i --location --request POST '{{$dotenv LOCAL_ENDPOINT}}/app_dataset_review_submit_gate' \

--- a/test/app_dataset_create_version_test.ts
+++ b/test/app_dataset_create_version_test.ts
@@ -1,0 +1,150 @@
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+
+import {
+  executeCreateVersionCommand,
+  parseCreateVersionCommand,
+} from '../supabase/functions/_shared/commands/dataset/create_version.ts';
+
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+const TEST_DATASET_ID = '22222222-2222-4222-8222-222222222222';
+const TEST_MODEL_ID = '33333333-3333-4333-8333-333333333333';
+
+class FakeRpcSupabase {
+  rpcCalls: Array<{ fn: string; args: unknown }> = [];
+  response: { data: unknown; error: unknown };
+
+  constructor(
+    response: { data: unknown; error: unknown } = {
+      data: {
+        ok: true,
+        data: {
+          id: TEST_DATASET_ID,
+          version: '01.00.001',
+        },
+      },
+      error: null,
+    },
+  ) {
+    this.response = response;
+  }
+
+  rpc(fn: string, args: unknown) {
+    this.rpcCalls.push({
+      fn,
+      args: structuredClone(args),
+    });
+
+    return Promise.resolve(structuredClone(this.response));
+  }
+}
+
+function buildActor(supabase: FakeRpcSupabase) {
+  return {
+    userId: TEST_USER_ID,
+    accessToken: 'access-token',
+    supabase: supabase as unknown as SupabaseClient,
+  };
+}
+
+Deno.test(
+  'executeCreateVersionCommand forwards version creation to cmd_dataset_create_version',
+  async () => {
+    const supabase = new FakeRpcSupabase();
+    const result = await executeCreateVersionCommand(
+      {
+        table: 'processes',
+        id: TEST_DATASET_ID,
+        sourceVersion: '01.00.000',
+        jsonOrdered: { foo: 'bar' },
+        modelId: TEST_MODEL_ID,
+        ruleVerification: false,
+      },
+      buildActor(supabase),
+    );
+
+    assertEquals(result.ok, true);
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: 'cmd_dataset_create_version',
+        args: {
+          p_table: 'processes',
+          p_id: TEST_DATASET_ID,
+          p_source_version: '01.00.000',
+          p_json_ordered: { foo: 'bar' },
+          p_model_id: TEST_MODEL_ID,
+          p_rule_verification: false,
+          p_audit: {
+            command: 'dataset_create_version',
+            actorUserId: TEST_USER_ID,
+            targetTable: 'processes',
+            targetId: TEST_DATASET_ID,
+            targetVersion: '',
+            payload: {
+              sourceVersion: '01.00.000',
+              modelId: TEST_MODEL_ID,
+            },
+          },
+        },
+      },
+    ]);
+  },
+);
+
+Deno.test('executeCreateVersionCommand returns the server allocated version', async () => {
+  const supabase = new FakeRpcSupabase();
+  const result = await executeCreateVersionCommand(
+    {
+      table: 'flows',
+      id: TEST_DATASET_ID,
+      sourceVersion: '01.00.000',
+      jsonOrdered: { foo: 'bar' },
+    },
+    buildActor(supabase),
+  );
+
+  assertEquals(result, {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      command: 'dataset_create_version',
+      data: {
+        id: TEST_DATASET_ID,
+        version: '01.00.001',
+      },
+    },
+  });
+});
+
+Deno.test('parseCreateVersionCommand rejects missing sourceVersion', () => {
+  const result = parseCreateVersionCommand({
+    table: 'flows',
+    id: TEST_DATASET_ID,
+    jsonOrdered: { foo: 'bar' },
+  });
+
+  assertEquals(result.ok, false);
+});
+
+Deno.test('executeCreateVersionCommand rejects modelId for non-process datasets', async () => {
+  const supabase = new FakeRpcSupabase();
+  const result = await executeCreateVersionCommand(
+    {
+      table: 'flows',
+      id: TEST_DATASET_ID,
+      sourceVersion: '01.00.000',
+      jsonOrdered: { foo: 'bar' },
+      modelId: TEST_MODEL_ID,
+    },
+    buildActor(supabase),
+  );
+
+  assertEquals(result, {
+    ok: false,
+    code: 'MODEL_ID_NOT_ALLOWED',
+    message: 'modelId is only allowed for process dataset version creates',
+    status: 400,
+  });
+  assertEquals(supabase.rpcCalls, []);
+});

--- a/test/app_dataset_review_submit_gate_test.ts
+++ b/test/app_dataset_review_submit_gate_test.ts
@@ -41,6 +41,7 @@ class FakeReviewSubmitGateRepository implements DatasetCommandRepository {
   }
 
   create = () => this.unimplemented();
+  createVersion = () => this.unimplemented();
   delete = () => this.unimplemented();
   saveDraft = () => this.unimplemented();
   assignTeam = () => this.unimplemented();

--- a/test/app_dataset_review_submit_jobs_test.ts
+++ b/test/app_dataset_review_submit_jobs_test.ts
@@ -35,6 +35,7 @@ class FakeReviewSubmitJobRepository implements DatasetCommandRepository {
   }
 
   create = () => this.unimplemented();
+  createVersion = () => this.unimplemented();
   delete = () => this.unimplemented();
   saveDraft = () => this.unimplemented();
   assignTeam = () => this.unimplemented();

--- a/test/dataset_command_rpc_contract_test.ts
+++ b/test/dataset_command_rpc_contract_test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertThrows } from 'jsr:@std/assert';
 
 import { buildCommandAuditPayload } from '../supabase/functions/_shared/command_runtime/audit_log.ts';
 import { createRequestSchema } from '../supabase/functions/_shared/commands/dataset/create.ts';
+import { createVersionRequestSchema } from '../supabase/functions/_shared/commands/dataset/create_version.ts';
 import { deleteRequestSchema } from '../supabase/functions/_shared/commands/dataset/delete.ts';
 import { createDatasetCommandRepository } from '../supabase/functions/_shared/commands/dataset/repository.ts';
 import { reviewSubmitGateRequestSchema } from '../supabase/functions/_shared/commands/dataset/review_submit_gate.ts';
@@ -10,6 +11,7 @@ import { saveDraftRequestSchema } from '../supabase/functions/_shared/commands/d
 import { submitReviewRequestSchema } from '../supabase/functions/_shared/commands/dataset/submit_review.ts';
 import {
   callDatasetCreateRpc,
+  callDatasetCreateVersionRpc,
   callDatasetDeleteRpc,
   callDatasetReviewSubmitGateRpc,
   callDatasetReviewSubmitJobEnqueueRpc,
@@ -111,6 +113,32 @@ Deno.test('createRequestSchema accepts optional ruleVerification', () => {
   assertEquals(parsed.success, true);
 });
 
+Deno.test(
+  'createVersionRequestSchema requires sourceVersion and rejects target version fields',
+  () => {
+    const parsed = createVersionRequestSchema.safeParse({
+      table: 'flows',
+      id: '11111111-1111-4111-8111-111111111111',
+      version: '01.00.001',
+      jsonOrdered: {},
+    });
+
+    assertEquals(parsed.success, false);
+  },
+);
+
+Deno.test('createVersionRequestSchema accepts sourceVersion and optional ruleVerification', () => {
+  const parsed = createVersionRequestSchema.safeParse({
+    table: 'flows',
+    id: '11111111-1111-4111-8111-111111111111',
+    sourceVersion: '01.00.000',
+    jsonOrdered: {},
+    ruleVerification: false,
+  });
+
+  assertEquals(parsed.success, true);
+});
+
 Deno.test('deleteRequestSchema rejects unexpected payload fields', () => {
   const parsed = deleteRequestSchema.safeParse({
     table: 'flows',
@@ -153,6 +181,15 @@ const createRequest = {
   id: '11111111-1111-4111-8111-111111111111',
   jsonOrdered: { foo: 'bar' },
   modelId: '33333333-3333-4333-8333-333333333333',
+};
+
+const createVersionRequest = {
+  table: 'processes' as const,
+  id: '11111111-1111-4111-8111-111111111111',
+  sourceVersion: '01.00.000',
+  jsonOrdered: { foo: 'bar' },
+  modelId: '33333333-3333-4333-8333-333333333333',
+  ruleVerification: false,
 };
 
 const deleteRequest = {
@@ -228,6 +265,49 @@ Deno.test(
         version: '01.00.000',
       },
     });
+  },
+);
+
+Deno.test(
+  'callDatasetCreateVersionRpc forwards create-version RPC args and unwraps success envelopes',
+  async () => {
+    const supabase = new FakeRpcSupabase({
+      data: {
+        ok: true,
+        data: {
+          id: createVersionRequest.id,
+          version: '01.00.001',
+        },
+      },
+      error: null,
+    });
+    const result = (await callDatasetCreateVersionRpc(
+      supabase as never,
+      createVersionRequest,
+      auditPayload,
+    )) as DatasetRpcResult;
+
+    assertEquals(result, {
+      ok: true,
+      data: {
+        id: createVersionRequest.id,
+        version: '01.00.001',
+      },
+    });
+    assertEquals(supabase.calls, [
+      {
+        fn: 'cmd_dataset_create_version',
+        args: {
+          p_table: 'processes',
+          p_id: createVersionRequest.id,
+          p_source_version: createVersionRequest.sourceVersion,
+          p_json_ordered: createVersionRequest.jsonOrdered,
+          p_model_id: createVersionRequest.modelId,
+          p_rule_verification: false,
+          p_audit: auditPayload,
+        },
+      },
+    ]);
   },
 );
 


### PR DESCRIPTION
## Summary
- Promote `dev` into `main` after merging edge-functions PR #184.
- Includes the dataset create-version edge function command.

## Source PR
- linancn/tiangong-lca-edge-functions#184

## Validation
- Source implementation PR #184 is merged into `dev`.
- This fork promote branch was cut from canonical `origin/dev` because this account cannot create a canonical `dev` -> `main` PR directly.