### PR TITLE
Promote hybrid search query terms

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: '2026-06-13'
-lastReviewedCommit: 'e4393d6ba25fed6fe045bf64dc96e05b5687a0b1'
+lastReviewedCommit: '8552e9b8e574d05b8cf13fa296e4a6ae23058501'
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-13
-lastReviewedCommit: e4393d6ba25fed6fe045bf64dc96e05b5687a0b1
+lastReviewedCommit: 8552e9b8e574d05b8cf13fa296e4a6ae23058501
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-13
-lastReviewedCommit: e4393d6ba25fed6fe045bf64dc96e05b5687a0b1
+lastReviewedCommit: 8552e9b8e574d05b8cf13fa296e4a6ae23058501
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-06-13
-lastReviewedCommit: e4393d6ba25fed6fe045bf64dc96e05b5687a0b1
+lastReviewedCommit: 8552e9b8e574d05b8cf13fa296e4a6ae23058501
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/supabase/functions/_shared/hybrid_query_utils.ts
+++ b/supabase/functions/_shared/hybrid_query_utils.ts
@@ -182,9 +182,78 @@ function prependSeedTerm(terms: string[], seed: string): string[] {
   return uniqueTerms([normalizedSeed, ...terms]);
 }
 
-function quotePgroongaQueryTerm(term: string): string {
-  const escaped = normalizeTerm(term).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-  return `"${escaped}"`;
+function isOrBoundary(char: string | undefined): boolean {
+  return !char || /\s|[()]/.test(char);
+}
+
+function isTopLevelOrOperator(term: string, index: number): boolean {
+  return (
+    term.slice(index, index + 2).toLowerCase() === 'or' &&
+    isOrBoundary(term[index - 1]) &&
+    isOrBoundary(term[index + 2])
+  );
+}
+
+function stripOneBalancedOuterParen(term: string): string {
+  const normalized = normalizeTerm(term);
+  if (!normalized.startsWith('(') || !normalized.endsWith(')')) {
+    return normalized;
+  }
+
+  let depth = 0;
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    if (char === '(') {
+      depth += 1;
+    } else if (char === ')') {
+      depth -= 1;
+      if (depth === 0 && index < normalized.length - 1) {
+        return normalized;
+      }
+    }
+    if (depth < 0) {
+      return normalized;
+    }
+  }
+
+  return depth === 0 ? normalizeTerm(normalized.slice(1, -1)) : normalized;
+}
+
+function splitTopLevelOrTerms(term: string): string[] {
+  const normalized = normalizeTerm(term);
+  if (!normalized) {
+    return [];
+  }
+
+  const parts: string[] = [];
+  let partStart = 0;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+
+    if (parenDepth === 0 && bracketDepth === 0 && isTopLevelOrOperator(normalized, index)) {
+      parts.push(normalized.slice(partStart, index));
+      partStart = index + 2;
+      index += 1;
+      continue;
+    }
+
+    if (char === '(') {
+      parenDepth += 1;
+    } else if (char === ')') {
+      parenDepth = Math.max(0, parenDepth - 1);
+    } else if (char === '[') {
+      bracketDepth += 1;
+    } else if (char === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    }
+  }
+
+  parts.push(normalized.slice(partStart));
+
+  return parts.map(stripOneBalancedOuterParen).filter((part) => part.length > 0);
 }
 
 export function sanitizeHybridQueryOutput(
@@ -244,9 +313,8 @@ export function sanitizeHybridQueryOutput(
   };
 }
 
