### PR TITLE
feat: expose national carbon graph cache objects

### DIFF
--- a/supabase/functions/_shared/commands/national_carbon_graph_cache_objects.ts
+++ b/supabase/functions/_shared/commands/national_carbon_graph_cache_objects.ts
@@ -1,0 +1,391 @@
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+import { z } from 'zod';
+
+import type { ActorContext } from '../command_runtime/actor_context.ts';
+import type { CommandExecutionResult, CommandParseResult } from '../command_runtime/command.ts';
+import { createSupabaseServiceClient } from '../supabase_client.ts';
+
+const DEFAULT_CACHE_BUCKET = 'lca_results';
+const DEFAULT_CACHE_PREFIX = 'national-carbon/process-flow-graph/v1';
+const DEFAULT_SIGNED_URL_EXPIRES_IN_SECONDS = 3600;
+const MAX_SIGNED_URL_EXPIRES_IN_SECONDS = 86400;
+const ACTIVE_MANIFEST_SCHEMA_VERSION = 'process_flow_graph_manifest_v1';
+const BUILD_SCHEMA_VERSION = 'process_flow_graph_v2';
+
+type EnvReader = (name: string) => string | undefined;
+
+type CommandFailureResult = Extract<CommandExecutionResult, { ok: false }>;
+
+type StorageDownloadResult = {
+  data: { text(): Promise<string> } | null;
+  error: { message?: string; code?: string; statusCode?: string | number } | null;
+};
+
+type SignedUrlResult = {
+  data: { signedUrl?: string } | null;
+  error: { message?: string; code?: string; statusCode?: string | number } | null;
+};
+
+type StorageBucketClient = {
+  download(path: string): Promise<StorageDownloadResult>;
+  createSignedUrl(path: string, expiresIn: number): Promise<SignedUrlResult>;
+};
+
+type StorageClient = Pick<SupabaseClient, 'storage'> & {
+  storage: {
+    from(bucket: string): StorageBucketClient;
+  };
+};
+
+type ActiveManifest = {
+  schemaVersion: string;
+  activeBuildId: string;
+  buildManifestPath: string;
+  generatedAt?: string;
+};
+
+type BuildManifestFile = {
+  path: string;
+  byteSize?: number;
+  sha256?: string;
+  contentType?: string;
+  signedUrl?: string;
+};
+
+type BuildManifest = {
+  schemaVersion: string;
+  buildId: string;
+  files: Record<string, BuildManifestFile>;
+  [key: string]: unknown;
+};
+
+type GraphCacheObjectsConfig = {
+  bucket: string;
+  prefix: string;
+  signedUrlExpiresIn: number;
+};
+
+const requestSchema = z
+  .object({
+    action: z.literal('read_manifest_bundle'),
+  })
+  .strict();
+
+const activeManifestSchema = z
+  .object({
+    schemaVersion: z.literal(ACTIVE_MANIFEST_SCHEMA_VERSION),
+    activeBuildId: z.string().trim().min(1),
+    buildManifestPath: z.string().trim().min(1),
+    generatedAt: z.string().optional(),
+  })
+  .passthrough();
+
+const buildManifestFileSchema = z
+  .object({
+    path: z.string().trim().min(1),
+    byteSize: z.number().optional(),
+    sha256: z.string().optional(),
+    contentType: z.string().optional(),
+  })
+  .passthrough();
+
+const buildManifestSchema = z
+  .object({
+    schemaVersion: z.literal(BUILD_SCHEMA_VERSION),
+    buildId: z.string().trim().min(1),
+    files: z.record(z.string(), buildManifestFileSchema),
+  })
+  .passthrough();
+
+export type NationalCarbonGraphCacheObjectsRequest = z.infer<typeof requestSchema>;
+
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    const value = Deno.env.get(name);
+    return value && value.trim().length > 0 ? value.trim() : undefined;
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function invalidPayload<T>(message: string, error: z.ZodError): CommandParseResult<T> {
+  return {
+    ok: false,
+    message,
+    details: error.flatten(),
+  };
+}
+
+export function parseNationalCarbonGraphCacheObjectsCommand(
+  body: unknown,
+): CommandParseResult<NationalCarbonGraphCacheObjectsRequest> {
+  const parsed = requestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload('Invalid national carbon graph cache object payload', parsed.error);
+  }
+
+  return {
+    ok: true,
+    value: parsed.data,
+  };
+}
+
+function normalizePathPart(value: string): string {
+  return value.trim().replace(/^\/+|\/+$/g, '');
+}
+
+function hasUnsafePathSegment(path: string): boolean {
+  return path
+    .split('/')
+    .filter(Boolean)
+    .some((segment) => segment === '.' || segment === '..');
+}
+
+function joinStoragePath(...parts: string[]): string {
+  const path = parts.map(normalizePathPart).filter(Boolean).join('/');
+  if (!path || hasUnsafePathSegment(path)) {
+    throw new Error('Invalid national carbon graph cache object path');
+  }
+  return path;
+}
+
+function dirname(path: string): string {
+  const normalized = normalizePathPart(path);
+  const index = normalized.lastIndexOf('/');
+  return index < 0 ? '' : normalized.slice(0, index);
+}
+
+function readPositiveInt(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function readConfig(readEnv: EnvReader): GraphCacheObjectsConfig {
+  const bucket =
+    readEnv('NATIONAL_CARBON_GRAPH_CACHE_BUCKET') ??
+    readEnv('PROCESS_FLOW_GRAPH_CACHE_BUCKET') ??
+    DEFAULT_CACHE_BUCKET;
+  const prefix =
+    readEnv('NATIONAL_CARBON_GRAPH_CACHE_PREFIX') ??
+    readEnv('PROCESS_FLOW_GRAPH_CACHE_PREFIX') ??
+    DEFAULT_CACHE_PREFIX;
+  const signedUrlExpiresIn = Math.min(
+    readPositiveInt(readEnv('NATIONAL_CARBON_GRAPH_CACHE_SIGNED_URL_EXPIRES_IN')) ??
+      DEFAULT_SIGNED_URL_EXPIRES_IN_SECONDS,
+    MAX_SIGNED_URL_EXPIRES_IN_SECONDS,
+  );
+
+  return {
+    bucket,
+    prefix: normalizePathPart(prefix),
+    signedUrlExpiresIn,
+  };
+}
+
+function storageFailure(
+  code: string,
+  message: string,
+  status: number,
+  details?: unknown,
+): CommandFailureResult {
+  return {
+    ok: false,
+    code,
+    message,
+    status,
+    details,
+  };
+}
+
+async function downloadJson(
+  storage: StorageBucketClient,
+  objectPath: string,
+): Promise<{ ok: true; data: unknown } | CommandFailureResult> {
+  const result = await storage.download(objectPath);
+  if (result.error) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_OBJECT_NOT_FOUND',
+      `Unable to read national carbon graph cache object: ${objectPath}`,
+      404,
+      result.error,
+    );
+  }
+
+  try {
+    return {
+      ok: true,
+      data: JSON.parse(await result.data!.text()),
+    };
+  } catch (error) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_OBJECT_INVALID_JSON',
+      `National carbon graph cache object is not valid JSON: ${objectPath}`,
+      502,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function validateActiveManifest(payload: unknown): ActiveManifest | CommandFailureResult {
+  const parsed = activeManifestSchema.safeParse(payload);
+  if (!parsed.success) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_ACTIVE_MANIFEST_INVALID',
+      'National carbon graph cache active manifest is invalid',
+      502,
+      parsed.error.flatten(),
+    );
+  }
+
+  if (hasUnsafePathSegment(parsed.data.buildManifestPath)) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_ACTIVE_MANIFEST_INVALID',
+      'National carbon graph cache build manifest path is unsafe',
+      502,
+    );
+  }
+
+  return parsed.data;
+}
+
+function validateBuildManifest(payload: unknown): BuildManifest | CommandFailureResult {
+  const parsed = buildManifestSchema.safeParse(payload);
+  if (!parsed.success) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_BUILD_MANIFEST_INVALID',
+      'National carbon graph cache build manifest is invalid',
+      502,
+      parsed.error.flatten(),
+    );
+  }
+
+  for (const [key, file] of Object.entries(parsed.data.files)) {
+    if (hasUnsafePathSegment(file.path)) {
+      return storageFailure(
+        'NATIONAL_CARBON_GRAPH_CACHE_BUILD_MANIFEST_INVALID',
+        `National carbon graph cache file path is unsafe: ${key}`,
+        502,
+      );
+    }
+  }
+
+  return parsed.data;
+}
+
+async function attachSignedUrls(
+  storage: StorageBucketClient,
+  config: GraphCacheObjectsConfig,
+  activeManifest: ActiveManifest,
+  buildManifest: BuildManifest,
+): Promise<BuildManifest | CommandFailureResult> {
+  const buildRootPath = dirname(activeManifest.buildManifestPath);
+  const files: Record<string, BuildManifestFile> = {};
+
+  for (const [key, file] of Object.entries(buildManifest.files)) {
+    const objectPath = joinStoragePath(config.prefix, buildRootPath, file.path);
+    const signed = await storage.createSignedUrl(objectPath, config.signedUrlExpiresIn);
+    if (signed.error || !signed.data?.signedUrl) {
+      return storageFailure(
+        'NATIONAL_CARBON_GRAPH_CACHE_SIGNED_URL_FAILED',
+        `Unable to create signed URL for national carbon graph cache object: ${key}`,
+        502,
+        signed.error ?? { objectPath },
+      );
+    }
+
+    files[key] = {
+      ...file,
+      signedUrl: signed.data.signedUrl,
+    };
+  }
+
+  return {
+    ...buildManifest,
+    files,
+  };
+}
+
+function isCommandFailure(value: unknown): value is CommandFailureResult {
+  return Boolean(value && typeof value === 'object' && (value as { ok?: unknown }).ok === false);
+}
+
+export async function executeNationalCarbonGraphCacheObjectsCommand(
+  _request: NationalCarbonGraphCacheObjectsRequest,
+  _actor: ActorContext,
+  serviceClient: StorageClient = createSupabaseServiceClient() as StorageClient,
+  readEnv: EnvReader = defaultReadEnv,
+): Promise<CommandExecutionResult> {
+  const config = readConfig(readEnv);
+  let activeManifestPath: string;
+
+  try {
+    activeManifestPath = joinStoragePath(config.prefix, 'manifest.json');
+  } catch (error) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_CONFIG_INVALID',
+      error instanceof Error ? error.message : String(error),
+      500,
+    );
+  }
+
+  const storage = serviceClient.storage.from(config.bucket);
+  const activePayload = await downloadJson(storage, activeManifestPath);
+  if (!activePayload.ok) {
+    return activePayload;
+  }
+
+  const activeManifest = validateActiveManifest(activePayload.data);
+  if (isCommandFailure(activeManifest)) {
+    return activeManifest;
+  }
+
+  let buildManifestPath: string;
+  try {
+    buildManifestPath = joinStoragePath(config.prefix, activeManifest.buildManifestPath);
+  } catch (error) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_ACTIVE_MANIFEST_INVALID',
+      error instanceof Error ? error.message : String(error),
+      502,
+    );
+  }
+
+  const buildPayload = await downloadJson(storage, buildManifestPath);
+  if (!buildPayload.ok) {
+    return buildPayload;
+  }
+
+  const buildManifest = validateBuildManifest(buildPayload.data);
+  if (isCommandFailure(buildManifest)) {
+    return buildManifest;
+  }
+
+  const signedBuildManifest = await attachSignedUrls(
+    storage,
+    config,
+    activeManifest,
+    buildManifest,
+  );
+  if (isCommandFailure(signedBuildManifest)) {
+    return signedBuildManifest;
+  }
+
+  return {
+    ok: true,
+    body: {
+      ok: true,
+      command: 'national_carbon_graph_cache_objects_read_manifest_bundle',
+      data: {
+        activeManifest,
+        buildManifest: signedBuildManifest,
+        bucket: config.bucket,
+        prefix: config.prefix,
+        expiresIn: config.signedUrlExpiresIn,
+      },
+    },
+  };
+}

