### PR TITLE
Promote dev to main for national carbon graph cache APIs

### DIFF
--- a/supabase/functions/_shared/commands/national_carbon_graph_cache_jobs.ts
+++ b/supabase/functions/_shared/commands/national_carbon_graph_cache_jobs.ts
@@ -1,0 +1,326 @@
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+import { z } from 'zod';
+
+import type { ActorContext } from '../command_runtime/actor_context.ts';
+import type { CommandExecutionResult, CommandParseResult } from '../command_runtime/command.ts';
+import {
+  callWorkerJobEnqueueRpc,
+  callWorkerJobListRpc,
+  callWorkerJobReadRpc,
+  type WorkerJobRpcResult,
+} from '../db_rpc/worker_jobs.ts';
+import { createSupabaseServiceClient } from '../supabase_client.ts';
+import type { WorkerJobResult, WorkerJobStatus } from './dataset/types.ts';
+
+export const NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND =
+  'national_carbon.process_flow_graph_cache_build';
+export const NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE = 'national_carbon_process_flow_graph_cache';
+
+const SYSTEM_TEAM_ID = '00000000-0000-0000-0000-000000000000';
+const SYSTEM_MANAGER_ROLES = ['owner', 'admin', 'member'];
+const DEFAULT_JOB_ENVIRONMENT = 'main';
+
+const uuidSchema = z.string().uuid();
+const workerJobStatuses = [
+  'queued',
+  'running',
+  'waiting',
+  'completed',
+  'blocked',
+  'stale',
+  'failed',
+  'cancelled',
+] as const;
+
+const enqueueSchema = z
+  .object({
+    action: z.literal('enqueue'),
+  })
+  .strict();
+
+const readSchema = z
+  .object({
+    action: z.literal('read'),
+    jobId: uuidSchema,
+  })
+  .strict();
+
+const readLatestSchema = z
+  .object({
+    action: z.literal('read_latest'),
+    statuses: z.array(z.enum(workerJobStatuses)).optional(),
+    limit: z.number().int().min(1).max(20).optional(),
+  })
+  .strict();
+
+export const nationalCarbonGraphCacheJobRequestSchema = z.union([
+  enqueueSchema,
+  readSchema,
+  readLatestSchema,
+]);
+
+export type NationalCarbonGraphCacheJobRequest = z.infer<
+  typeof nationalCarbonGraphCacheJobRequestSchema
+>;
+
+export type EnvReader = (name: string) => string | undefined;
+
+export type NationalCarbonGraphCacheJobExecutionOptions = {
+  now?: () => Date;
+  readEnv?: EnvReader;
+};
+
+function invalidPayload<T>(message: string, error: z.ZodError): CommandParseResult<T> {
+  return {
+    ok: false,
+    message,
+    details: error.flatten(),
+  };
+}
+
+export function parseNationalCarbonGraphCacheJobCommand(
+  body: unknown,
+): CommandParseResult<NationalCarbonGraphCacheJobRequest> {
+  const parsed = nationalCarbonGraphCacheJobRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload('Invalid national carbon graph cache job payload', parsed.error);
+  }
+
+  return {
+    ok: true,
+    value: parsed.data,
+  };
+}
+
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    const value = Deno.env.get(name);
+    return value && value.trim().length > 0 ? value.trim() : undefined;
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function readJobEnvironment(readEnv: EnvReader = defaultReadEnv): string {
+  return (
+    readEnv('NATIONAL_CARBON_GRAPH_CACHE_ENVIRONMENT') ??
+    readEnv('LCA_WORKER_ENVIRONMENT') ??
+    readEnv('APP_ENV') ??
+    DEFAULT_JOB_ENVIRONMENT
+  );
+}
+
+function buildJobPayload(readEnv: EnvReader, environment: string): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    environment,
+    execute: true,
+  };
+
+  const cachePrefix = readEnv('NATIONAL_CARBON_GRAPH_CACHE_PREFIX');
+  if (cachePrefix) {
+    payload.cachePrefix = cachePrefix;
+  }
+
+  const cacheBucket = readEnv('NATIONAL_CARBON_GRAPH_CACHE_BUCKET');
+  if (cacheBucket) {
+    payload.cacheBucket = cacheBucket;
+  }
+
+  return payload;
+}
+
+function isWorkerJobStatus(value: unknown): value is WorkerJobStatus {
+  return workerJobStatuses.some((status) => status === value);
+}
+
+function normalizeWorkerJob(data: unknown): WorkerJobResult {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return {
+      status: 'failed',
+      errorCode: 'invalid_worker_job_rpc_result',
+      errorMessage: 'Worker job RPC returned an invalid response payload.',
+    };
+  }
+
+  const candidate = data as Record<string, unknown>;
+  return {
+    ...candidate,
+    status: isWorkerJobStatus(candidate.status) ? candidate.status : 'failed',
+  } as WorkerJobResult;
+}
+
+function normalizeWorkerJobList(data: unknown): WorkerJobResult[] {
+  return Array.isArray(data) ? data.map(normalizeWorkerJob) : [];
+}
+
+function isNationalCarbonGraphCacheJob(job: WorkerJobResult): boolean {
+  return (
+    job.jobKind === NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND &&
+    job.subjectType === NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE
+  );
+}
+
+async function ensureSystemManager(
+  actor: ActorContext,
+  serviceClient: SupabaseClient,
+): Promise<CommandExecutionResult | null> {
+  const { data, error } = await serviceClient
+    .from('roles')
+    .select('user_id')
+    .eq('user_id', actor.userId)
+    .eq('team_id', SYSTEM_TEAM_ID)
+    .in('role', SYSTEM_MANAGER_ROLES)
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    return {
+      ok: false,
+      code: 'SYSTEM_MANAGER_CHECK_FAILED',
+      status: 502,
+      message: 'Unable to verify system-manager permissions',
+      details: error,
+    };
+  }
+
+  if (!data) {
+    return {
+      ok: false,
+      code: 'SYSTEM_MANAGER_REQUIRED',
+      status: 403,
+      message: 'System-manager permissions are required to manage national carbon graph cache jobs',
+    };
+  }
+
+  return null;
+}
+
+function rpcFailure(result: WorkerJobRpcResult): CommandExecutionResult {
+  if (result.ok) {
+    return {
+      ok: false,
+      code: 'WORKER_JOB_RPC_RESULT_INVALID',
+      status: 502,
+      message: 'Worker job RPC result was unexpectedly successful',
+    };
+  }
+
+  return result;
+}
+
+function graphCacheJobNotFound(): CommandExecutionResult {
+  return {
+    ok: false,
+    code: 'NATIONAL_CARBON_GRAPH_CACHE_JOB_NOT_FOUND',
+    status: 404,
+    message: 'National carbon graph cache job not found',
+  };
+}
+
+export async function executeNationalCarbonGraphCacheJobCommand(
+  request: NationalCarbonGraphCacheJobRequest,
+  actor: ActorContext,
+  serviceClient: SupabaseClient = createSupabaseServiceClient(),
+  options: NationalCarbonGraphCacheJobExecutionOptions = {},
+): Promise<CommandExecutionResult> {
+  const aclFailure = await ensureSystemManager(actor, serviceClient);
+  if (aclFailure) {
+    return aclFailure;
+  }
+
+  if (request.action === 'read_latest') {
+    const result = await callWorkerJobListRpc(serviceClient, {
+      requestedBy: null,
+      subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+      subjectId: null,
+      statuses: request.statuses ?? null,
+      visibility: 'operator',
+      limit: request.limit ?? 5,
+      includeInternal: false,
+    });
+    if (!result.ok) {
+      return rpcFailure(result);
+    }
+
+    return {
+      ok: true,
+      body: {
+        ok: true,
+        command: 'national_carbon_graph_cache_jobs_read_latest',
+        data: normalizeWorkerJobList(result.data).filter(isNationalCarbonGraphCacheJob),
+      },
+    };
+  }
+
+  if (request.action === 'read') {
+    const result = await callWorkerJobReadRpc(serviceClient, {
+      jobId: request.jobId,
+      includeInternal: false,
+    });
+    if (!result.ok) {
+      return rpcFailure(result);
+    }
+
+    const job = normalizeWorkerJob(result.data);
+    if (!isNationalCarbonGraphCacheJob(job)) {
+      return graphCacheJobNotFound();
+    }
+
+    return {
+      ok: true,
+      body: {
+        ok: true,
+        command: 'national_carbon_graph_cache_jobs_read',
+        data: job,
+      },
+    };
+  }
+
+  const readEnv = options.readEnv ?? defaultReadEnv;
+  const environment = readJobEnvironment(readEnv);
+  const now = (options.now ?? (() => new Date()))();
+  const idempotencyWindow = now.toISOString().slice(0, 16);
+  const activeKey = `${NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND}:${environment}:execute`;
+  const result = await callWorkerJobEnqueueRpc(serviceClient, {
+    jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+    payload: buildJobPayload(readEnv, environment),
+    payloadSchemaVersion: 'national_carbon.process_flow_graph_cache_build.request.v1',
+    subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+    subjectId: null,
+    subjectVersion: environment,
+    requestedBy: actor.userId,
+    requesterType: 'operator',
+    idempotencyKey: `${activeKey}:${actor.userId}:${idempotencyWindow}`,
+    concurrencyKey: activeKey,
+    priority: 0,
+    queueKey: environment,
+    visibility: 'operator',
+    maxAttempts: 1,
+  });
+
+  if (!result.ok) {
+    if (result.code === 'WORKER_JOB_CONCURRENCY_CONFLICT' && result.details) {
+      return {
+        ok: true,
+        body: {
+          ok: true,
+          command: 'national_carbon_graph_cache_jobs_enqueue',
+          reused: true,
+          data: normalizeWorkerJob(result.details),
+        },
+      };
+    }
+
+    return rpcFailure(result);
+  }
+
+  return {
+    ok: true,
+    body: {
+      ok: true,
+      command: 'national_carbon_graph_cache_jobs_enqueue',
+      reused: false,
+      data: normalizeWorkerJob(result.data),
+    },
+  };
+}