-export function buildHybridFulltextQueryString(query: HybridSearchQuery): string {
-  return [...query.fulltext_query_zh, ...query.fulltext_query_en]
-    .filter((term) => term.trim().length > 0)
-    .map((term) => `(${quotePgroongaQueryTerm(term)})`)
-    .join(' OR ');
+export function buildHybridFulltextQueryTerms(query: HybridSearchQuery): string[] {
+  return uniqueTerms(
+    [...query.fulltext_query_zh, ...query.fulltext_query_en].flatMap(splitTopLevelOrTerms),
+  );
 }

--- a/supabase/functions/_shared/hybrid_search_request.ts
+++ b/supabase/functions/_shared/hybrid_search_request.ts
@@ -25,6 +25,7 @@ export interface HybridSearchRpcOptions {
 
 export interface HybridSearchRpcRequest extends HybridSearchRpcOptions {
   query_text: string;
+  query_terms: string[];
   query_embedding: string;
 }
 
@@ -161,11 +162,13 @@ export function parseHybridSearchClientRequest(body: unknown): HybridSearchClien
 
 export function buildHybridSearchRpcRequest(
   queryText: string,
+  queryTerms: string[],
   queryEmbedding: string,
   options: HybridSearchRpcOptions,
 ): HybridSearchRpcRequest {
   return {
     query_text: queryText,
+    query_terms: queryTerms,
     query_embedding: queryEmbedding,
     ...options,
   };

--- a/supabase/functions/flow_hybrid_search/index.ts
+++ b/supabase/functions/flow_hybrid_search/index.ts
@@ -4,7 +4,7 @@ import { InvokeEndpointCommand, SageMakerRuntimeClient } from '@aws-sdk/client-s
 import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
 import {
-  buildHybridFulltextQueryString,
+  buildHybridFulltextQueryTerms,
   HYBRID_SYNONYM_RULES,
   hybridQuerySchema,
   HybridSearchQuery,
@@ -231,13 +231,14 @@ ${HYBRID_SYNONYM_RULES}`,
     throw new Error('OpenAI structured output missing semantic_query_en');
   }
 
-  const queryFulltextString = buildHybridFulltextQueryString(normalizedRes);
+  const queryFulltextTerms = buildHybridFulltextQueryTerms(normalizedRes);
 
   const embedding = await generateEmbedding(semanticQueryEn);
   const vectorStr = `[${embedding.join(',')}]`;
 
   const requestBody = buildHybridSearchRpcRequest(
-    queryFulltextString,
+    parsedRequest.queryText,
+    queryFulltextTerms,
     vectorStr,
     parsedRequest.rpcOptions,
   );
@@ -265,7 +266,7 @@ ${HYBRID_SYNONYM_RULES}`,
     semantic_query_en: semanticQueryEn,
     fulltext_query_en: fulltextQueryEn,
     fulltext_query_zh: fulltextQueryZh,
-    query_fulltext_string: queryFulltextString,
+    query_fulltext_terms: queryFulltextTerms,
     match_threshold: requestBody.match_threshold,
     data_source: requestBody.data_source,
     user_context_kind: rpcClientContext.userContextKind,

--- a/supabase/functions/lifecyclemodel_hybrid_search/index.ts
+++ b/supabase/functions/lifecyclemodel_hybrid_search/index.ts
@@ -4,7 +4,7 @@ import { InvokeEndpointCommand, SageMakerRuntimeClient } from '@aws-sdk/client-s
 import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
 import {
-  buildHybridFulltextQueryString,
+  buildHybridFulltextQueryTerms,
   HYBRID_SYNONYM_RULES,
   hybridQuerySchema,
   HybridSearchQuery,
@@ -231,13 +231,14 @@ ${HYBRID_SYNONYM_RULES}`,
     throw new Error('OpenAI structured output missing semantic_query_en');
   }
 
-  const queryFulltextString = buildHybridFulltextQueryString(normalizedRes);
+  const queryFulltextTerms = buildHybridFulltextQueryTerms(normalizedRes);
 
   const embedding = await generateEmbedding(semanticQueryEn);
   const vectorStr = `[${embedding.join(',')}]`;
 
   const requestBody = buildHybridSearchRpcRequest(
-    queryFulltextString,
+    parsedRequest.queryText,
+    queryFulltextTerms,
     vectorStr,
     parsedRequest.rpcOptions,
   );
@@ -265,7 +266,7 @@ ${HYBRID_SYNONYM_RULES}`,
     semantic_query_en: semanticQueryEn,
     fulltext_query_en: fulltextQueryEn,
     fulltext_query_zh: fulltextQueryZh,
-    query_fulltext_string: queryFulltextString,
+    query_fulltext_terms: queryFulltextTerms,
     match_threshold: requestBody.match_threshold,
     data_source: requestBody.data_source,
     user_context_kind: rpcClientContext.userContextKind,

--- a/supabase/functions/process_hybrid_search/index.ts
+++ b/supabase/functions/process_hybrid_search/index.ts
@@ -5,7 +5,7 @@ import { InvokeEndpointCommand, SageMakerRuntimeClient } from '@aws-sdk/client-s
 import { authenticateRequest, AuthMethod } from '../_shared/auth.ts';
 import { corsHeaders } from '../_shared/cors.ts';
 import {
-  buildHybridFulltextQueryString,
+  buildHybridFulltextQueryTerms,
   HYBRID_SYNONYM_RULES,
   hybridQuerySchema,
   HybridSearchQuery,
@@ -234,13 +234,14 @@ ${HYBRID_SYNONYM_RULES}`,
     throw new Error('OpenAI structured output missing semantic_query_en');
   }
 
-  const queryFulltextString = buildHybridFulltextQueryString(normalizedRes);
+  const queryFulltextTerms = buildHybridFulltextQueryTerms(normalizedRes);
 
   const embedding = await generateEmbedding(semanticQueryEn);
   const vectorStr = `[${embedding.join(',')}]`;
 
   const requestBody = buildHybridSearchRpcRequest(
-    queryFulltextString,
+    parsedRequest.queryText,
+    queryFulltextTerms,
     vectorStr,
     parsedRequest.rpcOptions,
   );
@@ -268,7 +269,7 @@ ${HYBRID_SYNONYM_RULES}`,
     semantic_query_en: semanticQueryEn,
     fulltext_query_en: fulltextQueryEn,
     fulltext_query_zh: fulltextQueryZh,
-    query_fulltext_string: queryFulltextString,
+    query_fulltext_terms: queryFulltextTerms,
     match_threshold: requestBody.match_threshold,
     data_source: requestBody.data_source,
     user_context_kind: rpcClientContext.userContextKind,

--- a/test/hybrid_query_utils_test.ts
+++ b/test/hybrid_query_utils_test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from 'jsr:@std/assert';
 
 import {
-  buildHybridFulltextQueryString,
+  buildHybridFulltextQueryTerms,
   sanitizeHybridQueryOutput,
 } from '../supabase/functions/_shared/hybrid_query_utils.ts';
 
@@ -57,7 +57,7 @@ Deno.test('sanitizeHybridQueryOutput keeps raw query within capped fulltext alia
   assertEquals(sanitized.fulltext_query_en.includes('electricity'), true);
 });
 
-Deno.test('buildHybridFulltextQueryString preserves raw-query aliases in RPC query text', () => {
+Deno.test('buildHybridFulltextQueryTerms preserves simple Chinese and English aliases', () => {
   const sanitized = sanitizeHybridQueryOutput(
     {
       semantic_query_en: 'alternating current',
@@ -67,15 +67,19 @@ Deno.test('buildHybridFulltextQueryString preserves raw-query aliases in RPC que
     'electricity',
   );
 
-  assertEquals(
-    buildHybridFulltextQueryString(sanitized),
-    '("交流电") OR ("alternating current") OR ("electricity") OR ("AC power")',
-  );
+  assertEquals(buildHybridFulltextQueryTerms(sanitized), [
+    '交流电',
+    'alternating current',
+    'electricity',
+    'AC power',
+  ]);
 });
 
-Deno.test('buildHybridFulltextQueryString quotes PGroonga query-syntax characters', () => {
+Deno.test('buildHybridFulltextQueryTerms splits only top-level OR in chemical queries', () => {
   const rawChemicalQuery =
     '(111479-05-1) OR (Propanoic acid, 2-[4-[(6-chloro-2-quinoxalinyl)oxy]phenoxy]-, 2-[[(1-methylethylidene)amino]oxy]ethyl ester, (2R)-)';
+  const rawChemicalName =
+    'Propanoic acid, 2-[4-[(6-chloro-2-quinoxalinyl)oxy]phenoxy]-, 2-[[(1-methylethylidene)amino]oxy]ethyl ester, (2R)-';
 
   const sanitized = sanitizeHybridQueryOutput(
     {
@@ -86,19 +90,42 @@ Deno.test('buildHybridFulltextQueryString quotes PGroonga query-syntax character
     rawChemicalQuery,
   );
 
+  assertEquals(buildHybridFulltextQueryTerms(sanitized), [
+    '111479-05-1',
+    rawChemicalName,
+    'quizalofop-P-tefuryl',
+  ]);
+});
+
+Deno.test('buildHybridFulltextQueryTerms splits ordinary top-level OR expressions', () => {
   assertEquals(
-    buildHybridFulltextQueryString(sanitized),
-    `("${rawChemicalQuery}") OR ("quizalofop-P-tefuryl") OR ("${rawChemicalQuery}") OR ("111479-05-1")`,
+    buildHybridFulltextQueryTerms({
+      semantic_query_en: '',
+      fulltext_query_en: ['sodium chloride OR NaCl'],
+      fulltext_query_zh: [],
+    }),
+    ['sodium chloride', 'NaCl'],
   );
 });
 
-Deno.test('buildHybridFulltextQueryString escapes quotes and backslashes inside terms', () => {
+Deno.test('buildHybridFulltextQueryTerms does not split words containing or', () => {
   assertEquals(
-    buildHybridFulltextQueryString({
+    buildHybridFulltextQueryTerms({
+      semantic_query_en: '',
+      fulltext_query_en: ['chlorinated organic solvent'],
+      fulltext_query_zh: [],
+    }),
+    ['chlorinated organic solvent'],
+  );
+});
+
+Deno.test('buildHybridFulltextQueryTerms preserves quotes and backslashes as raw terms', () => {
+  assertEquals(
+    buildHybridFulltextQueryTerms({
       semantic_query_en: 'quoted solvent',
       fulltext_query_en: ['a "quoted" \\ solvent'],
       fulltext_query_zh: [],
     }),
-    '("a \\"quoted\\" \\\\ solvent")',
+    ['a "quoted" \\ solvent'],
   );
 });

--- a/test/hybrid_search_request_test.ts
+++ b/test/hybrid_search_request_test.ts
@@ -94,10 +94,16 @@ Deno.test('buildHybridSearchRpcRequest builds the database RPC payload', () => {
     data_source: 'co',
   });
 
-  const payload = buildHybridSearchRpcRequest('[steel]', '[0.1,0.2]', parsed.rpcOptions);
+  const payload = buildHybridSearchRpcRequest(
+    'steel',
+    ['steel', 'stainless steel'],
+    '[0.1,0.2]',
+    parsed.rpcOptions,
+  );
 
   assertEquals(payload, {
-    query_text: '[steel]',
+    query_text: 'steel',
+    query_terms: ['steel', 'stainless steel'],
     query_embedding: '[0.1,0.2]',
     filter_condition: '{}',
     match_threshold: 0.5,


### PR DESCRIPTION
## Summary

- Promote Edge hybrid-search query_terms changes from `dev` to `main`.
- Includes PR #196: Edge HTTP API remains unchanged; Edge sends raw `query_text` plus generated raw `query_terms` to the DB RPCs.

## Validation

- PR #196 local validation: `npm run lint`, `npm run check`, targeted Deno tests for hybrid query/request helpers.

## Rollout

- Deploy `flow_hybrid_search`, `process_hybrid_search`, and `lifecyclemodel_hybrid_search` to the main Supabase project after merge.