### PR TITLE
fix: harden hybrid search main deploy

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: '2026-06-13'
-lastReviewedCommit: '8552e9b8e574d05b8cf13fa296e4a6ae23058501'
+lastReviewedAt: '2026-06-15'
+lastReviewedCommit: '5c48d14b29cc8473ace0b6c88078651d45111753'
 
 # Keep deterministic governance facts here.
 # AGENTS.md stays as the repo contract entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-13
-lastReviewedCommit: 8552e9b8e574d05b8cf13fa296e4a6ae23058501
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 5c48d14b29cc8473ace0b6c88078651d45111753
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -94,6 +94,7 @@ Keep these entry-level facts in `AGENTS.md`. Use `README.md` and `docs/agents/re
   - `npm run deploy:main -- <function-name> [more-function-names...]`
 - auth and connectivity drift probe: `npm run probe:auth -- --remote` or `npm run probe:auth -- --local`
 - local serve and scripted remote deploys both use `--no-verify-jwt`
+- scripted remote deploys pass `supabase/functions/deno.json` as the Supabase CLI import map so remote bundling resolves shared npm/jsr imports consistently
 - gateway JWT verification being off does not make runtime auth optional; functions must still authenticate and authorize requests explicitly
 
 ## Ownership Boundaries

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Deploy to the production `main` project (`qgzvkongdjqiiamzbbts`) only as part of
 npm run deploy:main -- flow_hybrid_search process_hybrid_search lifecyclemodel_hybrid_search
 ```
 
-The deploy script pins the Supabase CLI version from `package.json`, sets the target `--project-ref`, and disables gateway JWT verification with `--no-verify-jwt`. Function imports are resolved from `supabase/functions/deno.json`.
+The deploy script pins the Supabase CLI version from `package.json`, sets the target `--project-ref`, disables gateway JWT verification with `--no-verify-jwt`, and passes `supabase/functions/deno.json` as the import map so server-side bundling resolves shared npm/jsr imports.
 
 Recommended deploy workflow:
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-13
-lastReviewedCommit: 8552e9b8e574d05b8cf13fa296e4a6ae23058501
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 5c48d14b29cc8473ace0b6c88078651d45111753
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -60,6 +60,7 @@ This repo is organized around Edge Function families plus a shared runtime layer
 | `test/**` | stable | repo-level Deno tests for functions and shared modules |
 | `scripts/**` | stable | deno-check inventory, deploy contract, auth probe, and LCA smoke helper |
 | `supabase/config.toml` | stable | local serve and remote edge deploy config; not database schema truth |
+| `supabase/functions/deno.json` | stable | Deno config and import map used by local checks and scripted remote deploy bundling |
 | `test.example.http` | stable | checked-in smoke request collection for local and remote routes |
 | `.github/PULL_REQUEST_TEMPLATE/*.md` | stable | M2 branch-specific PR note shape for feature and promote flows |
 
@@ -83,6 +84,8 @@ The repo intentionally keeps gateway JWT verification off in its standard operat
 - scripted remote deploys: `npm run deploy:dev`, `npm run deploy:main`
 
 Both paths use `--no-verify-jwt`.
+
+Scripted remote deploys also pass `supabase/functions/deno.json` as the Supabase CLI import map. Keep shared npm/jsr import mappings there so local `deno check` and server-side Supabase bundling use the same resolution contract.
 
 The real auth boundary is therefore inside runtime code, primarily:
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-06-13
-lastReviewedCommit: 8552e9b8e574d05b8cf13fa296e4a6ae23058501
+lastReviewedAt: 2026-06-15
+lastReviewedCommit: 5c48d14b29cc8473ace0b6c88078651d45111753
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -72,7 +72,7 @@ If you reactivate or rely on one of those routes, update the inventory and valid
 | Hybrid search, AI suggestion, or OpenAI shared layer | `npm run lint`; `npm run check`; targeted `deno check` on changed function and shared OpenAI helper files | smoke one relevant request from `test.example.http` or equivalent local or remote call | Model defaults and query-rewrite helpers live in repo code, not only in env or README prose. |
 | LCA solve, queue, result, or scope helpers | `npm run lint`; `npm run check`; targeted `deno check` on changed `lca_*` files and `_shared/lca_*` helpers; for worker_jobs cutover changes also run `test/worker_jobs_cutover_test.ts`, `test/worker_jobs_test.ts`, and `test/lca_snapshot_scope_test.ts` | run `scripts/lca_submit_poll_fetch.sh` when the task explicitly touches the submit, poll, or fetch path; otherwise record why that proof is deferred | `worker_jobs` is the default enqueue path; `LCA_WORKER_JOBS_ENABLED=false` must fail closed instead of using legacy queue fallback. Domain rows/cache remain result metadata, not task fact. Missing worker_jobs DB-side truth is validated in `database-engine`, not here. |
 | TIDAS package import, export, or job paths | `npm run lint`; `npm run check`; targeted `deno check` on changed package files and `_shared/tidas_package.ts`; run `deno test --allow-env --config supabase/functions/deno.json test/tidas_package_test.ts test/tidas_package_api_test.ts` when package enqueue behavior changes | use the relevant requests in `test.example.http`; if auth or payload shaping changed, run a local or remote smoke path | JWT and `USER_API_KEY` coverage matters for these routes. `worker_jobs` is the default enqueue path; `TIDAS_PACKAGE_WORKER_JOBS_ENABLED=false` must fail closed instead of using legacy queue fallback. Package domain rows/cache/artifacts stay retained metadata, not task fact. |