--- a/supabase/functions/_shared/commands/national_carbon_graph_cache_objects.ts
+++ b/supabase/functions/_shared/commands/national_carbon_graph_cache_objects.ts
@@ -1,0 +1,391 @@
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+import { z } from 'zod';
+
+import type { ActorContext } from '../command_runtime/actor_context.ts';
+import type { CommandExecutionResult, CommandParseResult } from '../command_runtime/command.ts';
+import { createSupabaseServiceClient } from '../supabase_client.ts';
+
+const DEFAULT_CACHE_BUCKET = 'lca_results';
+const DEFAULT_CACHE_PREFIX = 'national-carbon/process-flow-graph/v1';
+const DEFAULT_SIGNED_URL_EXPIRES_IN_SECONDS = 3600;
+const MAX_SIGNED_URL_EXPIRES_IN_SECONDS = 86400;
+const ACTIVE_MANIFEST_SCHEMA_VERSION = 'process_flow_graph_manifest_v1';
+const BUILD_SCHEMA_VERSION = 'process_flow_graph_v2';
+
+type EnvReader = (name: string) => string | undefined;
+
+type CommandFailureResult = Extract<CommandExecutionResult, { ok: false }>;
+
+type StorageDownloadResult = {
+  data: { text(): Promise<string> } | null;
+  error: { message?: string; code?: string; statusCode?: string | number } | null;
+};
+
+type SignedUrlResult = {
+  data: { signedUrl?: string } | null;
+  error: { message?: string; code?: string; statusCode?: string | number } | null;
+};
+
+type StorageBucketClient = {
+  download(path: string): Promise<StorageDownloadResult>;
+  createSignedUrl(path: string, expiresIn: number): Promise<SignedUrlResult>;
+};
+
+type StorageClient = Pick<SupabaseClient, 'storage'> & {
+  storage: {
+    from(bucket: string): StorageBucketClient;
+  };
+};
+
+type ActiveManifest = {
+  schemaVersion: string;
+  activeBuildId: string;
+  buildManifestPath: string;
+  generatedAt?: string;
+};
+
+type BuildManifestFile = {
+  path: string;
+  byteSize?: number;
+  sha256?: string;
+  contentType?: string;
+  signedUrl?: string;
+};
+
+type BuildManifest = {
+  schemaVersion: string;
+  buildId: string;
+  files: Record<string, BuildManifestFile>;
+  [key: string]: unknown;
+};
+
+type GraphCacheObjectsConfig = {
+  bucket: string;
+  prefix: string;
+  signedUrlExpiresIn: number;
+};
+
+const requestSchema = z
+  .object({
+    action: z.literal('read_manifest_bundle'),
+  })
+  .strict();
+
+const activeManifestSchema = z
+  .object({
+    schemaVersion: z.literal(ACTIVE_MANIFEST_SCHEMA_VERSION),
+    activeBuildId: z.string().trim().min(1),
+    buildManifestPath: z.string().trim().min(1),
+    generatedAt: z.string().optional(),
+  })
+  .passthrough();
+
+const buildManifestFileSchema = z
+  .object({
+    path: z.string().trim().min(1),
+    byteSize: z.number().optional(),
+    sha256: z.string().optional(),
+    contentType: z.string().optional(),
+  })
+  .passthrough();
+
+const buildManifestSchema = z
+  .object({
+    schemaVersion: z.literal(BUILD_SCHEMA_VERSION),
+    buildId: z.string().trim().min(1),
+    files: z.record(z.string(), buildManifestFileSchema),
+  })
+  .passthrough();
+
+export type NationalCarbonGraphCacheObjectsRequest = z.infer<typeof requestSchema>;
+
+function defaultReadEnv(name: string): string | undefined {
+  try {
+    const value = Deno.env.get(name);
+    return value && value.trim().length > 0 ? value.trim() : undefined;
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function invalidPayload<T>(message: string, error: z.ZodError): CommandParseResult<T> {
+  return {
+    ok: false,
+    message,
+    details: error.flatten(),
+  };
+}
+
+export function parseNationalCarbonGraphCacheObjectsCommand(
+  body: unknown,
+): CommandParseResult<NationalCarbonGraphCacheObjectsRequest> {
+  const parsed = requestSchema.safeParse(body);
+  if (!parsed.success) {
+    return invalidPayload('Invalid national carbon graph cache object payload', parsed.error);
+  }
+
+  return {
+    ok: true,
+    value: parsed.data,
+  };
+}
+
+function normalizePathPart(value: string): string {
+  return value.trim().replace(/^\/+|\/+$/g, '');
+}
+
+function hasUnsafePathSegment(path: string): boolean {
+  return path
+    .split('/')
+    .filter(Boolean)
+    .some((segment) => segment === '.' || segment === '..');
+}
+
+function joinStoragePath(...parts: string[]): string {
+  const path = parts.map(normalizePathPart).filter(Boolean).join('/');
+  if (!path || hasUnsafePathSegment(path)) {
+    throw new Error('Invalid national carbon graph cache object path');
+  }
+  return path;
+}
+
+function dirname(path: string): string {
+  const normalized = normalizePathPart(path);
+  const index = normalized.lastIndexOf('/');
+  return index < 0 ? '' : normalized.slice(0, index);
+}
+
+function readPositiveInt(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function readConfig(readEnv: EnvReader): GraphCacheObjectsConfig {
+  const bucket =
+    readEnv('NATIONAL_CARBON_GRAPH_CACHE_BUCKET') ??
+    readEnv('PROCESS_FLOW_GRAPH_CACHE_BUCKET') ??
+    DEFAULT_CACHE_BUCKET;
+  const prefix =
+    readEnv('NATIONAL_CARBON_GRAPH_CACHE_PREFIX') ??
+    readEnv('PROCESS_FLOW_GRAPH_CACHE_PREFIX') ??
+    DEFAULT_CACHE_PREFIX;
+  const signedUrlExpiresIn = Math.min(
+    readPositiveInt(readEnv('NATIONAL_CARBON_GRAPH_CACHE_SIGNED_URL_EXPIRES_IN')) ??
+      DEFAULT_SIGNED_URL_EXPIRES_IN_SECONDS,
+    MAX_SIGNED_URL_EXPIRES_IN_SECONDS,
+  );
+
+  return {
+    bucket,
+    prefix: normalizePathPart(prefix),
+    signedUrlExpiresIn,
+  };
+}
+
+function storageFailure(
+  code: string,
+  message: string,
+  status: number,
+  details?: unknown,
+): CommandFailureResult {
+  return {
+    ok: false,
+    code,
+    message,
+    status,
+    details,
+  };
+}
+
+async function downloadJson(
+  storage: StorageBucketClient,
+  objectPath: string,
+): Promise<{ ok: true; data: unknown } | CommandFailureResult> {
+  const result = await storage.download(objectPath);
+  if (result.error) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_OBJECT_NOT_FOUND',
+      `Unable to read national carbon graph cache object: ${objectPath}`,
+      404,
+      result.error,
+    );
+  }
+
+  try {
+    return {
+      ok: true,
+      data: JSON.parse(await result.data!.text()),
+    };
+  } catch (error) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_OBJECT_INVALID_JSON',
+      `National carbon graph cache object is not valid JSON: ${objectPath}`,
+      502,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function validateActiveManifest(payload: unknown): ActiveManifest | CommandFailureResult {
+  const parsed = activeManifestSchema.safeParse(payload);
+  if (!parsed.success) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_ACTIVE_MANIFEST_INVALID',
+      'National carbon graph cache active manifest is invalid',
+      502,
+      parsed.error.flatten(),
+    );
+  }
+
+  if (hasUnsafePathSegment(parsed.data.buildManifestPath)) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_ACTIVE_MANIFEST_INVALID',
+      'National carbon graph cache build manifest path is unsafe',
+      502,
+    );
+  }
+
+  return parsed.data;
+}
+
+function validateBuildManifest(payload: unknown): BuildManifest | CommandFailureResult {
+  const parsed = buildManifestSchema.safeParse(payload);
+  if (!parsed.success) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_BUILD_MANIFEST_INVALID',
+      'National carbon graph cache build manifest is invalid',
+      502,
+      parsed.error.flatten(),
+    );
+  }
+
+  for (const [key, file] of Object.entries(parsed.data.files)) {
+    if (hasUnsafePathSegment(file.path)) {
+      return storageFailure(
+        'NATIONAL_CARBON_GRAPH_CACHE_BUILD_MANIFEST_INVALID',
+        `National carbon graph cache file path is unsafe: ${key}`,
+        502,
+      );
+    }
+  }
+
+  return parsed.data;
+}
+
+async function attachSignedUrls(
+  storage: StorageBucketClient,
+  config: GraphCacheObjectsConfig,
+  activeManifest: ActiveManifest,
+  buildManifest: BuildManifest,
+): Promise<BuildManifest | CommandFailureResult> {
+  const buildRootPath = dirname(activeManifest.buildManifestPath);
+  const files: Record<string, BuildManifestFile> = {};
+
+  for (const [key, file] of Object.entries(buildManifest.files)) {
+    const objectPath = joinStoragePath(config.prefix, buildRootPath, file.path);
+    const signed = await storage.createSignedUrl(objectPath, config.signedUrlExpiresIn);
+    if (signed.error || !signed.data?.signedUrl) {
+      return storageFailure(
+        'NATIONAL_CARBON_GRAPH_CACHE_SIGNED_URL_FAILED',
+        `Unable to create signed URL for national carbon graph cache object: ${key}`,
+        502,
+        signed.error ?? { objectPath },
+      );
+    }
+
+    files[key] = {
+      ...file,
+      signedUrl: signed.data.signedUrl,
+    };
+  }
+
+  return {
+    ...buildManifest,
+    files,
+  };
+}
+
+function isCommandFailure(value: unknown): value is CommandFailureResult {
+  return Boolean(value && typeof value === 'object' && (value as { ok?: unknown }).ok === false);
+}
+
+export async function executeNationalCarbonGraphCacheObjectsCommand(
+  _request: NationalCarbonGraphCacheObjectsRequest,
+  _actor: ActorContext,
+  serviceClient: StorageClient = createSupabaseServiceClient() as StorageClient,
+  readEnv: EnvReader = defaultReadEnv,
+): Promise<CommandExecutionResult> {
+  const config = readConfig(readEnv);
+  let activeManifestPath: string;
+
+  try {
+    activeManifestPath = joinStoragePath(config.prefix, 'manifest.json');
+  } catch (error) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_CONFIG_INVALID',
+      error instanceof Error ? error.message : String(error),
+      500,
+    );
+  }
+
+  const storage = serviceClient.storage.from(config.bucket);
+  const activePayload = await downloadJson(storage, activeManifestPath);
+  if (!activePayload.ok) {
+    return activePayload;
+  }
+
+  const activeManifest = validateActiveManifest(activePayload.data);
+  if (isCommandFailure(activeManifest)) {
+    return activeManifest;
+  }
+
+  let buildManifestPath: string;
+  try {
+    buildManifestPath = joinStoragePath(config.prefix, activeManifest.buildManifestPath);
+  } catch (error) {
+    return storageFailure(
+      'NATIONAL_CARBON_GRAPH_CACHE_ACTIVE_MANIFEST_INVALID',
+      error instanceof Error ? error.message : String(error),
+      502,
+    );
+  }
+
+  const buildPayload = await downloadJson(storage, buildManifestPath);
+  if (!buildPayload.ok) {
+    return buildPayload;
+  }
+
+  const buildManifest = validateBuildManifest(buildPayload.data);
+  if (isCommandFailure(buildManifest)) {
+    return buildManifest;
+  }
+
+  const signedBuildManifest = await attachSignedUrls(
+    storage,
+    config,
+    activeManifest,
+    buildManifest,
+  );
+  if (isCommandFailure(signedBuildManifest)) {
+    return signedBuildManifest;
+  }
+
+  return {
+    ok: true,
+    body: {
+      ok: true,
+      command: 'national_carbon_graph_cache_objects_read_manifest_bundle',
+      data: {
+        activeManifest,
+        buildManifest: signedBuildManifest,
+        bucket: config.bucket,
+        prefix: config.prefix,
+        expiresIn: config.signedUrlExpiresIn,
+      },
+    },
+  };
+}

