### PR TITLE
新增全国碳图谱缓存 worker job API

### DIFF
--- a/supabase/functions/_shared/commands/national_carbon_graph_cache_jobs.ts
+++ b/supabase/functions/_shared/commands/national_carbon_graph_cache_jobs.ts
@@ -1,0 +1,326 @@
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+import { z } from 'zod';
+
+import type { ActorContext } from '../command_runtime/actor_context.ts';
+import type { CommandExecutionResult, CommandParseResult } from '../command_runtime/command.ts';
+import {
+  callWorkerJobEnqueueRpc,
+  callWorkerJobListRpc,
+  callWorkerJobReadRpc,
+  type WorkerJobRpcResult,
+} from '../db_rpc/worker_jobs.ts';
+import { createSupabaseServiceClient } from '../supabase_client.ts';
+import type { WorkerJobResult, WorkerJobStatus } from './dataset/types.ts';
+
+export const NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND =
+  'national_carbon.process_flow_graph_cache_build';
+export const NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE = 'national_carbon_process_flow_graph_cache';
+
+const SYSTEM_TEAM_ID = '00000000-0000-0000-0000-000000000000';
+const SYSTEM_MANAGER_ROLES = ['owner', 'admin', 'member'];
+const DEFAULT_JOB_ENVIRONMENT = 'main';
+
+const uuidSchema = z.string().uuid();
+const workerJobStatuses = [
+  'queued',
+  'running',
+  'waiting',
+  'completed',
+  'blocked',
+  'stale',
+  'failed',
+  'cancelled',
+] as const;
+
+const enqueueSchema = z
+  .object({
+    action: z.literal('enqueue'),
+  })
+  .strict();
+
+const readSchema = z
+  .object({
+    action: z.literal('read'),
+    jobId: uuidSchema,
+  })
+  .strict();
+
+const readLatestSchema = z
+  .object({
+    action: z.literal('read_latest'),
+    statuses: z.array(z.enum(workerJobStatuses)).optional(),
+    limit: z.number().int().min(1).max(20).optional(),
+  })
+  .strict();
+
+export const nationalCarbonGraphCacheJobRequestSchema = z.union([
+  enqueueSchema,
+  readSchema,
+  readLatestSchema,
+]);
+
+export type NationalCarbonGraphCacheJobRequest = z.infer<
+  typeof nationalCarbonGraphCacheJobRequestSchema
+>;
+
+export type EnvReader = (name: string) => string | undefined;
+
+export type NationalCarbonGraphCacheJobExecutionOptions = {
+  now?: () => Date;
+  readEnv?: EnvReader;
+};
+
+function invalidPayload<T>(message: string, error: z.ZodError): CommandParseResult<T> {
+  return {
+    ok: false,
+    message,
+    details: error.flatten(),
+  };
+}
+
+export function parseNationalCarbonGraphCacheJobCommand(
+  body: unknown,
+): CommandParseResult<NationalCarbonGraphCacheJobRequest> {
+  const parsed = nationalCarbonGraphCacheJobRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload('Invalid national carbon graph cache job payload', parsed.error);
+  }
+
+  return {
+    ok: true,
+    value: parsed.data,
+  };
+}
+
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    const value = Deno.env.get(name);
+    return value && value.trim().length > 0 ? value.trim() : undefined;
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function readJobEnvironment(readEnv: EnvReader = defaultReadEnv): string {
+  return (
+    readEnv('NATIONAL_CARBON_GRAPH_CACHE_ENVIRONMENT') ??
+    readEnv('LCA_WORKER_ENVIRONMENT') ??
+    readEnv('APP_ENV') ??
+    DEFAULT_JOB_ENVIRONMENT
+  );
+}
+
+function buildJobPayload(readEnv: EnvReader, environment: string): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    environment,
+    execute: true,
+  };
+
+  const cachePrefix = readEnv('NATIONAL_CARBON_GRAPH_CACHE_PREFIX');
+  if (cachePrefix) {
+    payload.cachePrefix = cachePrefix;
+  }
+
+  const cacheBucket = readEnv('NATIONAL_CARBON_GRAPH_CACHE_BUCKET');
+  if (cacheBucket) {
+    payload.cacheBucket = cacheBucket;
+  }
+
+  return payload;
+}
+
+function isWorkerJobStatus(value: unknown): value is WorkerJobStatus {
+  return workerJobStatuses.some((status) => status === value);
+}
+
+function normalizeWorkerJob(data: unknown): WorkerJobResult {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return {
+      status: 'failed',
+      errorCode: 'invalid_worker_job_rpc_result',
+      errorMessage: 'Worker job RPC returned an invalid response payload.',
+    };
+  }
+
+  const candidate = data as Record<string, unknown>;
+  return {
+    ...candidate,
+    status: isWorkerJobStatus(candidate.status) ? candidate.status : 'failed',
+  } as WorkerJobResult;
+}
+
+function normalizeWorkerJobList(data: unknown): WorkerJobResult[] {
+  return Array.isArray(data) ? data.map(normalizeWorkerJob) : [];
+}
+
+function isNationalCarbonGraphCacheJob(job: WorkerJobResult): boolean {
+  return (
+    job.jobKind === NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND &&
+    job.subjectType === NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE
+  );
+}
+
+async function ensureSystemManager(
+  actor: ActorContext,
+  serviceClient: SupabaseClient,
+): Promise<CommandExecutionResult | null> {
+  const { data, error } = await serviceClient
+    .from('roles')
+    .select('user_id')
+    .eq('user_id', actor.userId)
+    .eq('team_id', SYSTEM_TEAM_ID)
+    .in('role', SYSTEM_MANAGER_ROLES)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    return {
+      ok: false,
+      code: 'SYSTEM_MANAGER_CHECK_FAILED',
+      status: 502,
+      message: 'Unable to verify system-manager permissions',
+      details: error,
+    };
+  }
+
+  if (!data) {
+    return {
+      ok: false,
+      code: 'SYSTEM_MANAGER_REQUIRED',
+      status: 403,
+      message: 'System-manager permissions are required to manage national carbon graph cache jobs',
+    };
+  }
+
+  return null;
+}
+
+function rpcFailure(result: WorkerJobRpcResult): CommandExecutionResult {
+  if (result.ok) {
+    return {
+      ok: false,
+      code: 'WORKER_JOB_RPC_RESULT_INVALID',
+      status: 502,
+      message: 'Worker job RPC result was unexpectedly successful',
+    };
+  }
+
+  return result;
+}
+
+function graphCacheJobNotFound(): CommandExecutionResult {
+  return {
+    ok: false,
+    code: 'NATIONAL_CARBON_GRAPH_CACHE_JOB_NOT_FOUND',
+    status: 404,
+    message: 'National carbon graph cache job not found',
+  };
+}
+
+export async function executeNationalCarbonGraphCacheJobCommand(
+  request: NationalCarbonGraphCacheJobRequest,
+  actor: ActorContext,
+  serviceClient: SupabaseClient = createSupabaseServiceClient(),
+  options: NationalCarbonGraphCacheJobExecutionOptions = {},
+): Promise<CommandExecutionResult> {
+  const aclFailure = await ensureSystemManager(actor, serviceClient);
+  if (aclFailure) {
+    return aclFailure;
+  }
+
+  if (request.action === 'read_latest') {
+    const result = await callWorkerJobListRpc(serviceClient, {
+      requestedBy: null,
+      subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+      subjectId: null,
+      statuses: request.statuses ?? null,
+      visibility: 'operator',
+      limit: request.limit ?? 5,
+      includeInternal: false,
+    });
+    if (!result.ok) {
+      return rpcFailure(result);
+    }
+
+    return {
+      ok: true,
+      body: {
+        ok: true,
+        command: 'national_carbon_graph_cache_jobs_read_latest',
+        data: normalizeWorkerJobList(result.data).filter(isNationalCarbonGraphCacheJob),
+      },
+    };
+  }
+
+  if (request.action === 'read') {
+    const result = await callWorkerJobReadRpc(serviceClient, {
+      jobId: request.jobId,
+      includeInternal: false,
+    });
+    if (!result.ok) {
+      return rpcFailure(result);
+    }
+
+    const job = normalizeWorkerJob(result.data);
+    if (!isNationalCarbonGraphCacheJob(job)) {
+      return graphCacheJobNotFound();
+    }
+
+    return {
+      ok: true,
+      body: {
+        ok: true,
+        command: 'national_carbon_graph_cache_jobs_read',
+        data: job,
+      },
+    };
+  }
+
+  const readEnv = options.readEnv ?? defaultReadEnv;
+  const environment = readJobEnvironment(readEnv);
+  const now = (options.now ?? (() => new Date()))();
+  const idempotencyWindow = now.toISOString().slice(0, 16);
+  const activeKey = `${NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND}:${environment}:execute`;
+  const result = await callWorkerJobEnqueueRpc(serviceClient, {
+    jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+    payload: buildJobPayload(readEnv, environment),
+    payloadSchemaVersion: 'national_carbon.process_flow_graph_cache_build.request.v1',
+    subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+    subjectId: null,
+    subjectVersion: environment,
+    requestedBy: actor.userId,
+    requesterType: 'operator',
+    idempotencyKey: `${activeKey}:${actor.userId}:${idempotencyWindow}`,
+    concurrencyKey: activeKey,
+    priority: 0,
+    queueKey: environment,
+    visibility: 'operator',
+    maxAttempts: 1,
+  });
+
+  if (!result.ok) {
+    if (result.code === 'WORKER_JOB_CONCURRENCY_CONFLICT' && result.details) {
+      return {
+        ok: true,
+        body: {
+          ok: true,
+          command: 'national_carbon_graph_cache_jobs_enqueue',
+          reused: true,
+          data: normalizeWorkerJob(result.details),
+        },
+      };
+    }
+
+    return rpcFailure(result);
+  }
+
+  return {
+    ok: true,
+    body: {
+      ok: true,
+      command: 'national_carbon_graph_cache_jobs_enqueue',
+      reused: false,
+      data: normalizeWorkerJob(result.data),
+    },
+  };
+}