--- a/supabase/functions/app_national_carbon_graph_cache_objects/index.ts
+++ b/supabase/functions/app_national_carbon_graph_cache_objects/index.ts
@@ -1,0 +1,28 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+
+import {
+  createCommandHandler,
+  type CommandHandlerOptions,
+} from '../_shared/command_runtime/command.ts';
+import {
+  executeNationalCarbonGraphCacheObjectsCommand,
+  parseNationalCarbonGraphCacheObjectsCommand,
+  type NationalCarbonGraphCacheObjectsRequest,
+} from '../_shared/commands/national_carbon_graph_cache_objects.ts';
+
+export function createAppNationalCarbonGraphCacheObjectsHandler(
+  overrides: Partial<CommandHandlerOptions<NationalCarbonGraphCacheObjectsRequest>> = {},
+) {
+  return createCommandHandler<NationalCarbonGraphCacheObjectsRequest>({
+    parse: parseNationalCarbonGraphCacheObjectsCommand,
+    execute: executeNationalCarbonGraphCacheObjectsCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppNationalCarbonGraphCacheObjects =
+  createAppNationalCarbonGraphCacheObjectsHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppNationalCarbonGraphCacheObjects);
+}

--- a/test/national_carbon_graph_cache_objects_test.ts
+++ b/test/national_carbon_graph_cache_objects_test.ts
@@ -1,0 +1,278 @@
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+
+import type { ActorContext } from '../supabase/functions/_shared/command_runtime/actor_context.ts';
+import {
+  executeNationalCarbonGraphCacheObjectsCommand,
+  parseNationalCarbonGraphCacheObjectsCommand,
+} from '../supabase/functions/_shared/commands/national_carbon_graph_cache_objects.ts';
+
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+
+type StoredObject = {
+  body?: unknown;
+  error?: { message: string; code?: string };
+};
+
+class FakeBlob {
+  constructor(private readonly body: unknown) {}
+
+  text() {
+    return Promise.resolve(typeof this.body === 'string' ? this.body : JSON.stringify(this.body));
+  }
+}
+
+class FakeGraphCacheStorageBucket {
+  downloads: string[] = [];
+  signedUrls: Array<{ objectPath: string; expiresIn: number }> = [];
+  signedErrors = new Map<string, { message: string; code?: string }>();
+
+  constructor(private readonly objects: Map<string, StoredObject>) {}
+
+  async download(objectPath: string) {
+    this.downloads.push(objectPath);
+    const object = this.objects.get(objectPath);
+    if (!object || object.error) {
+      return {
+        data: null,
+        error: object?.error ?? { message: 'Object not found', code: '404' },
+      };
+    }
+
+    return {
+      data: new FakeBlob(object.body),
+      error: null,
+    };
+  }
+
+  async createSignedUrl(objectPath: string, expiresIn: number) {
+    this.signedUrls.push({ objectPath, expiresIn });
+    const error = this.signedErrors.get(objectPath);
+    if (error) {
+      return { data: null, error };
+    }
+
+    return {
+      data: {
+        signedUrl: `https://signed.example/${encodeURIComponent(objectPath)}?expires=${expiresIn}`,
+      },
+      error: null,
+    };
+  }
+}
+
+class FakeGraphCacheSupabase {
+  buckets: string[] = [];
+
+  constructor(readonly bucket: FakeGraphCacheStorageBucket) {}
+
+  storage = {
+    from: (bucket: string) => {
+      this.buckets.push(bucket);
+      return this.bucket;
+    },
+  };
+}
+
+function actor(): ActorContext {
+  return {
+    userId: TEST_USER_ID,
+    accessToken: 'access-token',
+    supabase: {} as SupabaseClient,
+  };
+}
+
+function makeObjects(overrides: Record<string, StoredObject> = {}): Map<string, StoredObject> {
+  const activeManifestPath = 'national-carbon/process-flow-graph/v1/manifest.json';
+  const buildManifestPath =
+    'national-carbon/process-flow-graph/v1/builds/process-flow-graph-test/manifest.json';
+
+  return new Map<string, StoredObject>([
+    [
+      activeManifestPath,
+      {
+        body: {
+          schemaVersion: 'process_flow_graph_manifest_v1',
+          activeBuildId: 'process-flow-graph-test',
+          buildManifestPath: 'builds/process-flow-graph-test/manifest.json',
+          generatedAt: '2026-06-12T00:00:00Z',
+        },
+      },
+    ],
+    [
+      buildManifestPath,
+      {
+        body: {
+          schemaVersion: 'process_flow_graph_v2',
+          buildId: 'process-flow-graph-test',
+          files: {
+            nodes: {
+              path: 'graph/nodes.json.gz',
+              byteSize: 12,
+              sha256: 'abc',
+              contentType: 'application/gzip',
+            },
+            geoMapWorldView: {
+              path: 'geo-map/world/view.json.gz',
+              byteSize: 34,
+              sha256: 'def',
+              contentType: 'application/gzip',
+            },
+          },
+        },
+      },
+    ],
+    ...Object.entries(overrides),
+  ]);
+}
+
+function env(values: Record<string, string | undefined>) {
+  return (name: string) => values[name];
+}
+
+Deno.test('parseNationalCarbonGraphCacheObjectsCommand accepts read manifest bundle action', () => {
+  const result = parseNationalCarbonGraphCacheObjectsCommand({
+    action: 'read_manifest_bundle',
+  });
+
+  assertEquals(result.ok, true);
+});
+
+Deno.test('parseNationalCarbonGraphCacheObjectsCommand rejects unknown actions', () => {
+  const result = parseNationalCarbonGraphCacheObjectsCommand({
+    action: 'read_anything',
+  });
+
+  assertEquals(result.ok, false);
+});
+
+Deno.test(
+  'executeNationalCarbonGraphCacheObjectsCommand returns manifest bundle with signed URLs',
+  async () => {
+    const bucket = new FakeGraphCacheStorageBucket(makeObjects());
+    const supabase = new FakeGraphCacheSupabase(bucket);
+
+    const result = await executeNationalCarbonGraphCacheObjectsCommand(
+      { action: 'read_manifest_bundle' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+      env({
+        NATIONAL_CARBON_GRAPH_CACHE_BUCKET: 'lca_results',
+        NATIONAL_CARBON_GRAPH_CACHE_PREFIX: 'national-carbon/process-flow-graph/v1',
+        NATIONAL_CARBON_GRAPH_CACHE_SIGNED_URL_EXPIRES_IN: '120',
+      }),
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      const body = result.body as {
+        data: {
+          bucket: string;
+          prefix: string;
+          expiresIn: number;
+          activeManifest: { activeBuildId: string };
+          buildManifest: { files: Record<string, { signedUrl?: string }> };
+        };
+      };
+      assertEquals(body.data.bucket, 'lca_results');
+      assertEquals(body.data.prefix, 'national-carbon/process-flow-graph/v1');
+      assertEquals(body.data.expiresIn, 120);
+      assertEquals(body.data.activeManifest.activeBuildId, 'process-flow-graph-test');
+      assertEquals(
+        body.data.buildManifest.files.nodes.signedUrl,
+        'https://signed.example/national-carbon%2Fprocess-flow-graph%2Fv1%2Fbuilds%2Fprocess-flow-graph-test%2Fgraph%2Fnodes.json.gz?expires=120',
+      );
+    }
+
+    assertEquals(supabase.buckets, ['lca_results']);
+    assertEquals(bucket.downloads, [
+      'national-carbon/process-flow-graph/v1/manifest.json',
+      'national-carbon/process-flow-graph/v1/builds/process-flow-graph-test/manifest.json',
+    ]);
+    assertEquals(bucket.signedUrls, [
+      {
+        objectPath:
+          'national-carbon/process-flow-graph/v1/builds/process-flow-graph-test/graph/nodes.json.gz',
+        expiresIn: 120,
+      },
+      {
+        objectPath:
+          'national-carbon/process-flow-graph/v1/builds/process-flow-graph-test/geo-map/world/view.json.gz',
+        expiresIn: 120,
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  'executeNationalCarbonGraphCacheObjectsCommand rejects unsafe build manifest paths',
+  async () => {
+    const bucket = new FakeGraphCacheStorageBucket(
+      makeObjects({
+        'national-carbon/process-flow-graph/v1/manifest.json': {
+          body: {
+            schemaVersion: 'process_flow_graph_manifest_v1',
+            activeBuildId: 'process-flow-graph-test',
+            buildManifestPath: '../private/manifest.json',
+          },
+        },
+      }),
+    );
+    const supabase = new FakeGraphCacheSupabase(bucket);
+
+    const result = await executeNationalCarbonGraphCacheObjectsCommand(
+      { action: 'read_manifest_bundle' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+      env({}),
+    );
+
+    assertEquals(result.ok, false);
+    if (!result.ok) {
+      assertEquals(result.code, 'NATIONAL_CARBON_GRAPH_CACHE_ACTIVE_MANIFEST_INVALID');
+    }
+  },
+);
+
+Deno.test(
+  'executeNationalCarbonGraphCacheObjectsCommand reports missing active manifest',
+  async () => {
+    const bucket = new FakeGraphCacheStorageBucket(new Map());
+    const supabase = new FakeGraphCacheSupabase(bucket);
+
+    const result = await executeNationalCarbonGraphCacheObjectsCommand(
+      { action: 'read_manifest_bundle' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+      env({}),
+    );
+
+    assertEquals(result.ok, false);
+    if (!result.ok) {
+      assertEquals(result.status, 404);
+      assertEquals(result.code, 'NATIONAL_CARBON_GRAPH_CACHE_OBJECT_NOT_FOUND');
+    }
+  },
+);
+
+Deno.test('executeNationalCarbonGraphCacheObjectsCommand reports signed URL failures', async () => {
+  const bucket = new FakeGraphCacheStorageBucket(makeObjects());
+  bucket.signedErrors.set(
+    'national-carbon/process-flow-graph/v1/builds/process-flow-graph-test/graph/nodes.json.gz',
+    { message: 'sign failed', code: 'SIGN_FAILED' },
+  );
+  const supabase = new FakeGraphCacheSupabase(bucket);
+
+  const result = await executeNationalCarbonGraphCacheObjectsCommand(
+    { action: 'read_manifest_bundle' },
+    actor(),
+    supabase as unknown as SupabaseClient,
+    env({}),
+  );
+
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.code, 'NATIONAL_CARBON_GRAPH_CACHE_SIGNED_URL_FAILED');
+    assertEquals(result.status, 502);
+  }
+});


### PR DESCRIPTION
Closes #188

## Summary
- Adds app_national_carbon_graph_cache_objects for authenticated reads of the active national-carbon process-flow graph cache manifest bundle.
- Downloads private lca_results objects with the service client and attaches signed URLs to build manifest file entries for browser consumption.

## Key Decisions
- Uses lca_results/national-carbon/process-flow-graph/v1 defaults with env overrides for bucket, prefix, and signed URL TTL.
- Keeps gateway --no-verify-jwt compatible while enforcing runtime actor authentication through the shared command handler.

## Validation
- npm run lint
- npx -y deno check --config supabase/functions/deno.json supabase/functions/_shared/commands/national_carbon_graph_cache_objects.ts supabase/functions/app_national_carbon_graph_cache_objects/index.ts test/national_carbon_graph_cache_objects_test.ts
- npx -y deno test --config supabase/functions/deno.json test/national_carbon_graph_cache_objects_test.ts
- npx --yes supabase@2.85.0 functions deploy app_national_carbon_graph_cache_objects --project-ref fotofiyqnuyvgtotswie --no-verify-jwt --use-api --import-map supabase/functions/deno.json
- curl anonymous POST against dev returned 401 AUTH_REQUIRED from the deployed function

## Risks / Rollback
- Full npm run check currently reaches the new function, then fails on pre-existing supabase/functions/embedding_ft/index.ts TS7006 implicit-any baseline.

## Follow-ups
- Frontend consumption lands in linancn/tiangong-lca-next#515.

## Workspace Integration
- Root workspace integration remains pending after merge/promote according to M2 policy.