--- a/supabase/functions/app_national_carbon_graph_cache_jobs/index.ts
+++ b/supabase/functions/app_national_carbon_graph_cache_jobs/index.ts
@@ -1,0 +1,27 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+
+import {
+  createCommandHandler,
+  type CommandHandlerOptions,
+} from '../_shared/command_runtime/command.ts';
+import {
+  executeNationalCarbonGraphCacheJobCommand,
+  parseNationalCarbonGraphCacheJobCommand,
+  type NationalCarbonGraphCacheJobRequest,
+} from '../_shared/commands/national_carbon_graph_cache_jobs.ts';
+
+export function createAppNationalCarbonGraphCacheJobsHandler(
+  overrides: Partial<CommandHandlerOptions<NationalCarbonGraphCacheJobRequest>> = {},
+) {
+  return createCommandHandler<NationalCarbonGraphCacheJobRequest>({
+    parse: parseNationalCarbonGraphCacheJobCommand,
+    execute: executeNationalCarbonGraphCacheJobCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppNationalCarbonGraphCacheJobs = createAppNationalCarbonGraphCacheJobsHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppNationalCarbonGraphCacheJobs);
+}

--- a/supabase/functions/app_national_carbon_graph_cache_objects/index.ts
+++ b/supabase/functions/app_national_carbon_graph_cache_objects/index.ts
@@ -1,0 +1,28 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+
+import {
+  createCommandHandler,
+  type CommandHandlerOptions,
+} from '../_shared/command_runtime/command.ts';
+import {
+  executeNationalCarbonGraphCacheObjectsCommand,
+  parseNationalCarbonGraphCacheObjectsCommand,
+  type NationalCarbonGraphCacheObjectsRequest,
+} from '../_shared/commands/national_carbon_graph_cache_objects.ts';
+
+export function createAppNationalCarbonGraphCacheObjectsHandler(
+  overrides: Partial<CommandHandlerOptions<NationalCarbonGraphCacheObjectsRequest>> = {},
+) {
+  return createCommandHandler<NationalCarbonGraphCacheObjectsRequest>({
+    parse: parseNationalCarbonGraphCacheObjectsCommand,
+    execute: executeNationalCarbonGraphCacheObjectsCommand,
+    ...overrides,
+  });
+}
+
+export const handleAppNationalCarbonGraphCacheObjects =
+  createAppNationalCarbonGraphCacheObjectsHandler();
+
+if (import.meta.main) {
+  Deno.serve(handleAppNationalCarbonGraphCacheObjects);
+}

--- a/test/national_carbon_graph_cache_jobs_test.ts
+++ b/test/national_carbon_graph_cache_jobs_test.ts
@@ -1,0 +1,335 @@
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+
+import type { ActorContext } from '../supabase/functions/_shared/command_runtime/actor_context.ts';
+import {
+  executeNationalCarbonGraphCacheJobCommand,
+  NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+  NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+  parseNationalCarbonGraphCacheJobCommand,
+} from '../supabase/functions/_shared/commands/national_carbon_graph_cache_jobs.ts';
+
+const TEST_JOB_ID = '66666666-6666-4666-8666-666666666666';
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+const SYSTEM_TEAM_ID = '00000000-0000-0000-0000-000000000000';
+
+class FakeNationalCarbonGraphCacheSupabase {
+  rpcCalls: Array<{ fn: string; args: Record<string, unknown> }> = [];
+  roleQueries: Array<{ table: string }> = [];
+
+  constructor(
+    private readonly responses: Array<{ data: unknown; error: unknown }>,
+    private readonly systemManager = true,
+  ) {}
+
+  from(table: string) {
+    this.roleQueries.push({ table });
+    const state: Record<string, unknown> = { table };
+    return {
+      select: (columns: string) => {
+        state.columns = columns;
+        return {
+          eq: (column: string, value: unknown) => {
+            state[column] = value;
+            return {
+              eq: (nextColumn: string, nextValue: unknown) => {
+                state[nextColumn] = nextValue;
+                return {
+                  in: (inColumn: string, values: unknown[]) => {
+                    state[inColumn] = values;
+                    return {
+                      limit: (limit: number) => {
+                        state.limit = limit;
+                        return {
+                          maybeSingle: () =>
+                            Promise.resolve({
+                              data: this.systemManager ? { user_id: TEST_USER_ID } : null,
+                              error: null,
+                            }),
+                        };
+                      },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        };
+      },
+    };
+  }
+
+  rpc(fn: string, args: Record<string, unknown>) {
+    this.rpcCalls.push({ fn, args: structuredClone(args) });
+    const response = this.responses.shift();
+    if (!response) {
+      throw new Error(`Unexpected RPC call: ${fn}`);
+    }
+    return Promise.resolve(response);
+  }
+}
+
+function actor(): ActorContext {
+  return {
+    userId: TEST_USER_ID,
+    accessToken: 'access-token',
+    supabase: {} as SupabaseClient,
+  };
+}
+
+function readEnv(name: string): string | undefined {
+  const values: Record<string, string> = {
+    NATIONAL_CARBON_GRAPH_CACHE_ENVIRONMENT: 'dev',
+    NATIONAL_CARBON_GRAPH_CACHE_PREFIX: 'national-carbon/process-flow-graph/v1',
+    NATIONAL_CARBON_GRAPH_CACHE_BUCKET: 'cache-bucket',
+  };
+  return values[name];
+}
+
+Deno.test('parseNationalCarbonGraphCacheJobCommand accepts enqueue action only', () => {
+  const result = parseNationalCarbonGraphCacheJobCommand({ action: 'enqueue' });
+
+  assertEquals(result.ok, true);
+  if (result.ok) {
+    assertEquals(result.value, { action: 'enqueue' });
+  }
+});
+
+Deno.test(
+  'executeNationalCarbonGraphCacheJobCommand requires system-manager permissions',
+  async () => {
+    const supabase = new FakeNationalCarbonGraphCacheSupabase([], false);
+
+    const result = await executeNationalCarbonGraphCacheJobCommand(
+      { action: 'enqueue' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+    );
+
+    assertEquals(result, {
+      ok: false,
+      code: 'SYSTEM_MANAGER_REQUIRED',
+      status: 403,
+      message: 'System-manager permissions are required to manage national carbon graph cache jobs',
+    });
+    assertEquals(supabase.rpcCalls, []);
+  },
+);
+
+Deno.test(
+  'executeNationalCarbonGraphCacheJobCommand enqueues fixed maintenance worker job',
+  async () => {
+    const supabase = new FakeNationalCarbonGraphCacheSupabase([
+      {
+        data: {
+          ok: true,
+          data: {
+            id: TEST_JOB_ID,
+            jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+            subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+            status: 'queued',
+          },
+        },
+        error: null,
+      },
+    ]);
+
+    const result = await executeNationalCarbonGraphCacheJobCommand(
+      { action: 'enqueue' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+      {
+        now: () => new Date('2026-06-12T09:45:37.000Z'),
+        readEnv,
+      },
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.body, {
+        ok: true,
+        command: 'national_carbon_graph_cache_jobs_enqueue',
+        reused: false,
+        data: {
+          id: TEST_JOB_ID,
+          jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+          subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+          status: 'queued',
+        },
+      });
+    }
+    assertEquals(supabase.roleQueries, [{ table: 'roles' }]);
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: 'worker_enqueue_job',
+        args: {
+          p_job_kind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+          p_payload_json: {
+            environment: 'dev',
+            execute: true,
+            cachePrefix: 'national-carbon/process-flow-graph/v1',
+            cacheBucket: 'cache-bucket',
+          },
+          p_payload_schema_version: 'national_carbon.process_flow_graph_cache_build.request.v1',
+          p_subject_type: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+          p_subject_id: null,
+          p_subject_version: 'dev',
+          p_requested_by: TEST_USER_ID,
+          p_requester_type: 'operator',
+          p_team_id: null,
+          p_idempotency_key:
+            'national_carbon.process_flow_graph_cache_build:dev:execute:11111111-1111-4111-8111-111111111111:2026-06-12T09:45',
+          p_request_hash: null,
+          p_concurrency_key: 'national_carbon.process_flow_graph_cache_build:dev:execute',
+          p_priority: 0,
+          p_queue_key: 'dev',
+          p_run_after: null,
+          p_visibility: 'operator',
+          p_max_attempts: 1,
+          p_timeout_at: null,
+          p_payload_ref: null,
+          p_parent_job_id: null,
+          p_root_job_id: null,
+        },
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  'executeNationalCarbonGraphCacheJobCommand returns active job on concurrency conflict',
+  async () => {
+    const supabase = new FakeNationalCarbonGraphCacheSupabase([
+      {
+        data: {
+          ok: false,
+          code: 'WORKER_JOB_CONCURRENCY_CONFLICT',
+          status: 409,
+          message: 'A conflicting worker job is already active',
+          details: {
+            id: TEST_JOB_ID,
+            jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+            subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+            status: 'running',
+          },
+        },
+        error: null,
+      },
+    ]);
+
+    const result = await executeNationalCarbonGraphCacheJobCommand(
+      { action: 'enqueue' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+      {
+        now: () => new Date('2026-06-12T09:45:37.000Z'),
+        readEnv,
+      },
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.body, {
+        ok: true,
+        command: 'national_carbon_graph_cache_jobs_enqueue',
+        reused: true,
+        data: {
+          id: TEST_JOB_ID,
+          jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+          subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+          status: 'running',
+        },
+      });
+    }
+  },
+);
+
+Deno.test('executeNationalCarbonGraphCacheJobCommand reads only graph cache jobs', async () => {
+  const supabase = new FakeNationalCarbonGraphCacheSupabase([
+    {
+      data: {
+        ok: true,
+        data: {
+          id: TEST_JOB_ID,
+          jobKind: 'review_submit.gate',
+          subjectType: 'processes',
+          status: 'completed',
+        },
+      },
+      error: null,
+    },
+  ]);
+
+  const result = await executeNationalCarbonGraphCacheJobCommand(
+    { action: 'read', jobId: TEST_JOB_ID },
+    actor(),
+    supabase as unknown as SupabaseClient,
+  );
+
+  assertEquals(result, {
+    ok: false,
+    code: 'NATIONAL_CARBON_GRAPH_CACHE_JOB_NOT_FOUND',
+    status: 404,
+    message: 'National carbon graph cache job not found',
+  });
+});
+
+Deno.test(
+  'executeNationalCarbonGraphCacheJobCommand lists latest operator graph cache jobs',
+  async () => {
+    const supabase = new FakeNationalCarbonGraphCacheSupabase([
+      {
+        data: {
+          ok: true,
+          data: [
+            {
+              id: TEST_JOB_ID,
+              jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+              subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+              status: 'completed',
+            },
+          ],
+        },
+        error: null,
+      },
+    ]);
+
+    const result = await executeNationalCarbonGraphCacheJobCommand(
+      { action: 'read_latest', limit: 1 },
+      actor(),
+      supabase as unknown as SupabaseClient,
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      assertEquals(result.body, {
+        ok: true,
+        command: 'national_carbon_graph_cache_jobs_read_latest',
+        data: [
+          {
+            id: TEST_JOB_ID,
+            jobKind: NATIONAL_CARBON_GRAPH_CACHE_JOB_KIND,
+            subjectType: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+            status: 'completed',
+          },
+        ],
+      });
+    }
+    assertEquals(supabase.rpcCalls, [
+      {
+        fn: 'worker_list_jobs',
+        args: {
+          p_requested_by: null,
+          p_subject_type: NATIONAL_CARBON_GRAPH_CACHE_SUBJECT_TYPE,
+          p_subject_id: null,
+          p_statuses: null,
+          p_visibility: 'operator',
+          p_limit: 1,
+          p_include_internal: false,
+        },
+      },
+    ]);
+  },
+);
+
+assertEquals(SYSTEM_TEAM_ID, '00000000-0000-0000-0000-000000000000');

--- a/test/national_carbon_graph_cache_objects_test.ts
+++ b/test/national_carbon_graph_cache_objects_test.ts
@@ -1,0 +1,278 @@
+import { assertEquals } from 'jsr:@std/assert';
+import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2.98.0';
+
+import type { ActorContext } from '../supabase/functions/_shared/command_runtime/actor_context.ts';
+import {
+  executeNationalCarbonGraphCacheObjectsCommand,
+  parseNationalCarbonGraphCacheObjectsCommand,
+} from '../supabase/functions/_shared/commands/national_carbon_graph_cache_objects.ts';
+
+const TEST_USER_ID = '11111111-1111-4111-8111-111111111111';
+
+type StoredObject = {
+  body?: unknown;
+  error?: { message: string; code?: string };
+};
+
+class FakeBlob {
+  constructor(private readonly body: unknown) {}
+
+  text() {
+    return Promise.resolve(typeof this.body === 'string' ? this.body : JSON.stringify(this.body));
+  }
+}
+
+class FakeGraphCacheStorageBucket {
+  downloads: string[] = [];
+  signedUrls: Array<{ objectPath: string; expiresIn: number }> = [];
+  signedErrors = new Map<string, { message: string; code?: string }>();
+
+  constructor(private readonly objects: Map<string, StoredObject>) {}
+
+  async download(objectPath: string) {
+    this.downloads.push(objectPath);
+    const object = this.objects.get(objectPath);
+    if (!object || object.error) {
+      return {
+        data: null,
+        error: object?.error ?? { message: 'Object not found', code: '404' },
+      };
+    }
+
+    return {
+      data: new FakeBlob(object.body),
+      error: null,
+    };
+  }
+
+  async createSignedUrl(objectPath: string, expiresIn: number) {
+    this.signedUrls.push({ objectPath, expiresIn });
+    const error = this.signedErrors.get(objectPath);
+    if (error) {
+      return { data: null, error };
+    }
+
+    return {
+      data: {
+        signedUrl: `https://signed.example/${encodeURIComponent(objectPath)}?expires=${expiresIn}`,
+      },
+      error: null,
+    };
+  }
+}
+
+class FakeGraphCacheSupabase {
+  buckets: string[] = [];
+
+  constructor(readonly bucket: FakeGraphCacheStorageBucket) {}
+
+  storage = {
+    from: (bucket: string) => {
+      this.buckets.push(bucket);
+      return this.bucket;
+    },
+  };
+}
+
+function actor(): ActorContext {
+  return {
+    userId: TEST_USER_ID,
+    accessToken: 'access-token',
+    supabase: {} as SupabaseClient,
+  };
+}
+
+function makeObjects(overrides: Record<string, StoredObject> = {}): Map<string, StoredObject> {
+  const activeManifestPath = 'national-carbon/process-flow-graph/v1/manifest.json';
+  const buildManifestPath =
+    'national-carbon/process-flow-graph/v1/builds/process-flow-graph-test/manifest.json';
+
+  return new Map<string, StoredObject>([
+    [
+      activeManifestPath,
+      {
+        body: {
+          schemaVersion: 'process_flow_graph_manifest_v1',
+          activeBuildId: 'process-flow-graph-test',
+          buildManifestPath: 'builds/process-flow-graph-test/manifest.json',
+          generatedAt: '2026-06-12T00:00:00Z',
+        },
+      },
+    ],
+    [
+      buildManifestPath,
+      {
+        body: {
+          schemaVersion: 'process_flow_graph_v2',
+          buildId: 'process-flow-graph-test',
+          files: {
+            nodes: {
+              path: 'graph/nodes.json.gz',
+              byteSize: 12,
+              sha256: 'abc',
+              contentType: 'application/gzip',
+            },
+            geoMapWorldView: {
+              path: 'geo-map/world/view.json.gz',
+              byteSize: 34,
+              sha256: 'def',
+              contentType: 'application/gzip',
+            },
+          },
+        },
+      },
+    ],
+    ...Object.entries(overrides),
+  ]);
+}
+
+function env(values: Record<string, string | undefined>) {
+  return (name: string) => values[name];
+}
+
+Deno.test('parseNationalCarbonGraphCacheObjectsCommand accepts read manifest bundle action', () => {
+  const result = parseNationalCarbonGraphCacheObjectsCommand({
+    action: 'read_manifest_bundle',
+  });
+
+  assertEquals(result.ok, true);
+});
+
+Deno.test('parseNationalCarbonGraphCacheObjectsCommand rejects unknown actions', () => {
+  const result = parseNationalCarbonGraphCacheObjectsCommand({
+    action: 'read_anything',
+  });
+
+  assertEquals(result.ok, false);
+});
+
+Deno.test(
+  'executeNationalCarbonGraphCacheObjectsCommand returns manifest bundle with signed URLs',
+  async () => {
+    const bucket = new FakeGraphCacheStorageBucket(makeObjects());
+    const supabase = new FakeGraphCacheSupabase(bucket);
+
+    const result = await executeNationalCarbonGraphCacheObjectsCommand(
+      { action: 'read_manifest_bundle' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+      env({
+        NATIONAL_CARBON_GRAPH_CACHE_BUCKET: 'lca_results',
+        NATIONAL_CARBON_GRAPH_CACHE_PREFIX: 'national-carbon/process-flow-graph/v1',
+        NATIONAL_CARBON_GRAPH_CACHE_SIGNED_URL_EXPIRES_IN: '120',
+      }),
+    );
+
+    assertEquals(result.ok, true);
+    if (result.ok) {
+      const body = result.body as {
+        data: {
+          bucket: string;
+          prefix: string;
+          expiresIn: number;
+          activeManifest: { activeBuildId: string };
+          buildManifest: { files: Record<string, { signedUrl?: string }> };
+        };
+      };
+      assertEquals(body.data.bucket, 'lca_results');
+      assertEquals(body.data.prefix, 'national-carbon/process-flow-graph/v1');
+      assertEquals(body.data.expiresIn, 120);
+      assertEquals(body.data.activeManifest.activeBuildId, 'process-flow-graph-test');
+      assertEquals(
+        body.data.buildManifest.files.nodes.signedUrl,
+        'https://signed.example/national-carbon%2Fprocess-flow-graph%2Fv1%2Fbuilds%2Fprocess-flow-graph-test%2Fgraph%2Fnodes.json.gz?expires=120',
+      );
+    }
+
+    assertEquals(supabase.buckets, ['lca_results']);
+    assertEquals(bucket.downloads, [
+      'national-carbon/process-flow-graph/v1/manifest.json',
+      'national-carbon/process-flow-graph/v1/builds/process-flow-graph-test/manifest.json',
+    ]);
+    assertEquals(bucket.signedUrls, [
+      {
+        objectPath:
+          'national-carbon/process-flow-graph/v1/builds/process-flow-graph-test/graph/nodes.json.gz',
+        expiresIn: 120,
+      },
+      {
+        objectPath:
+          'national-carbon/process-flow-graph/v1/builds/process-flow-graph-test/geo-map/world/view.json.gz',
+        expiresIn: 120,
+      },
+    ]);
+  },
+);
+
+Deno.test(
+  'executeNationalCarbonGraphCacheObjectsCommand rejects unsafe build manifest paths',
+  async () => {
+    const bucket = new FakeGraphCacheStorageBucket(
+      makeObjects({
+        'national-carbon/process-flow-graph/v1/manifest.json': {
+          body: {
+            schemaVersion: 'process_flow_graph_manifest_v1',
+            activeBuildId: 'process-flow-graph-test',
+            buildManifestPath: '../private/manifest.json',
+          },
+        },
+      }),
+    );
+    const supabase = new FakeGraphCacheSupabase(bucket);
+
+    const result = await executeNationalCarbonGraphCacheObjectsCommand(
+      { action: 'read_manifest_bundle' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+      env({}),
+    );
+
+    assertEquals(result.ok, false);
+    if (!result.ok) {
+      assertEquals(result.code, 'NATIONAL_CARBON_GRAPH_CACHE_ACTIVE_MANIFEST_INVALID');
+    }
+  },
+);
+
+Deno.test(
+  'executeNationalCarbonGraphCacheObjectsCommand reports missing active manifest',
+  async () => {
+    const bucket = new FakeGraphCacheStorageBucket(new Map());
+    const supabase = new FakeGraphCacheSupabase(bucket);
+
+    const result = await executeNationalCarbonGraphCacheObjectsCommand(
+      { action: 'read_manifest_bundle' },
+      actor(),
+      supabase as unknown as SupabaseClient,
+      env({}),
+    );
+
+    assertEquals(result.ok, false);
+    if (!result.ok) {
+      assertEquals(result.status, 404);
+      assertEquals(result.code, 'NATIONAL_CARBON_GRAPH_CACHE_OBJECT_NOT_FOUND');
+    }
+  },
+);
+
+Deno.test('executeNationalCarbonGraphCacheObjectsCommand reports signed URL failures', async () => {
+  const bucket = new FakeGraphCacheStorageBucket(makeObjects());
+  bucket.signedErrors.set(
+    'national-carbon/process-flow-graph/v1/builds/process-flow-graph-test/graph/nodes.json.gz',
+    { message: 'sign failed', code: 'SIGN_FAILED' },
+  );
+  const supabase = new FakeGraphCacheSupabase(bucket);
+
+  const result = await executeNationalCarbonGraphCacheObjectsCommand(
+    { action: 'read_manifest_bundle' },
+    actor(),
+    supabase as unknown as SupabaseClient,
+    env({}),
+  );
+
+  assertEquals(result.ok, false);
+  if (!result.ok) {
+    assertEquals(result.code, 'NATIONAL_CARBON_GRAPH_CACHE_SIGNED_URL_FAILED');
+    assertEquals(result.status, 502);
+  }
+});


### PR DESCRIPTION
## Promotion Contract

- Base branch: `main`
- Source branch: `dev` via fork branch `ForeverYoung5:promote/dev-to-main-national-carbon-cache-20260612`, which matched upstream `origin/dev` at `d25458d` before merge
- Merged main commit: `dd914bb7c361f41062c7696c2567b27e36008fa4`
- Validated environment before promotion: `dev` via merged PR validation for #187 and #189
- Remote deploy expected?: `Yes`; production/main deploy completed after merge for `app_national_carbon_graph_cache_jobs` and `app_national_carbon_graph_cache_objects`
- Back-merge required after merge?: `No`; this PR did not include a direct `main` hotfix path. The pre-merge main-only commit was the prior promote merge commit `c55e93f`
- Root workspace integration expected?: `Yes`; after merge, bump the `lca-workspace` submodule pointer to the promoted `tiangong-lca-edge-functions/main` commit according to M2 policy

- [x] This PR promotes `dev` into `main`.
- [x] I confirm this repo's GitHub default branch remaining `main` is a platform exception; routine feature and fix work still lands in `dev` first.
- [x] If remote deployment is part of this promotion, `main` deployment still uses the repo-standard `--no-verify-jwt` contract and the runtime auth boundary is documented.
- [x] I verified the integrated result in `dev` before requesting promotion to `main` through the merged dev PR validation records below.
- [x] If this PR includes a direct `main` hotfix path, I documented the required `main -> dev` back-merge plan.

## Linked Issue

Closes #186
Closes #188

## Release Summary

Promotes the national carbon graph cache Edge Function changes from `dev` to `main`:

- #187 adds `app_national_carbon_graph_cache_jobs` with `enqueue`, `read`, and `read_latest` command support for the national carbon process-flow graph cache build job.
- #189 adds `app_national_carbon_graph_cache_objects` for authenticated reads of the active cache manifest bundle and signed private object URLs.
- The promoted changes keep the repo-standard `--no-verify-jwt` gateway deployment contract while enforcing runtime actor authentication inside the functions.

## Validation

- #187 recorded `npm run lint`, targeted Deno check, and targeted Deno test coverage for the cache job API. Its full `npm run check` reached the new function and then failed on the pre-existing `supabase/functions/embedding_ft/index.ts` TS7006 implicit-any baseline.
- #189 recorded `npm run lint`, targeted Deno check, targeted Deno test coverage, a dev deploy for `app_national_carbon_graph_cache_objects`, and an anonymous dev POST smoke returning `401 AUTH_REQUIRED` from the deployed function. Its full `npm run check` had the same pre-existing `embedding_ft` TS7006 baseline failure after reaching the new function.
- Promote-session remote checks: no existing open `dev -> main` PR at creation time; `dev` was 4 commits ahead of `main`; `main` was 1 merge commit ahead from the prior promote PR.

## Production Deployment

Target project: `qgzvkongdjqiiamzbbts`

- Initial repo-standard `npm run deploy:main -- app_national_carbon_graph_cache_jobs app_national_carbon_graph_cache_objects` attempt failed before deployment because the local Docker daemon could not pull `public.ecr.aws/supabase/edge-runtime:v1.73.2` through the configured `127.0.0.1:7890` proxy.
- Retried with the repo-pinned Supabase CLI version and `--use-api` server-side bundling:
  - `npx --yes supabase@2.85.0 functions deploy app_national_carbon_graph_cache_jobs --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt --use-api --import-map supabase/functions/deno.json`
  - `npx --yes supabase@2.85.0 functions deploy app_national_carbon_graph_cache_objects --project-ref qgzvkongdjqiiamzbbts --no-verify-jwt --use-api --import-map supabase/functions/deno.json`
- Both functions deployed successfully to production/main.
- Anonymous production smoke checks for both functions returned HTTP `401` with `AUTH_REQUIRED` from `x-served-by: supabase-edge-runtime`, confirming the functions are reachable and runtime auth rejects anonymous access.

## Integration / Follow-up

- Root `lca-workspace` submodule pointer integration remains pending for promoted `tiangong-lca-edge-functions/main` commit `dd914bb7c361f41062c7696c2567b27e36008fa4`.
- The dependent frontend consumption remains tracked in linancn/tiangong-lca-next#515.
- Database-side job kind support remains outside this repo and is tracked in database-engine#213.