--- a/supabase/functions/app_national_carbon_graph_cache_jobs/index.ts
+++ b/supabase/functions/app_national_carbon_graph_cache_jobs/index.ts
@@ -1,0 +1,27 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+
+import {
+  createCommandHandler,
+  type CommandHandlerOptions,
+} from '../_shared/command_runtime/command.ts';
+import {
+  executeNationalCarbonGraphCacheJobCommand,
+  parseNationalCarbonGraphCacheJobCommand,
+  type NationalCarbonGraphCacheJobRequest,
+} from '../_shared/commands/national_carbon_graph_cache_jobs.ts';
+
+export function createAppNationalCarbonGraphCacheJobsHandler(
+  overrides: Partial<CommandHandlerOptions<NationalCarbonGraphCacheJobRequest>> = {},
+) {
+  return createCommandHandler<NationalCarbonGraphCacheJobRequest>({
+    parse: parseNationalCarbonGraphCacheJobCommand,
+    execute: executeNationalCarbonGraphCacheJobCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppNationalCarbonGraphCacheJobs = createAppNationalCarbonGraphCacheJobsHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppNationalCarbonGraphCacheJobs);
+}

--- a/test/national_carbon_graph_cache_jobs_test.ts
+++ b/test/national_carbon_graph_cache_jobs_test.ts
@@ -1,0 +1,335 @@
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+
+import type { ActorContext } from '../supabase/functions/_shared/command_runtime/actor_context.ts';
+import {
+  executeNationalCarbonGraphCacheJobCommand,
+  NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+  NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+  parseNationalCarbonGraphCacheJobCommand,
+} from '../supabase/functions/_shared/commands/national_carbon_graph_cache_jobs.ts';
+
+const TEST_JOB_ID = '66666666-6666-4666-8666-666666666666';
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+const SYSTEM_TEAM_ID = '00000000-0000-0000-0000-000000000000';
+
+class FakeNationalCarbonGraphCacheSupabase {
+  rpcCalls: Array<{ fn: string; args: Record<string, unknown> }> = [];
+  roleQueries: Array<{ table: string }> = [];
+
+  constructor(
+    private readonly responses: Array<{ data: unknown; error: unknown }>,
+    private readonly systemManager = true,
+  ) {}
+
+  from(table: string) {
+    this.roleQueries.push({ table });
+    const state: Record<string, unknown> = { table };
+    return {
+      select: (columns: string) => {
+        state.columns = columns;
+        return {
+          eq: (column: string, value: unknown) => {
+            state[column] = value;
+            return {
+              eq: (nextColumn: string, nextValue: unknown) => {
+                state[nextColumn] = nextValue;
+                return {
+                  in: (inColumn: string, values: unknown[]) => {
+                    state[inColumn] = values;
+                    return {
+                      limit: (limit: number) => {
+                        state.limit = limit;
+                        return {
+                          maybeSingle: () =>
+                            Promise.resolve({
+                              data: this.systemManager ? { user_id: TEST_USER_ID } : null,
+                              error: null,
+                            }),
+                        };
+                      },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  rpc(fn: string, args: Record<string, unknown>) {
+    this.rpcCalls.push({ fn, args: structuredClone(args) });
+    const response = this.responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected RPC call: ${fn}`);
+    }
+    return Promise.resolve(response);
+  }
+}
+
+function actor(): ActorContext {
+  return {
+    userId: TEST_USER_ID,
+    accessToken: 'access-token',
+    supabase: {} as SupabaseClient,
+  };
+}
+
+function readEnv(name: string): string | undefined {
+  const values: Record<string, string> = {
+    NATIONAL_CARBON_GRAPH_CACHE_ENVIRONMENT: 'dev',
+    NATIONAL_CARBON_GRAPH_CACHE_PREFIX: 'national-carbon/process-flow-graph/v1',
+    NATIONAL_CARBON_GRAPH_CACHE_BUCKET: 'cache-bucket',
+  };
+  return values[name];
+}
+
+Deno.test('parseNationalCarbonGraphCacheJobCommand accepts enqueue action only', () => {
+  const result = parseNationalCarbonGraphCacheJobCommand({ action: 'enqueue' });
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.value, { action: 'enqueue' });
+  }
+});
+
+Deno.test(
+  'executeNationalCarbonGraphCacheJobCommand requires system-manager permissions',
+  async () => {
+    const supabase = new FakeNationalCarbonGraphCacheSupabase([], false);
+
+    const result = await executeNationalCarbonGraphCacheJobCommand(
+      { action: 'enqueue' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+    );
+
+    assertEquals(result, {
+      ok: false,
+      code: 'SYSTEM_MANAGER_REQUIRED',
+      status: 403,
+      message: 'System-manager permissions are required to manage national carbon graph cache jobs',
+    });
+    assertEquals(supabase.rpcCalls, []);
+  },
+);
+
+Deno.test(
+  'executeNationalCarbonGraphCacheJobCommand enqueues fixed maintenance worker job',
+  async () => {
+    const supabase = new FakeNationalCarbonGraphCacheSupabase([
+      {
+        data: {
+          ok: true,
+          data: {
+            id: TEST_JOB_ID,
+            jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+            subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+            status: 'queued',
+          },
+        },
+        error: null,
+      },
+    ]);
+
+    const result = await executeNationalCarbonGraphCacheJobCommand(
+      { action: 'enqueue' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+      {
+        now: () => new Date('2026-06-12T09:45:37.000Z'),
+        readEnv,
+      },
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.body, {
+        ok: true,
+        command: 'national_carbon_graph_cache_jobs_enqueue',
+        reused: false,
+        data: {
+          id: TEST_JOB_ID,
+          jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+          subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+          status: 'queued',
+        },
+      });
+    }
+    assertEquals(supabase.roleQueries, [{ table: 'roles' }]);
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: 'worker_enqueue_job',
+        args: {
+          p_job_kind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+          p_payload_json: {
+            environment: 'dev',
+            execute: true,
+            cachePrefix: 'national-carbon/process-flow-graph/v1',
+            cacheBucket: 'cache-bucket',
+          },
+          p_payload_schema_version: 'national_carbon.process_flow_graph_cache_build.request.v1',
+          p_subject_type: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+          p_subject_id: null,
+          p_subject_version: 'dev',
+          p_requested_by: TEST_USER_ID,
+          p_requester_type: 'operator',
+          p_team_id: null,
+          p_idempotency_key:
+            'national_carbon.process_flow_graph_cache_build:dev:execute:11111111-1111-4111-8111-111111111111:2026-06-12T09:45',
+          p_request_hash: null,
+          p_concurrency_key: 'national_carbon.process_flow_graph_cache_build:dev:execute',
+          p_priority: 0,
+          p_queue_key: 'dev',
+          p_run_after: null,
+          p_visibility: 'operator',
+          p_max_attempts: 1,
+          p_timeout_at: null,
+          p_payload_ref: null,
+          p_parent_job_id: null,
+          p_root_job_id: null,
+        },
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  'executeNationalCarbonGraphCacheJobCommand returns active job on concurrency conflict',
+  async () => {
+    const supabase = new FakeNationalCarbonGraphCacheSupabase([
+      {
+        data: {
+          ok: false,
+          code: 'WORKER_JOB_CONCURRENCY_CONFLICT',
+          status: 409,
+          message: 'A conflicting worker job is already active',
+          details: {
+            id: TEST_JOB_ID,
+            jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+            subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+            status: 'running',
+          },
+        },
+        error: null,
+      },
+    ]);
+
+    const result = await executeNationalCarbonGraphCacheJobCommand(
+      { action: 'enqueue' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+      {
+        now: () => new Date('2026-06-12T09:45:37.000Z'),
+        readEnv,
+      },
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.body, {
+        ok: true,
+        command: 'national_carbon_graph_cache_jobs_enqueue',
+        reused: true,
+        data: {
+          id: TEST_JOB_ID,
+          jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+          subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+          status: 'running',
+        },
+      });
+    }
+  },
+);
+
+Deno.test('executeNationalCarbonGraphCacheJobCommand reads only graph cache jobs', async () => {
+  const supabase = new FakeNationalCarbonGraphCacheSupabase([
+    {
+      data: {
+        ok: true,
+        data: {
+          id: TEST_JOB_ID,
+          jobKind: 'review_submit.gate',
+          subjectType: 'processes',
+          status: 'completed',
+        },
+      },
+      error: null,
+    },
+  ]);
+
+  const result = await executeNationalCarbonGraphCacheJobCommand(
+    { action: 'read', jobId: TEST_JOB_ID },
+    actor(),
+    supabase as unknown as SupabaseClient,
+  );
+
+  assertEquals(result, {
+    ok: false,
+    code: 'NATIONAL_CARBON_GRAPH_CACHE_JOB_NOT_FOUND',
+    status: 404,
+    message: 'National carbon graph cache job not found',
+  });
+});
+
+Deno.test(
+  'executeNationalCarbonGraphCacheJobCommand lists latest operator graph cache jobs',
+  async () => {
+    const supabase = new FakeNationalCarbonGraphCacheSupabase([
+      {
+        data: {
+          ok: true,
+          data: [
+            {
+              id: TEST_JOB_ID,
+              jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+              subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+              status: 'completed',
+            },
+          ],
+        },
+        error: null,
+      },
+    ]);
+
+    const result = await executeNationalCarbonGraphCacheJobCommand(
+      { action: 'read_latest', limit: 1 },
+      actor(),
+      supabase as unknown as SupabaseClient,
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.body, {
+        ok: true,
+        command: 'national_carbon_graph_cache_jobs_read_latest',
+        data: [
+          {
+            id: TEST_JOB_ID,
+            jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+            subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+            status: 'completed',
+          },
+        ],
+      });
+    }
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: 'worker_list_jobs',
+        args: {
+          p_requested_by: null,
+          p_subject_type: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+          p_subject_id: null,
+          p_statuses: null,
+          p_visibility: 'operator',
+          p_limit: 1,
+          p_include_internal: false,
+        },
+      },
+    ]);
+  },
+);
+
+assertEquals(SYSTEM_TEAM_ID, '00000000-0000-0000-0000-000000000000');


### PR DESCRIPTION
Closes linancn/tiangong-lca-edge-functions#186

## Summary
- 新增 app_national_carbon_graph_cache_jobs Edge Function，提供 enqueue、read、read_latest 三个动作。
- 服务端固定 national_carbon.process_flow_graph_cache_build job kind、subjectType、operator visibility 与 concurrency/idempotency 约束。
- 新增命令层单元测试，覆盖鉴权拒绝、enqueue 参数、并发复用、read 过滤和 latest 查询。

## Key Decisions
- Edge Function 使用 service role 查询 system team roles 判断 owner/admin/member，避免依赖未对 public 暴露的 DB manager RPC。
- 并发冲突返回 reused=true 和现有 active job，便于前端恢复轮询而不是重复触发 worker。

## Validation
- npm run lint 通过。
- npx -y deno check --config supabase/functions/deno.json supabase/functions/_shared/commands/national_carbon_graph_cache_jobs.ts supabase/functions/app_national_carbon_graph_cache_jobs/index.ts test/national_carbon_graph_cache_jobs_test.ts 通过。
- npx -y deno test --config supabase/functions/deno.json test/national_carbon_graph_cache_jobs_test.ts 通过，6 个测试通过。
- npm run check 已覆盖到新函数，随后在既有文件 supabase/functions/embedding_ft/index.ts:498 的 TS7006 implicit any 处失败；该失败与本 PR 变更无关。

## Risks / Rollback
- 中等：新增 operator-only 触发入口；风险主要在部署环境变量与数据库 job kind migration 未同步时返回 enqueue 失败。

## Follow-ups
- 依赖 database-engine#213 合并并部署 job kind migration 后，前端按钮才能成功 enqueue。

## Workspace Integration
- 合并到 edge-functions dev 后仍需按 workspace release/promotion 规则处理 root submodule integration。