-| Deploy script, `package.json`, `supabase/config.toml`, or PR contract files | `npm run lint`; inspect branch, project-ref, and deploy-flag changes against `AGENTS.md` and `.docpact/config.yaml`; run `npm run check` if runtime inventory or imports changed | if the task includes a real deploy, record which environment was deployed and which function names were used | Remote deploy proof is not implied by local lint or type-check. |
+| Deploy script, `package.json`, `supabase/config.toml`, or PR contract files | `npm run lint`; inspect branch, project-ref, import-map, and deploy-flag changes against `AGENTS.md` and `.docpact/config.yaml`; run `npm run check` if runtime inventory or imports changed | if the task includes a real deploy, record which environment was deployed and which function names were used | Remote deploy proof is not implied by local lint or type-check. Scripted deploys should resolve imports through `supabase/functions/deno.json`. |
 | Auth probe tooling | `npm run lint`; `node scripts/probe-functions-auth.cjs --help`; `npm run probe:auth -- --dry-run` | run `npm run probe:auth -- --remote` or `--local` when the task explicitly includes live probe validation | Dry-run is the safe default when you only changed classification or selection logic. |
 | Repo tests only | `npm run lint`; `npm run check`; targeted `deno check --config supabase/functions/deno.json <changed-test-file>` | run neighboring tests that cover the same shared module or function family | This repo keeps Deno tests in `test/**`, not under each function folder. |
 | Repo docs or docpact config only | `scripts/docpact validate-config --root . --strict`; `scripts/docpact lint --root . --worktree --mode enforce` | perform scenario-based route checks for the affected intent surface | Refresh review metadata when governed docs change without code changes. |
@@ -83,6 +83,7 @@ Facts that matter:
 
 - local serve uses `--no-verify-jwt`
 - scripted remote deploys also use `--no-verify-jwt`
+- scripted remote deploys pass `supabase/functions/deno.json` as the Supabase CLI import map
 - runtime auth still happens inside functions, primarily through `supabase/functions/_shared/auth.ts`
 - `scripts/probe-functions-auth.cjs` is the fastest way to separate gateway rejection from runtime-auth rejection
 

--- a/scripts/deploy-function.cjs
+++ b/scripts/deploy-function.cjs
@@ -39,6 +39,8 @@ for (const functionName of functionNames) {
       '--project-ref',
       projectRef,
       '--no-verify-jwt',
+      '--import-map',
+      path.join('supabase', 'functions', 'deno.json'),
     ],
     {
       cwd: repoRoot,

--- a/supabase/functions/_shared/hybrid_query_utils.ts
+++ b/supabase/functions/_shared/hybrid_query_utils.ts
@@ -224,6 +224,10 @@ function splitTopLevelOrTerms(term: string): string[] {
   if (!normalized) {
     return [];
   }
+  const unwrapped = stripOneBalancedOuterParen(normalized);
+  if (unwrapped !== normalized) {
+    return splitTopLevelOrTerms(unwrapped);
+  }
 
   const parts: string[] = [];
   let partStart = 0;

--- a/test/hybrid_query_utils_test.ts
+++ b/test/hybrid_query_utils_test.ts
@@ -108,6 +108,40 @@ Deno.test('buildHybridFulltextQueryTerms splits ordinary top-level OR expression
   );
 });
 
+Deno.test('buildHybridFulltextQueryTerms splits wrapped top-level OR expressions', () => {
+  assertEquals(
+    buildHybridFulltextQueryTerms({
+      semantic_query_en: '',
+      fulltext_query_en: ['(sodium chloride OR NaCl)'],
+      fulltext_query_zh: [],
+    }),
+    ['sodium chloride', 'NaCl'],
+  );
+
+  assertEquals(
+    buildHybridFulltextQueryTerms({
+      semantic_query_en: '',
+      fulltext_query_en: ['((sodium chloride OR NaCl))'],
+      fulltext_query_zh: [],
+    }),
+    ['sodium chloride', 'NaCl'],
+  );
+});
+
+Deno.test('buildHybridFulltextQueryTerms splits wrapped chemical OR expressions', () => {
+  const rawChemicalName =
+    'Propanoic acid, 2-[4-[(6-chloro-2-quinoxalinyl)oxy]phenoxy]-, 2-[[(1-methylethylidene)amino]oxy]ethyl ester, (2R)-';
+
+  assertEquals(
+    buildHybridFulltextQueryTerms({
+      semantic_query_en: '',
+      fulltext_query_en: [`((111479-05-1) OR (${rawChemicalName}))`],
+      fulltext_query_zh: [],
+    }),
+    ['111479-05-1', rawChemicalName],
+  );
+});
+
 Deno.test('buildHybridFulltextQueryTerms does not split words containing or', () => {
   assertEquals(
     buildHybridFulltextQueryTerms({


### PR DESCRIPTION
## Summary
- pass `supabase/functions/deno.json` as the Supabase CLI import map during scripted remote deploys
- split wrapped top-level OR hybrid full-text terms before sending `query_terms` to database RPCs
- add wrapped OR test coverage for ordinary and chemical query samples

## Validation
- `deno test --allow-env --config supabase/functions/deno.json test/hybrid_query_utils_test.ts`
- `npm run lint`
- `npm run check`
- `scripts/docpact-gate.sh --base origin/main`

Closes #195
Follow-up to #197 and discussion_r3410611836.